### PR TITLE
Fix tags shortcut and live badge update in main grid

### DIFF
--- a/ui/features/viewer/keyboard.ts
+++ b/ui/features/viewer/keyboard.ts
@@ -2,6 +2,13 @@ import { safeAddListener, safeCall } from "./lifecycle.js";
 import { comfyToast } from "../../app/toast.js";
 import { t } from "../../app/i18n.js";
 import { isHotkeysSuspended } from "../panel/controllers/hotkeysState.js";
+import { ASSET_TAGS_CHANGED_EVENT } from "../../app/events.js";
+import { safeDispatchCustomEvent } from "../../utils/events.js";
+import {
+    openViewerTagsPopover,
+    closeViewerTagsPopover,
+    viewerContextMenuState,
+} from "../contextmenu/viewerContextMenuState.js";
 
 /**
  * Extract prompt text from asset metadata for clipboard copy.
@@ -199,7 +206,11 @@ export function installViewerKeyboard({
 
                     if (e.key === "Escape") {
                         consume();
-                        safeCall(closeViewer);
+                        if (viewerContextMenuState.tags.open) {
+                            closeViewerTagsPopover();
+                        } else {
+                            safeCall(closeViewer);
+                        }
                     }
                     return;
                 }
@@ -424,6 +435,27 @@ export function installViewerKeyboard({
                 safeCall(renderGenInfoPanel);
                 break;
             }
+            case "t":
+            case "T": {
+                if (!current?.id) break;
+                consume();
+                openViewerTagsPopover({
+                    x: Number(state?._lastPointerX) || Math.round((overlay?.clientWidth || 0) / 2),
+                    y: Number(state?._lastPointerY) || Math.round((overlay?.clientHeight || 0) / 2),
+                    asset: current,
+                    onChanged: ((...args: any[]) => {
+                        const tags = args[0];
+                        current.tags = tags;
+                        safeDispatchCustomEvent(
+                            ASSET_TAGS_CHANGED_EVENT,
+                            { assetId: String(current.id), tags },
+                            { warnPrefix: "[ViewerKeyboard]" },
+                        );
+                        safeCall(renderBadges);
+                    }) as () => void,
+                });
+                break;
+            }
             case "z":
             case "Z": {
                 consume();
@@ -588,7 +620,11 @@ export function installViewerKeyboard({
             }
             case "Escape":
                 consume();
-                safeCall(closeViewer);
+                if (viewerContextMenuState.tags.open) {
+                    closeViewerTagsPopover();
+                } else {
+                    safeCall(closeViewer);
+                }
                 break;
             case "ArrowLeft":
                 if (isSingle && e.target?.closest?.(".mjr-viewer-playerbar")) {

--- a/ui/vue/components/common/TagsEditor.vue
+++ b/ui/vue/components/common/TagsEditor.vue
@@ -5,7 +5,7 @@
  * Phase 4.1: Replaces createTagsEditor() from TagsEditor.js.
  * Emits tags-change event when tags are updated.
  */
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { getAvailableTags, updateAssetTags } from "../../../api/client.js";
 import { ASSET_TAGS_CHANGED_EVENT } from "../../../app/events.js";
 import { t } from "../../../app/i18n.js";
