### PR TITLE
Sync grid selection to the viewer's active asset on close

### DIFF
--- a/ui/app/events.ts
+++ b/ui/app/events.ts
@@ -1,11 +1,13 @@
 export const ASSET_RATING_CHANGED_EVENT = "mjr:asset-rating-changed";
 export const ASSET_TAGS_CHANGED_EVENT = "mjr:asset-tags-changed";
 export const VIEWER_INFO_REFRESHED_EVENT = "mjr:viewer-info-refreshed";
+export const VIEWER_ACTIVE_ASSET_CHANGED_EVENT = "mjr:viewer-active-asset-changed";
 
 export const EVENTS = Object.freeze({
     ASSET_RATING_CHANGED: ASSET_RATING_CHANGED_EVENT,
     ASSET_TAGS_CHANGED: ASSET_TAGS_CHANGED_EVENT,
     VIEWER_INFO_REFRESHED: VIEWER_INFO_REFRESHED_EVENT,
+    VIEWER_ACTIVE_ASSET_CHANGED: VIEWER_ACTIVE_ASSET_CHANGED_EVENT,
     SCAN_COMPLETE: "mjr-scan-complete",
     CORE_EXECUTION_ASSETS_READY: "mjr-core-execution-assets-ready",
     ENRICHMENT_STATUS: "mjr-enrichment-status",

--- a/ui/components/ViewerRuntime.ts
+++ b/ui/components/ViewerRuntime.ts
@@ -11,7 +11,11 @@ import {
     getViewerInfo,
     getFileMetadataScoped,
 } from "../api/client.js";
-import { ASSET_RATING_CHANGED_EVENT, ASSET_TAGS_CHANGED_EVENT } from "../app/events.js";
+import {
+    ASSET_RATING_CHANGED_EVENT,
+    ASSET_TAGS_CHANGED_EVENT,
+    VIEWER_ACTIVE_ASSET_CHANGED_EVENT,
+} from "../app/events.js";
 import { t } from "../app/i18n.js";
 import {
     bindViewerContextMenu,
@@ -2315,6 +2319,18 @@ function createViewer() {
     }
 
     function closeViewer() {
+        try {
+            const current = state.assets?.[state.currentIndex];
+            if (current?.id) {
+                safeDispatchCustomEvent(
+                    VIEWER_ACTIVE_ASSET_CHANGED_EVENT,
+                    { assetId: String(current.id) },
+                    { warnPrefix: "[ViewerRuntime]" },
+                );
+            }
+        } catch (e: any) {
+            console.debug?.(e);
+        }
         try {
             state.distractionFree = false;
             applyDistractionFreeUI();

--- a/ui/vue/components/grid/VirtualAssetGridHost.vue
+++ b/ui/vue/components/grid/VirtualAssetGridHost.vue
@@ -567,6 +567,38 @@ function openKeyboardDetails() {
     }
 }
 
+function focusCardSoon(assetId, attempts = 6) {
+    const el = state.cardElements.get(assetId);
+    if (el) {
+        try {
+            el.focus?.({ preventScroll: true });
+        } catch (e) {
+            console.debug?.(e);
+        }
+        return;
+    }
+    if (attempts <= 0) return;
+    requestAnimationFrame(() => focusCardSoon(assetId, attempts - 1));
+}
+
+function onViewerActiveAssetChanged(event) {
+    const detail = event?.detail || {};
+    const assetId = String(detail.assetId ?? detail.id ?? "").trim();
+    if (!assetId) return;
+    const list = Array.isArray(renderableAssets.value) ? renderableAssets.value : [];
+    if (!list.some((entry) => String(entry?.id || "") === assetId)) return;
+
+    setSelection([assetId], assetId);
+    updateSelectionDatasets();
+    emitSelectionChanged();
+    scrollToAssetId(assetId, { align: "center" });
+
+    // Deferred: ViewerRuntime.closeViewer() restores focus to the element that
+    // was focused before the viewer opened *after* this listener returns, which
+    // would otherwise stomp the focus move below. Run after that finishes.
+    setTimeout(() => focusCardSoon(assetId), 0);
+}
+
 function installGridApi(container) {
     if (!container) return;
     container._mjrSelectionManagedByVue = true;
@@ -961,6 +993,7 @@ function scheduleInitialHostMeasurements() {
 
 onMounted(() => {
     scheduleInitialHostMeasurements();
+    window.addEventListener(EVENTS.VIEWER_ACTIVE_ASSET_CHANGED, onViewerActiveAssetChanged);
 });
 
 watch(
@@ -1679,6 +1712,11 @@ watch(
 );
 
 onBeforeUnmount(() => {
+    try {
+        window.removeEventListener(EVENTS.VIEWER_ACTIVE_ASSET_CHANGED, onViewerActiveAssetChanged);
+    } catch (e) {
+        console.debug?.(e);
+    }
     try {
         gridContainerRef.value?._mjrPrimaryPointerSelectionUnbind?.();
     } catch (e) {


### PR DESCRIPTION
## Summary
- When the viewer closes, the grid now selects and scrolls to the asset that was active in the viewer
- Focuses the corresponding grid card so keyboard navigation resumes from the right place

## Files changed
- `ui/app/events.ts` — add VIEWER_ACTIVE_ASSET_CHANGED event constant
- `ui/components/ViewerRuntime.ts` — emit event when viewer active asset changes
- `ui/vue/components/grid/VirtualAssetGridHost.vue` — listen for event and sync grid selection