### PR TITLE
Potential fix for code scanning alert no. 40: Uncontrolled data used in path expression

### DIFF
--- a/mjr_am_backend/features/assets/download_service.py
+++ b/mjr_am_backend/features/assets/download_service.py
@@ -112,7 +112,12 @@ def resolve_download_path(
     return resolved
 
 
-def build_download_response(resolved: Path, *, preview: bool) -> web.StreamResponse:
+def build_download_response(
+    resolved: Path,
+    *,
+    preview: bool,
+    is_resolved_path_allowed: Callable[[Path], bool] | None = None,
+) -> web.StreamResponse:
     try:
         safe_path = resolved.resolve(strict=True)
     except (OSError, RuntimeError, ValueError):
@@ -120,6 +125,9 @@ def build_download_response(resolved: Path, *, preview: bool) -> web.StreamRespo
 
     if not safe_path.is_absolute() or not safe_path.is_file():
         return web.Response(status=404, text="File not found")
+
+    if is_resolved_path_allowed is not None and not is_resolved_path_allowed(safe_path):
+        return web.Response(status=403, text="Path is not within allowed roots")
 
     mime_type, _ = mimetypes.guess_type(str(safe_path))
     safe_mime = mime_type or "application/octet-stream"

--- a/mjr_am_backend/routes/handlers/assets_impl.py
+++ b/mjr_am_backend/routes/handlers/assets_impl.py
@@ -206,7 +206,11 @@ def _wired_rate_limit(request_obj: Any, *, preview: bool) -> Any:
 
 
 def _wired_build_download_attachment(path: Any) -> Any:
-    return build_download_response(path, preview=False)
+    return build_download_response(
+        path,
+        preview=False,
+        is_resolved_path_allowed=_is_resolved_path_allowed,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +431,7 @@ async def download_asset(request: web.Request) -> web.StreamResponse:
         build_download_response=lambda path: build_download_response(
             path,
             preview=is_preview_download_request(request),
+            is_resolved_path_allowed=_is_resolved_path_allowed,
         ),
     )
 


### PR DESCRIPTION
Potential fix for [https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/security/code-scanning/40](https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/security/code-scanning/40)

The best fix is to make `build_download_response` perform a final, explicit authorization check on the resolved path before constructing `FileResponse`, instead of relying only on upstream callers. This preserves behavior for valid paths and blocks unsafe direct use.

In `mjr_am_backend/features/assets/download_service.py`, update `build_download_response` to accept an injected validator callback (e.g., `is_resolved_path_allowed: Callable[[Path], bool] | None = None`). After `safe_path = resolved.resolve(strict=True)` and absolute/file checks, add:

- if validator is provided and returns `False`, return `403`.

Then, in `mjr_am_backend/routes/handlers/assets_impl.py`, update the two places wiring `build_download_response` so they pass `_is_resolved_path_allowed` into `build_download_response` (the lambda in `download_asset`, and `_wired_build_download_attachment`).

This is minimal, keeps existing functionality, strengthens the sink boundary, and addresses all alert variants without broad refactors.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
