### PR TITLE
Potential fix for code scanning alert no. 33: Uncontrolled data used in path expression

### DIFF
--- a/mjr_am_backend/features/assets/download_service.py
+++ b/mjr_am_backend/features/assets/download_service.py
@@ -113,12 +113,20 @@ def resolve_download_path(
 
 
 def build_download_response(resolved: Path, *, preview: bool) -> web.StreamResponse:
-    mime_type, _ = mimetypes.guess_type(str(resolved))
+    try:
+        safe_path = resolved.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return web.Response(status=404, text="File not found")
+
+    if not safe_path.is_absolute() or not safe_path.is_file():
+        return web.Response(status=404, text="File not found")
+
+    mime_type, _ = mimetypes.guess_type(str(safe_path))
     safe_mime = mime_type or "application/octet-stream"
-    filename = safe_download_filename(resolved.name)
+    filename = safe_download_filename(safe_path.name)
     disposition = "inline" if preview else "attachment"
 
-    response = web.FileResponse(path=str(resolved))
+    response = web.FileResponse(path=str(safe_path))
     try:
         response.headers["Content-Type"] = safe_mime
         response.headers["Content-Disposition"] = f'{disposition}; filename="{filename}"'


### PR DESCRIPTION
Potential fix for [https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/security/code-scanning/33](https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/security/code-scanning/33)

General approach: enforce a final, explicit safety invariant right before constructing `web.FileResponse`: only absolute, normalized, regular files are allowed. This “defense in depth” check ensures that even if upstream wiring changes or a sanitizer is weakened, the sink remains protected.

Best concrete fix in `mjr_am_backend/features/assets/download_service.py`:
- In `build_download_response`, normalize/resolve the incoming `resolved` path again with `resolved.resolve(strict=True)`.
- Reject/abort if the path is not absolute or not a file.
- Use the re-resolved safe path for MIME detection and `FileResponse`.
- Keep current behavior otherwise (same headers, same preview/attachment logic).

This keeps functionality intact for valid requests and hardens the sink for all alert variants tied to this location.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