@@ -260,6 +260,13 @@ async function saveTags() {
 
 onMounted(async () => {
     try {
+        await nextTick();
+        resolveDomElement(inputRef.value)?.focus();
+    } catch (e) {
+        console.debug?.(e);
+    }
+
+    try {
         const result = await getAvailableTags();
         if (result?.ok && Array.isArray(result?.data)) {
             availableTags.value = dedupeTags(result.data);
@@ -306,7 +313,11 @@ function removeTag(index) {
 function handleInputKeydown(event) {
     if (event.key === "Enter" || event.key === ",") {
         event.preventDefault();
-        const tag = inputValue.value.trim();
+        const highlighted =
+            showDropdown.value && hasSuggestions.value && selectedIndex.value >= 0
+                ? filteredSuggestions.value[selectedIndex.value]
+                : null;
+        const tag = highlighted || inputValue.value.trim();
         if (tag) {
             addTag(tag);
             inputValue.value = "";

--- a/ui/vue/components/grid/VirtualAssetGridHost.vue
+++ b/ui/vue/components/grid/VirtualAssetGridHost.vue
@@ -567,6 +567,21 @@ function openKeyboardDetails() {
     }
 }
 
+function onAssetTagsChanged(event) {
+    const detail = event?.detail || {};
+    const assetId = String(detail.assetId ?? detail.id ?? "").trim();
+    if (!assetId) return;
+    const list = Array.isArray(state.assets) ? state.assets : [];
+    const idx = list.findIndex((entry) => String(entry?.id || "") === assetId);
+    if (idx === -1) return;
+    const nextTags = Array.isArray(detail.tags) ? [...detail.tags] : [];
+    // Replace the array (and the changed entry) so the shallowReactive grid state
+    // detects the update — mutating asset.tags in place is invisible to it.
+    const next = list.slice();
+    next[idx] = { ...next[idx], tags: nextTags };
+    state.assets = next;
+}
+
 function installGridApi(container) {
     if (!container) return;
     container._mjrSelectionManagedByVue = true;
@@ -961,6 +976,7 @@ function scheduleInitialHostMeasurements() {
 
 onMounted(() => {
     scheduleInitialHostMeasurements();
+    window.addEventListener(EVENTS.ASSET_TAGS_CHANGED, onAssetTagsChanged);
 });
 
 watch(
@@ -1679,6 +1695,11 @@ watch(
 );
 
 onBeforeUnmount(() => {
+    try {
+        window.removeEventListener(EVENTS.ASSET_TAGS_CHANGED, onAssetTagsChanged);
+    } catch (e) {
+        console.debug?.(e);
+    }
     try {
         gridContainerRef.value?._mjrPrimaryPointerSelectionUnbind?.();
     } catch (e) {

--- a/ui/vue/composables/useGridKeyboard.ts
+++ b/ui/vue/composables/useGridKeyboard.ts
@@ -1,5 +1,6 @@
 import { onUnmounted, watch } from "vue";
 import { installGridKeyboard } from "../../features/grid/GridKeyboard.js";
+import { showTagsPopover } from "../../features/contextmenu/GridContextMenu.js";
 
 /**
  * useGridKeyboard  -  Vue lifecycle wrapper around the legacy GridKeyboard engine.
@@ -23,6 +24,23 @@ export function bindLegacyGridKeyboard(container: HTMLElement | null | undefined
             },
             onOpenDetails: () => {
                 c._mjrOpenKeyboardDetails?.();
+            },
+            onOpenTagsEditor: (asset: any) => {
+                const activeCard =
+                    container.querySelector?.(
+                        `.mjr-asset-card[data-mjr-asset-id="${CSS?.escape ? CSS.escape(String(asset?.id || "")) : asset?.id || ""}"]`,
+                    ) || null;
+                let rect: any = null;
+                try {
+                    rect = activeCard?.getBoundingClientRect?.() || container.getBoundingClientRect();
+                } catch (e) {
+                    console.debug?.("[useGridKeyboard] rect lookup failed", e);
+                }
+                const x = Math.round((rect?.left || 0) + Math.min((rect?.width || 0) * 0.5, 160));
+                const y = Math.round((rect?.top || 0) + Math.min((rect?.height || 0) * 0.5, 120));
+                showTagsPopover(x, y, asset, () => {
+                    c._mjrOnKeyboardAssetChanged?.(asset);
+                });
             },
         });
         keyboard.bind();


### PR DESCRIPTION
## Summary
- Fix tags keyboard shortcut not triggering when focus is on the grid
- Fix live badge not updating when tags are changed from outside the grid
- Fix Escape key closing the viewer instead of dismissing the tags popover

## Files changed
- `ui/features/viewer/keyboard.ts` — correct Escape key handling scope
- `ui/vue/components/common/TagsEditor.vue` — shortcut wiring fix
- `ui/vue/components/grid/VirtualAssetGridHost.vue` — live tag badge update via event listener
- `ui/vue/composables/useGridKeyboard.ts` — keyboard event registration fix