### PR TITLE
Fix floating viewer mute/speed persistence and rating hotkeys

### DIFF
--- a/ui/features/panel/controllers/ratingHotkeysController.ts
+++ b/ui/features/panel/controllers/ratingHotkeysController.ts
@@ -155,7 +155,9 @@ export function createRatingHotkeysController({ gridContainer, createRatingBadge
             // allow targets inside it - e.g. focus lands on its mute/speed controls after use.
             const isTargetInGrid = gridContainer.contains(e.target) || gridContainer === e.target;
             const isTargetInFloatingViewer = !!e.target?.closest?.(".mjr-mfv");
-            if (!isTargetInGrid && !isTargetInFloatingViewer) return; // Only handle rating keys when interacting with our grid
+            // Also allow when the floating viewer is visible but focus is on body/canvas (non-focusable content)
+            const isFloatingViewerVisible = !!document.querySelector(".mjr-mfv.is-visible");
+            if (!isTargetInGrid && !isTargetInFloatingViewer && !isFloatingViewerVisible) return;
 
             const rating = k === "0" ? 0 : Number(k);
             if (!Number.isFinite(rating)) return;

--- a/ui/features/panel/controllers/ratingHotkeysController.ts
+++ b/ui/features/panel/controllers/ratingHotkeysController.ts
@@ -3,6 +3,7 @@ import { ASSET_RATING_CHANGED_EVENT } from "../../../app/events.js";
 import { comfyToast } from "../../../app/toast.js";
 import { t } from "../../../app/i18n.js";
 import { getHotkeysState, isHotkeysSuspended, setRatingHotkeysActive } from "./hotkeysState.js";
+import { getSelectedIdSet } from "../../grid/GridSelectionManager.js";
 
 const EVENT_NAME = ASSET_RATING_CHANGED_EVENT;
 
@@ -18,23 +19,38 @@ function _safeCssEscapeAttr(value: any) {
     return str.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 }
 
-function getSelectedCards(gridContainer: any, fallbackEventTarget: any = null) {
+function getSelectedAssetIds(gridContainer: any, fallbackEventTarget: any = null): string[] {
     if (!gridContainer) return [];
+    // Read from the selection dataset rather than querying `.is-selected` DOM cards -
+    // the grid is virtualized, so the active asset's card may not be rendered at all
+    // (e.g. scrolled out of view while the floating viewer is open) even though it's selected.
     try {
-        const selected = Array.from(gridContainer.querySelectorAll(".mjr-asset-card.is-selected"));
-        if (selected.length) return selected;
+        const ids = Array.from(getSelectedIdSet(gridContainer));
+        if (ids.length) return ids;
     } catch (e) {
         console.debug?.(e);
     }
 
     try {
         const card = fallbackEventTarget?.closest?.(".mjr-asset-card");
-        if (card && gridContainer.contains(card)) return [card];
+        const id = card?._mjrAsset?.id ?? card?.dataset?.mjrAssetId;
+        if (card && gridContainer.contains(card) && id != null) return [String(id)];
     } catch (e) {
         console.debug?.(e);
     }
 
     return [];
+}
+
+function findRenderedCard(gridContainer: any, assetId: any) {
+    try {
+        return gridContainer?.querySelector?.(
+            `.mjr-asset-card[data-mjr-asset-id="${_safeCssEscapeAttr(assetId)}"]`,
+        );
+    } catch (e) {
+        console.debug?.(e);
+        return null;
+    }
 }
 
 function updateCardRatingBadge(card: any, createRatingBadge: any, rating: any) {
@@ -86,9 +102,7 @@ export function createRatingHotkeysController({ gridContainer, createRatingBadge
     let onKeyDown: any = null;
     let onRatingEvent: any = null;
 
-    const applyRatingToCard = async (card: any, rating: any) => {
-        const asset = card?._mjrAsset;
-        const assetId = asset?.id;
+    const applyRatingToAsset = async (assetId: any, rating: any) => {
         if (assetId == null) return;
 
         try {
@@ -103,7 +117,15 @@ export function createRatingHotkeysController({ gridContainer, createRatingBadge
             return;
         }
 
-        updateCardRatingBadge(card, createRatingBadge, rating);
+        // Broadcasting here also drives the badge refresh via the onRatingEvent listener
+        // below, which finds the card (if currently rendered) and updates it.
+        try {
+            window.dispatchEvent(
+                new CustomEvent(EVENT_NAME, { detail: { assetId: String(assetId), rating } }),
+            );
+        } catch (e) {
+            console.debug?.(e);
+        }
     };
 
     const bind = () => {
@@ -128,24 +150,25 @@ export function createRatingHotkeysController({ gridContainer, createRatingBadge
             if (viewerOverlay && (viewerOverlay as HTMLElement).style.display !== "none") return;
 
             // Check if the event target is within our grid container or if the grid container itself has focus/hover
-            // This ensures rating hotkeys only work when interacting with the assets manager
+            // This ensures rating hotkeys only work when interacting with the assets manager.
+            // The floating viewer lives outside the grid DOM (it's a separate overlay), so also
+            // allow targets inside it - e.g. focus lands on its mute/speed controls after use.
             const isTargetInGrid = gridContainer.contains(e.target) || gridContainer === e.target;
-            if (!isTargetInGrid) return; // Only handle rating keys when interacting with our grid
+            const isTargetInFloatingViewer = !!e.target?.closest?.(".mjr-mfv");
+            if (!isTargetInGrid && !isTargetInFloatingViewer) return; // Only handle rating keys when interacting with our grid
 
             const rating = k === "0" ? 0 : Number(k);
             if (!Number.isFinite(rating)) return;
 
-            const cards = getSelectedCards(gridContainer, e.target);
-            if (!cards.length) return;
+            const assetIds = getSelectedAssetIds(gridContainer, e.target);
+            if (!assetIds.length) return;
 
             // Only prevent default and stop propagation if we're actually handling the key
-            if (cards.length > 0) {
-                e.preventDefault();
-                e.stopPropagation();
-                e.stopImmediatePropagation?.();
-            }
+            e.preventDefault();
+            e.stopPropagation();
+            e.stopImmediatePropagation?.();
 
-            await runWithConcurrencyLimit(cards, (card: any) => applyRatingToCard(card, rating), 5);
+            await runWithConcurrencyLimit(assetIds, (id: any) => applyRatingToAsset(id, rating), 5);
         };
 
         onRatingEvent = (ev: any) => {
@@ -153,14 +176,8 @@ export function createRatingHotkeysController({ gridContainer, createRatingBadge
             const assetId = detail.assetId ?? detail.id ?? null;
             const rating = Number(detail.rating);
             if (!assetId || !Number.isFinite(rating)) return;
-            try {
-                const card = gridContainer.querySelector(
-                    `.mjr-asset-card[data-mjr-asset-id="${_safeCssEscapeAttr(assetId)}"]`,
-                );
-                if (card) updateCardRatingBadge(card, createRatingBadge, rating);
-            } catch (e) {
-                console.debug?.(e);
-            }
+            const card = findRenderedCard(gridContainer, assetId);
+            if (card) updateCardRatingBadge(card, createRatingBadge, rating);
         };
 
         try {

--- a/ui/features/viewer/FloatingViewer.impl.ts
+++ b/ui/features/viewer/FloatingViewer.impl.ts
@@ -139,6 +139,11 @@ export class FloatingViewer {
         this._pinnedSlots = new Set();
         this._abDividerX = 0.5; // 0..1
 
+        // Persisted media playback state - intentionally NOT reset on navigation so
+        // mute/speed survive moving between assets with the arrow keys.
+        this._mfvMuted = false;
+        this._mfvPlaybackRate = 1;
+
         // Pan/zoom state
         this._zoom = 1;
         this._panX = 0;
@@ -914,6 +919,35 @@ export class FloatingViewer {
         return rootEl;
     }
 
+    // Keep mute/speed in sync as the user changes them on the primary media
+    // element, so the next navigated-to asset can be built with the same values.
+    _bindMfvPersistence(rootEl: any) {
+        try {
+            const mediaEl = rootEl?.matches?.("video, audio")
+                ? rootEl
+                : rootEl?.querySelector?.("video, audio");
+            if (!mediaEl) return rootEl;
+            mediaEl.addEventListener("volumechange", () => {
+                try {
+                    this._mfvMuted = !!mediaEl.muted;
+                } catch (e: any) {
+                    console.debug?.(e);
+                }
+            });
+            mediaEl.addEventListener("ratechange", () => {
+                try {
+                    const rate = Number(mediaEl.playbackRate);
+                    if (Number.isFinite(rate) && rate > 0) this._mfvPlaybackRate = rate;
+                } catch (e: any) {
+                    console.debug?.(e);
+                }
+            });
+        } catch (e: any) {
+            console.debug?.(e);
+        }
+        return rootEl;
+    }
+
     _initCompareSync() {
         this._destroyCompareSync();
         if (!this._contentEl) return;
@@ -1270,8 +1304,12 @@ export class FloatingViewer {
             this._contentEl.appendChild(_makeEmptyState());
             return;
         }
-        const rawMediaEl = _buildMediaEl(this._mediaA);
+        const rawMediaEl = _buildMediaEl(this._mediaA, {
+            initialMuted: this._mfvMuted,
+            initialPlaybackRate: this._mfvPlaybackRate,
+        });
         const mediaEl = this._trackMediaControls?.(rawMediaEl) || rawMediaEl;
+        this._bindMfvPersistence?.(mediaEl);
         if (!mediaEl) {
             this._contentEl.appendChild(_makeEmptyState("Could not load media"));
             return;
@@ -1283,12 +1321,19 @@ export class FloatingViewer {
     }
 
     _renderAB() {
-        const rawElA = this._mediaA ? _buildMediaEl(this._mediaA, { fill: true }) : null;
+        const rawElA = this._mediaA
+            ? _buildMediaEl(this._mediaA, {
+                  fill: true,
+                  initialMuted: this._mfvMuted,
+                  initialPlaybackRate: this._mfvPlaybackRate,
+              })
+            : null;
         const rawElB = this._mediaB
-            ? _buildMediaEl(this._mediaB, { fill: true, controls: false })
+            ? _buildMediaEl(this._mediaB, { fill: true, controls: false, initialMuted: true })
             : null;
         const elA = this._trackMediaControls?.(rawElA) || rawElA;
         const elB = this._trackMediaControls?.(rawElB) || rawElB;
+        this._bindMfvPersistence?.(elA);
         const kindA = this._mediaA ? _mediaKind(this._mediaA) : "";
         const kindB = this._mediaB ? _mediaKind(this._mediaB) : "";
 
@@ -1401,10 +1446,18 @@ export class FloatingViewer {
     }
 
     _renderSide() {
-        const rawElA = this._mediaA ? _buildMediaEl(this._mediaA) : null;
-        const rawElB = this._mediaB ? _buildMediaEl(this._mediaB, { controls: false }) : null;
+        const rawElA = this._mediaA
+            ? _buildMediaEl(this._mediaA, {
+                  initialMuted: this._mfvMuted,
+                  initialPlaybackRate: this._mfvPlaybackRate,
+              })
+            : null;
+        const rawElB = this._mediaB
+            ? _buildMediaEl(this._mediaB, { controls: false, initialMuted: true })
+            : null;
         const elA = this._trackMediaControls?.(rawElA) || rawElA;
         const elB = this._trackMediaControls?.(rawElB) || rawElB;
+        this._bindMfvPersistence?.(elA);
         const kindA = this._mediaA ? _mediaKind(this._mediaA) : "";
         const kindB = this._mediaB ? _mediaKind(this._mediaB) : "";
 
@@ -1478,8 +1531,14 @@ export class FloatingViewer {
             cell.className = "mjr-mfv-grid-cell";
             if (media) {
                 const kind = _mediaKind(media);
-                const rawEl = _buildMediaEl(media, { controls: label === "A" });
+                const isPrimary = label === "A";
+                const rawEl = _buildMediaEl(media, {
+                    controls: isPrimary,
+                    initialMuted: isPrimary ? this._mfvMuted : true,
+                    initialPlaybackRate: isPrimary ? this._mfvPlaybackRate : 1,
+                });
                 const el = this._trackMediaControls?.(rawEl) || rawEl;
+                if (isPrimary) this._bindMfvPersistence?.(el);
                 if (el) cell.appendChild(el);
                 else cell.appendChild(_makeEmptyState(" - "));
                 cell.appendChild(

--- a/ui/features/viewer/floatingViewerMedia.ts
+++ b/ui/features/viewer/floatingViewerMedia.ts
@@ -70,6 +70,28 @@ export function attemptFloatingViewerAutoplay(mediaEl: any): void {
     }
 }
 
+// Browsers generally block unmuted autoplay. When the caller wants sound on by
+// default, try playing unmuted first and fall back to muted playback if the
+// browser rejects it, so the media still autoplays either way.
+export function attemptFloatingViewerAutoplayWithSound(mediaEl: any): void {
+    if (!mediaEl || typeof mediaEl.play !== "function") return;
+    try {
+        const p = mediaEl.play();
+        if (p && typeof p.catch === "function") {
+            p.catch(() => {
+                try {
+                    mediaEl.muted = true;
+                    attemptFloatingViewerAutoplay(mediaEl);
+                } catch (e: any) {
+                    console.debug?.(e);
+                }
+            });
+        }
+    } catch (e: any) {
+        console.debug?.(e);
+    }
+}
+
 export function findFloatingViewerScrollableAncestor(target: any, boundary: any) {
     let node = target && target.nodeType === 1 ? target : target?.parentElement || null;
     while (node && node !== boundary) {
@@ -126,7 +148,10 @@ export function pauseFloatingViewerMediaIn(rootEl: any) {
     }
 }
 
-export function buildFloatingViewerMediaElement(fileData: any, { fill = false, controls = true } = {}) {
+export function buildFloatingViewerMediaElement(
+    fileData: any,
+    { fill = false, controls = true, initialMuted = false, initialPlaybackRate = 1 } = {},
+) {
     const url = resolveFloatingViewerMediaUrl(fileData);
     if (!url) return null;
     const kind = getFloatingViewerMediaKind(fileData);
@@ -166,6 +191,7 @@ export function buildFloatingViewerMediaElement(fileData: any, { fill = false, c
             mediaKind,
             initialFps: readAssetFps(fileData) || undefined,
             initialFrameCount: readAssetFrameCount(fileData, readAssetFps(fileData)) || undefined,
+            initialPlaybackRate,
         });
 
         try {
@@ -185,15 +211,17 @@ export function buildFloatingViewerMediaElement(fileData: any, { fill = false, c
         audio.autoplay = true;
         audio.preload = "metadata";
         audio.loop = true;
-        audio.muted = true;
+        audio.muted = initialMuted;
+        audio.playbackRate = initialPlaybackRate;
+        const autoplay = initialMuted
+            ? () => attemptFloatingViewerAutoplay(audio)
+            : () => attemptFloatingViewerAutoplayWithSound(audio);
         try {
-            audio.addEventListener("loadedmetadata", () => attemptFloatingViewerAutoplay(audio), {
-                once: true,
-            });
+            audio.addEventListener("loadedmetadata", autoplay, { once: true });
         } catch (e: any) {
             console.debug?.(e);
         }
-        attemptFloatingViewerAutoplay(audio);
+        autoplay();
         return buildPlayableMediaHost(audio, "audio");
     }
 
@@ -203,9 +231,15 @@ export function buildFloatingViewerMediaElement(fileData: any, { fill = false, c
         v.src = url;
         v.controls = false;
         v.loop = true;
-        v.muted = true;
+        v.muted = initialMuted;
+        v.playbackRate = initialPlaybackRate;
         v.autoplay = true;
         v.playsInline = true;
+        if (initialMuted) {
+            attemptFloatingViewerAutoplay(v);
+        } else {
+            attemptFloatingViewerAutoplayWithSound(v);
+        }
         return buildPlayableMediaHost(v, "video");
     }
 


### PR DESCRIPTION
## Summary
- Persist mute and playback speed settings across assets in the floating viewer
- Fix rating hotkeys not working when the floating viewer is focused

## Files changed
- `ui/features/panel/controllers/ratingHotkeysController.ts` — activate hotkeys when floating viewer has focus
- `ui/features/viewer/FloatingViewer.impl.ts` — save and restore mute/speed state
- `ui/features/viewer/floatingViewerMedia.ts` — apply persisted mute/speed on media load