### PR TITLE
Add 3x/5x/10x playback speeds and fix speed persistence and arrow-key nav

### DIFF
--- a/ui/components/VideoControls.ts
+++ b/ui/components/VideoControls.ts
@@ -524,7 +524,7 @@ export function mountVideoControls(video: any, opts: Record<string, any> = {}) {
         speedSelect.title = t("video.playbackSpeed", "Playback speed");
         speedSelect.setAttribute("aria-label", t("video.playbackSpeed", "Playback speed"));
         speedSelect.style.width = "74px";
-        const SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2];
+        const SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 2, 3, 5, 10];
         for (const rate of SPEED_OPTIONS) {
             const opt = document.createElement("option");
             opt.value = String(rate);
@@ -802,7 +802,7 @@ export function mountVideoControls(video: any, opts: Record<string, any> = {}) {
             loop: advanced,
             pingpong: false,
             once: false,
-            playbackRate: Math.max(0.25, Math.min(2, Number(opts?.initialPlaybackRate) || 1)),
+            playbackRate: Math.max(0.25, Math.min(10, Number(opts?.initialPlaybackRate) || 1)),
             _seeking: false,
             _ppReverse: false,
             _ppRafId: null,
@@ -907,7 +907,7 @@ export function mountVideoControls(video: any, opts: Record<string, any> = {}) {
             try {
                 const n = Number(nextRate);
                 if (!Number.isFinite(n) || n <= 0) return state.playbackRate;
-                const rate = Math.max(0.25, Math.min(2, Math.round(n * 100) / 100));
+                const rate = Math.max(0.25, Math.min(10, Math.round(n * 100) / 100));
                 state.playbackRate = rate;
                 try {
                     video.playbackRate = rate;
@@ -1928,6 +1928,13 @@ export function mountVideoControls(video: any, opts: Record<string, any> = {}) {
                 stop(e);
                 try {
                     setPlaybackRate(Number(speedSelect.value) || 1);
+                } catch (e: any) {
+                    console.debug?.(e);
+                }
+                try {
+                    // Release focus so Left/Right keep navigating between assets
+                    // instead of being swallowed by the focused <select>.
+                    speedSelect.blur?.();
                 } catch (e: any) {
                     console.debug?.(e);
                 }

--- a/ui/features/viewer/playerBarManager.ts
+++ b/ui/features/viewer/playerBarManager.ts
@@ -44,6 +44,12 @@ export function createPlayerBarManager({
         }
         state._videoSyncAbort = null;
         try {
+            state._videoRateAbort?.abort?.();
+        } catch (e: any) {
+            console.debug?.(e);
+        }
+        state._videoRateAbort = null;
+        try {
             state._videoMetaAbort?.abort?.();
         } catch (e: any) {
             console.debug?.(e);
@@ -200,6 +206,31 @@ export function createPlayerBarManager({
             state._videoControlsDestroy = mounted?.destroy || null;
             state._activeVideoEl = mediaEl;
             state._activeVideoAssetId = currentAssetId;
+            try {
+                state._videoRateAbort?.abort?.();
+            } catch (e: any) {
+                console.debug?.(e);
+            }
+            try {
+                const rateAc = new AbortController();
+                state._videoRateAbort = rateAc;
+                // Keep the viewer's persisted rate (carried into the next video) in sync
+                // regardless of how it was changed (speed select, keyboard, native controls).
+                mediaEl.addEventListener(
+                    "ratechange",
+                    () => {
+                        try {
+                            const rate = Number(mediaEl.playbackRate);
+                            if (Number.isFinite(rate) && rate > 0) state.playbackRate = rate;
+                        } catch (e: any) {
+                            console.debug?.(e);
+                        }
+                    },
+                    { signal: rateAc.signal, passive: true },
+                );
+            } catch (e: any) {
+                console.debug?.(e);
+            }
             try {
                 state.nativeFps = Number(initialFps) > 0 ? Number(initialFps) : null;
             } catch (e: any) {


### PR DESCRIPTION
## Summary
- Add 3x, 5x, and 10x playback speed options to the video controls
- Fix playback speed not persisting when switching between assets
- Fix arrow-key navigation resetting the playback speed

## Files changed
- `ui/components/VideoControls.ts` — add 3x/5x/10x speed options to the speed selector
- `ui/features/viewer/playerBarManager.ts` — persist speed across asset changes, restore on nav