### PR TITLE
Fix viewer path resolution and clarify write access

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,20 @@ See [`docs/DB_MAINTENANCE.md`](docs/DB_MAINTENANCE.md) for detailed recovery pro
 - Check firewall settings for ComfyUI port
 - Verify CORS settings if accessing from different origin
 
+### “Write access is blocked”
+
+Majoor's write guard is separate from Windows, Linux, macOS, or NAS file permissions. A user can have full access to the files and still be blocked by Majoor when ComfyUI is opened through a LAN IP, reverse proxy, or tunnel. Majoor protects operations that modify data, including ratings, tags, rename, delete, index reset, and some file actions.
+
+For the safest remote setup, open **Settings → Majoor Assets Manager → Security** and enable **Recommended Remote LAN Setup**. This creates or reuses an API token and authorizes the current browser. On a trusted private LAN using plain HTTP, **Allow HTTP Token Transport** may also be required.
+
+The settings shown below enable the individual operations while keeping Safe Mode off and delete confirmation on. They do not by themselves authorize an anonymous LAN client: remote access still requires either **Recommended Remote LAN Setup** with a token, or **Allow Remote Full Access** on a fully trusted private LAN.
+
+![Majoor operation permission settings](docs/images/security-settings-trusted-lan.svg)
+
+Do not enable **Allow Remote Full Access** when ComfyUI is exposed to the internet, an untrusted network, or an unprotected tunnel.
+
+After changing the settings, refresh the ComfyUI page. Restart ComfyUI if environment variables override the UI values. See [Remote Access Write Permissions](docs/INSTALLATION.md#remote-access-write-permissions) for the complete decision guide.
+
 ---
 
 ## Development & Testing

--- a/dist/chunks/FloatingViewer-DI28fYkn.js
+++ b/dist/chunks/FloatingViewer-DI28fYkn.js
@@ -1,12 +1,12 @@
-import { Yt as e, g as t, y as n } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { B as r, C as i, I as a, M as o, O as s, P as c, R as l, V as u, j as d, m as f, o as p, pt as m, r as h, rt as g, v as _, w as v, x as y } from "./events-BR4juJWK.js";
+import { Yt as e, g as t, y as n } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { B as r, C as i, I as a, M as o, O as s, P as c, R as l, V as u, j as d, m as f, o as p, pt as m, r as h, rt as g, v as _, w as v, x as y } from "./events-DSLVC_8W.js";
 import { a as b, i as x, o as S, s as C } from "./graphTraversal-Sruu0ipL.js";
-import { _ as w, g as T, m as E, n as D, p as ee, r as O, w as k } from "./Viewer-CZ9I2Zag.js";
-import { _ as A, r as j } from "./SidebarWorkflowSection-DaUIh32R.js";
-import { _ as M, a as N, c as P, d as F, f as I, g as L, h as te, i as ne, l as R, m as z, o as B, p as re, r as V, s as ie, t as ae, u as H, v as U } from "./openMajoorSettings-cHyywzYd.js";
-import { a as oe, n as se, r as ce } from "./model3dRenderer-Dz6vgESs.js";
+import { _ as w, g as T, m as E, n as D, p as ee, r as O, w as k } from "./Viewer-C1jSvHym.js";
+import { _ as A, r as j } from "./SidebarWorkflowSection-BwS0BsAZ.js";
+import { _ as M, a as N, c as P, d as F, f as I, g as L, h as te, i as ne, l as R, m as z, o as B, p as re, r as V, s as ie, t as ae, u as H, v as U } from "./openMajoorSettings-BaEfvO9h.js";
+import { a as oe, n as se, r as ce } from "./model3dRenderer-C7vE1AWS.js";
 import { i as le, o as ue, r as de, t as fe } from "./geninfoParser-D91g5NYg.js";
-import { t as pe } from "./genInfo-Dt2N-RoA.js";
+import { t as pe } from "./genInfo-BcSUiLW5.js";
 //#region ui/features/viewer/floatingViewerConstants.ts
 var W = Object.freeze({
 	SIMPLE: "simple",

--- a/dist/chunks/LiveStreamTracker-KOzN5Ww4.js
+++ b/dist/chunks/LiveStreamTracker-KOzN5Ww4.js
@@ -1,5 +1,5 @@
-import { J as e, r as t } from "./events-BR4juJWK.js";
-import { t as n } from "./floatingViewerManager-KlR-wLQO.js";
+import { J as e, r as t } from "./events-DSLVC_8W.js";
+import { t as n } from "./floatingViewerManager-BtnD0d6Z.js";
 //#region ui/features/viewer/LiveStreamTracker.ts
 var r = !1, i = null, a = null, o = null, s = null, c = null, l = 0, u = 0, d = 400, f = new Set([
 	".png",

--- a/dist/chunks/SidebarWorkflowSection-BwS0BsAZ.js
+++ b/dist/chunks/SidebarWorkflowSection-BwS0BsAZ.js
@@ -1,10 +1,10 @@
-import { $ as e, At as t, Ct as n, Dt as r, Et as i, G as a, Gt as o, Ht as s, I as c, It as l, J as u, Jt as d, Lt as f, Mt as p, N as m, O as h, Ot as g, Pt as _, Q as v, R as y, Rt as b, S as x, St as S, T as C, Tt as ee, Vt as te, X as w, Xt as T, Y as ne, Yt as E, Z as re, bt as D, ct as ie, et as ae, in as oe, it as se, jt as ce, k as le, kt as ue, lt as de, mt as fe, nt as pe, ot as me, p as he, qt as ge, rn as _e, rt as ve, st as ye, tt as be, w as xe, wt as Se, xt as Ce, zt as we } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { Ct as Te, K as Ee, N as De, T as Oe, c as ke, d as Ae, f as je, h as Me, j as Ne, l as Pe, m as O, o as k, p as Fe, pt as Ie, s as A, tt as Le, u as Re, x as ze, y as Be } from "./events-BR4juJWK.js";
-import { F as Ve, K as He, P as Ue, Y as We, f as Ge, m as Ke, p as qe } from "./Viewer-CZ9I2Zag.js";
-import { t as Je } from "./floatingViewerManager-KlR-wLQO.js";
+import { $ as e, At as t, Ct as n, Dt as r, Et as i, G as a, Gt as o, Ht as s, I as c, It as l, J as u, Jt as d, Lt as f, Mt as p, N as m, O as h, Ot as g, Pt as _, Q as v, R as y, Rt as b, S as x, St as S, T as C, Tt as ee, Vt as te, X as w, Xt as T, Y as ne, Yt as E, Z as re, bt as D, ct as ie, et as ae, in as oe, it as se, jt as ce, k as le, kt as ue, lt as de, mt as fe, nt as pe, ot as me, p as he, qt as ge, rn as _e, rt as ve, st as ye, tt as be, w as xe, wt as Se, xt as Ce, zt as we } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { Ct as Te, K as Ee, N as De, T as Oe, c as ke, d as Ae, f as je, h as Me, j as Ne, l as Pe, m as O, o as k, p as Fe, pt as Ie, s as A, tt as Le, u as Re, x as ze, y as Be } from "./events-DSLVC_8W.js";
+import { F as Ve, K as He, P as Ue, Y as We, f as Ge, m as Ke, p as qe } from "./Viewer-C1jSvHym.js";
+import { t as Je } from "./floatingViewerManager-BtnD0d6Z.js";
 import { A as Ye, B as j, C as M, D as Xe, E as N, G as Ze, H as P, J as Qe, L as $e, O as F, R as et, S as tt, T as I, W as nt, _ as rt, a as it, b as at, c as ot, ct as L, d as st, dt as R, f as ct, g as lt, h as ut, i as dt, j as ft, k as z, l as pt, lt as mt, m as ht, n as gt, nt as B, o as _t, p as vt, q as yt, r as bt, s as xt, t as St, tt as Ct, u as wt, ut as V, y as Tt } from "./mjr-primevue-n1rsQYJg.js";
 import { t as Et } from "./mjr-vue-vendor-D2GeV7Qd.js";
-import { t as Dt } from "./viewerOpenRequest-DgSvgf1L.js";
+import { t as Dt } from "./viewerOpenRequest-BCoer6gp.js";
 import { a as Ot, i as kt, n as At, o as jt, r as Mt, t as Nt } from "./geninfoParser-D91g5NYg.js";
 //#region ui/app/settings/settingsUtils.ts
 var H = (e, t) => {
@@ -198,7 +198,9 @@ var H = (e, t) => {
 	security: {
 		safeMode: !1,
 		allowWrite: !0,
-		allowRemoteWrite: !0,
+		requireAuth: !1,
+		allowRemoteWrite: !1,
+		allowInsecureTokenTransport: !1,
 		allowDelete: !0,
 		allowRename: !0,
 		allowOpenInFolder: !0,
@@ -5091,7 +5093,7 @@ var So = ["title"], Co = ["src"], wo = {
 	setup(e) {
 		let t = e, n = B(0), r = B(!1), i = null;
 		function a() {
-			return i ||= import("./floatingViewerManager-KlR-wLQO.js").then((e) => e.n), i;
+			return i ||= import("./floatingViewerManager-BtnD0d6Z.js").then((e) => e.n), i;
 		}
 		function o() {
 			return (Array.isArray(t.inputFile?.previewCandidates) ? t.inputFile.previewCandidates : [])[n.value] || "";

--- a/dist/chunks/TagsEditor-DTRo7QA7.js
+++ b/dist/chunks/TagsEditor-DTRo7QA7.js
@@ -1,6 +1,6 @@
-import { F as e, Yt as t, v as n } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { St as r, m as i, n as a } from "./events-BR4juJWK.js";
-import { Y as o } from "./Viewer-CZ9I2Zag.js";
+import { F as e, Yt as t, v as n } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { St as r, m as i, n as a } from "./events-DSLVC_8W.js";
+import { Y as o } from "./Viewer-C1jSvHym.js";
 import { A as s, B as c, C as l, E as u, G as d, H as f, I as ee, J as te, L as p, R as ne, T as m, W as h, b as g, ct as _, dt as v, j as y, k as b, lt as x, nt as S, q as C } from "./mjr-primevue-n1rsQYJg.js";
 //#region ui/vue/components/common/TagsEditor.vue
 var w = ["aria-busy"], T = ["aria-label"], re = {

--- a/dist/chunks/Viewer-C1jSvHym.js
+++ b/dist/chunks/Viewer-C1jSvHym.js
@@ -1,9 +1,9 @@
-import { P as e, V as t, Yt as n, _ as r, c as i, d as a, g as o, gt as s, mt as c, n as l, o as u, r as d, s as f, x as p, y as m } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { Ct as h, D as g, a as _, ct as v, h as y, i as b, j as x, k as S, m as C, n as w, o as T, pt as E, r as D, rt as O, t as k } from "./events-BR4juJWK.js";
+import { P as e, V as t, Yt as n, _ as r, c as i, d as a, g as o, gt as s, mt as c, n as l, o as u, r as d, s as f, x as p, y as m } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { Ct as h, D as g, a as _, ct as v, h as y, i as b, j as x, k as S, m as C, n as w, o as T, pt as E, r as D, rt as O, t as k } from "./events-DSLVC_8W.js";
 import { T as A, nt as j, tt as M } from "./mjr-primevue-n1rsQYJg.js";
 import { n as N, r as ee } from "./mjr-vue-vendor-D2GeV7Qd.js";
 import { n as P, r as te, t as F } from "./state-DPiaUMw1.js";
-import { a as ne, c as re, i as ie, o as ae, r as oe, s as se } from "./model3dRenderer-Dz6vgESs.js";
+import { a as ne, c as re, i as ie, o as ae, r as oe, s as se } from "./model3dRenderer-C7vE1AWS.js";
 //#region ui/utils/events.ts
 function ce(e, t, { target: n = null, warnPrefix: r = "[Majoor]" } = {}) {
 	let i = n || (typeof window < "u" ? window : null);
@@ -9737,13 +9737,13 @@ var Wr = null, Gr = null, Kr = null, qr = null, Jr = null, Yr = null;
 function Xr() {
 	Wr || import("./abCompare-BXOoRlmV.js").then((e) => {
 		Wr = e;
-	}), Gr || import("./sideBySide-ClC9JgwZ.js").then((e) => {
+	}), Gr || import("./sideBySide-Cpno2qKL.js").then((e) => {
 		Gr = e;
-	}), Kr || import("./model3dRenderer-Dz6vgESs.js").then((e) => e.t).then((e) => {
+	}), Kr || import("./model3dRenderer-C7vE1AWS.js").then((e) => e.t).then((e) => {
 		Kr = e;
 	}), qr || import("./scopes-X1iFrTle.js").then((e) => {
 		qr = e;
-	}), Jr || import("./genInfo-Dt2N-RoA.js").then((e) => e.n).then((e) => {
+	}), Jr || import("./genInfo-BcSUiLW5.js").then((e) => e.n).then((e) => {
 		Jr = e;
 	}), Yr || import("./frameExport-tksSZ7sb.js").then((e) => {
 		Yr = e;

--- a/dist/chunks/ViewerPortal-DqUjGixW.js
+++ b/dist/chunks/ViewerPortal-DqUjGixW.js
@@ -1,9 +1,9 @@
-import { a as e, i as t } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { r as n } from "./events-BR4juJWK.js";
-import { a as r, c as i, i as a, l as o, o as s, s as c, t as l, u } from "./Viewer-CZ9I2Zag.js";
-import { i as d, r as f } from "./floatingViewerManager-KlR-wLQO.js";
+import { a as e, i as t } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { r as n } from "./events-DSLVC_8W.js";
+import { a as r, c as i, i as a, l as o, o as s, s as c, t as l, u } from "./Viewer-C1jSvHym.js";
+import { i as d, r as f } from "./floatingViewerManager-BtnD0d6Z.js";
 import { B as p, C as m, D as h, E as g, G as _, H as v, I as y, O as b, R as x, T as S, W as C, ct as w, dt as T, j as E, k as D, lt as O, nt as k, q as A, ut as j, w as M, z as N } from "./mjr-primevue-n1rsQYJg.js";
-import { t as P } from "./TagsEditor-D2XWKmOs.js";
+import { t as P } from "./TagsEditor-DTRo7QA7.js";
 //#region ui/vue/components/viewer/FloatingViewerHost.vue
 var F = {
 	__name: "FloatingViewerHost",

--- a/dist/chunks/events-DSLVC_8W.js
+++ b/dist/chunks/events-DSLVC_8W.js
@@ -273,7 +273,9 @@ function ae(e = {}) {
 	});
 }
 function oe(e) {
-	let t = e?.mtime, n = (e) => !e || !t ? e : `${e}${e.includes("?") ? "&" : "?"}v=${encodeURIComponent(t)}`, r = d(String(e?.filepath || e?.path || e?.fullpath || e?.full_path || e?.file_info?.filepath || e?.file_info?.path || "").trim()), i = String(e?.filename || e?.name || e?.file_info?.filename || "").trim(), a = String(e?.subfolder || e?.file_info?.subfolder || "").trim(), o = ((e) => {
+	let t = e?.mtime, n = (e) => !e || !t ? e : `${e}${e.includes("?") ? "&" : "?"}v=${encodeURIComponent(t)}`, r = d(String(e?.filepath || e?.path || e?.fullpath || e?.full_path || e?.file_info?.filepath || e?.file_info?.path || "").trim()), i = String(e?.type || e?.file_info?.type || "").toLowerCase().trim(), a = Number(e?.id ?? e?.asset_id);
+	if (!(i === "temp" || r.toLowerCase().includes("/temp/")) && Number.isSafeInteger(a) && a > 0) return n(`/mjr/am/viewer/asset/${encodeURIComponent(String(a))}`);
+	let o = String(e?.filename || e?.name || e?.file_info?.filename || "").trim(), s = String(e?.subfolder || e?.file_info?.subfolder || "").trim(), c = ((e) => {
 		let t = {
 			type: "",
 			subfolder: "",
@@ -287,23 +289,23 @@ function oe(e) {
 		} else t.filename = f(n).filename;
 		return t;
 	})(r);
-	if (!a && i.includes("/")) {
-		let e = i.lastIndexOf("/");
-		e > 0 && (a = i.slice(0, e), i = i.slice(e + 1));
+	if (!s && o.includes("/")) {
+		let e = o.lastIndexOf("/");
+		e > 0 && (s = o.slice(0, e), o = o.slice(e + 1));
 	}
-	if (!i && o.filename && (i = o.filename), !a && o.subfolder && (a = o.subfolder), !i) return "";
-	let s = String(e?.type || e?.file_info?.type || "").toLowerCase().trim();
-	s !== "input" && s !== "output" && s !== "temp" && s !== "custom" && (s = ""), !s && o.type && (s = o.type), !s && r && (r.includes("/input/") ? s = "input" : r.includes("/output/") ? s = "output" : r.includes("/temp/") && (s = "temp")), s ||= "output";
-	let c = r.includes("/output/") || r.includes("/input/") || r.includes("/temp/"), l = p(a) || a.startsWith("/");
-	if (r && s !== "custom" && (l || !c)) return n(se(r, { inline: !0 }));
-	if (s === "custom") {
+	if (!o && c.filename && (o = c.filename), !s && c.subfolder && (s = c.subfolder), !o) return "";
+	let l = String(e?.type || e?.file_info?.type || "").toLowerCase().trim();
+	l !== "input" && l !== "output" && l !== "temp" && l !== "custom" && (l = ""), !l && c.type && (l = c.type), !l && r && (r.includes("/input/") ? l = "input" : r.includes("/output/") ? l = "output" : r.includes("/temp/") && (l = "temp")), l ||= "output";
+	let m = r.includes("/output/") || r.includes("/input/") || r.includes("/temp/"), h = p(s) || s.startsWith("/");
+	if (r && l !== "custom" && (h || !m)) return n(se(r, { inline: !0 }));
+	if (l === "custom") {
 		let t = String(u(e) || "").trim();
-		if (t) return n(x(i, a, t));
+		if (t) return n(x(o, s, t));
 		if (r) return n(`${g.CUSTOM_VIEW}?filepath=${encodeURIComponent(r)}&browser_mode=1`);
-		let s = o.type || "output";
-		return n(v(i, a, s));
+		let i = c.type || "output";
+		return n(v(o, s, i));
 	}
-	return r.includes("/output/") && (s = "output"), r.includes("/input/") && (s = "input"), r.includes("/temp/") && (s = "temp"), n(v(i, a, s));
+	return r.includes("/output/") && (l = "output"), r.includes("/input/") && (l = "input"), r.includes("/temp/") && (l = "temp"), n(v(o, s, l));
 }
 function se(e, t = {}) {
 	if (!e) return "";

--- a/dist/chunks/floatingViewerManager-BtnD0d6Z.js
+++ b/dist/chunks/floatingViewerManager-BtnD0d6Z.js
@@ -1,6 +1,6 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { _ as t, d as n, o as r, s as i, t as a } from "./viewerRuntimeHosts-CZwQiIFv.js";
-import { o, r as s, z as c } from "./events-BR4juJWK.js";
+import { _ as t, d as n, o as r, s as i, t as a } from "./viewerRuntimeHosts-BeyPtIl9.js";
+import { o, r as s, z as c } from "./events-DSLVC_8W.js";
 //#region ui/features/panel/panelRuntimeRefs.ts
 var l = null;
 function u(e) {
@@ -98,7 +98,7 @@ var ie = /* @__PURE__ */ e({
 	teardownFloatingViewerManager: () => $
 }), h = null, g = null;
 async function ae() {
-	return h || (g ||= import("./FloatingViewer-C0Z8QsbS.js").then((e) => (h = e.FloatingViewer, h)), g);
+	return h || (g ||= import("./FloatingViewer-DI28fYkn.js").then((e) => (h = e.FloatingViewer, h)), g);
 }
 var _ = null, oe = null;
 async function se() {

--- a/dist/chunks/genInfo-BcSUiLW5.js
+++ b/dist/chunks/genInfo-BcSUiLW5.js
@@ -1,7 +1,7 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { m as t, o as n } from "./events-BR4juJWK.js";
-import { h as r } from "./Viewer-CZ9I2Zag.js";
-import { i, n as a, r as o, t as s, u as c } from "./SidebarWorkflowSection-DaUIh32R.js";
+import { m as t, o as n } from "./events-DSLVC_8W.js";
+import { h as r } from "./Viewer-C1jSvHym.js";
+import { i, n as a, r as o, t as s, u as c } from "./SidebarWorkflowSection-BwS0BsAZ.js";
 import { B as l, D as u, E as d, O as f, T as p, ct as m, dt as h, k as g, ut as _ } from "./mjr-primevue-n1rsQYJg.js";
 //#region ui/vue/components/viewer/ViewerMetadataBlock.vue
 var v = { style: {

--- a/dist/chunks/model3dRenderer-C7vE1AWS.js
+++ b/dist/chunks/model3dRenderer-C7vE1AWS.js
@@ -1,5 +1,5 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { m as t, mt as n, o as r, r as i } from "./events-BR4juJWK.js";
+import { m as t, mt as n, o as r, r as i } from "./events-DSLVC_8W.js";
 import { n as a } from "./state-DPiaUMw1.js";
 //#region ui/features/viewer/model3dCore.ts
 function o(e, t) {

--- a/dist/chunks/openMajoorSettings-BaEfvO9h.js
+++ b/dist/chunks/openMajoorSettings-BaEfvO9h.js
@@ -1,6 +1,6 @@
-import { A as e, E as t, J as n, R as r, S as i, Y as a, b as o, j as s, m as c } from "./events-BR4juJWK.js";
+import { A as e, E as t, J as n, R as r, S as i, Y as a, b as o, j as s, m as c } from "./events-DSLVC_8W.js";
 import { a as l, n as u } from "./graphTraversal-Sruu0ipL.js";
-import { J as d, b as f, v as p, x as ee, y as te } from "./SidebarWorkflowSection-DaUIh32R.js";
+import { J as d, b as f, v as p, x as ee, y as te } from "./SidebarWorkflowSection-BwS0BsAZ.js";
 //#region ui/features/viewer/floatingViewerProgress.ts
 var m = "progress-update", h = "__MJR_MFV_PROGRESS_SERVICE__";
 function ne() {

--- a/dist/chunks/sideBySide-Cpno2qKL.js
+++ b/dist/chunks/sideBySide-Cpno2qKL.js
@@ -1,4 +1,4 @@
-import { i as e } from "./model3dRenderer-Dz6vgESs.js";
+import { i as e } from "./model3dRenderer-C7vE1AWS.js";
 import { i as t, o as n } from "./geninfoParser-D91g5NYg.js";
 //#region ui/features/viewer/sideBySide.ts
 function r(e) {

--- a/dist/chunks/viewerOpenRequest-BCoer6gp.js
+++ b/dist/chunks/viewerOpenRequest-BCoer6gp.js
@@ -1,6 +1,6 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { r as t } from "./events-BR4juJWK.js";
-import { t as n } from "./Viewer-CZ9I2Zag.js";
+import { r as t } from "./events-DSLVC_8W.js";
+import { t as n } from "./Viewer-C1jSvHym.js";
 //#region ui/features/viewer/viewerOpenRequest.ts
 var r = /* @__PURE__ */ e({ requestViewerOpen: () => o });
 function i(e) {

--- a/dist/chunks/viewerRuntimeHosts-BeyPtIl9.js
+++ b/dist/chunks/viewerRuntimeHosts-BeyPtIl9.js
@@ -1,4 +1,4 @@
-import { Ct as e, St as t, _t as n, gt as r, ht as i, k as a, m as o, nt as s, o as c, tt as l, vt as u, xt as d } from "./events-BR4juJWK.js";
+import { Ct as e, St as t, _t as n, gt as r, ht as i, k as a, m as o, nt as s, o as c, tt as l, vt as u, xt as d } from "./events-DSLVC_8W.js";
 //#region ui/app/settingsStore.ts
 var f = "mjrSettings", p = "mjrMinimapSettings", m = new Set([
 	"POST",

--- a/dist/entry.js
+++ b/dist/entry.js
@@ -1,13 +1,13 @@
-import { $t as e, A as t, B as n, Bt as r, C as i, Ct as a, D as o, Dt as s, E as c, Ft as l, Gt as u, H as d, It as f, K as p, Kt as m, L as h, Lt as g, M as _, N as v, Nt as y, O as b, P as x, Pt as S, Qt as C, S as w, U as T, Ut as E, V as D, W as O, Wt as k, Xt as A, Yt as j, Zt as M, _ as N, _t as P, at as ee, b as te, c as F, ct as I, d as ne, dt as re, en as ie, f as ae, ft as oe, g as se, gt as ce, h as le, ht as ue, j as de, k as fe, l as pe, m as me, mt as he, nn as ge, o as _e, pt as ve, q as ye, s as be, tn as xe, u as Se, ut as Ce, vt as we, w as Te, y as Ee, yt as De, z as Oe, zt as ke } from "./chunks/viewerRuntimeHosts-CZwQiIFv.js";
-import { $ as Ae, A as je, Ct as Me, F as Ne, G as Pe, H as Fe, K as Ie, L as Le, Q as Re, St as ze, U as Be, W as Ve, X as He, Z as Ue, _ as We, at as Ge, bt as Ke, ct as qe, dt as Je, et as Ye, ft as Xe, g as Ze, h as Qe, it as $e, j as et, lt as tt, m as L, n as R, o as z, ot as nt, pt as rt, q as it, r as B, rt as at, st as ot, t as st, tt as V, ut as ct, xt as lt, yt as ut } from "./chunks/events-BR4juJWK.js";
+import { $t as e, A as t, B as n, Bt as r, C as i, Ct as a, D as o, Dt as s, E as c, Ft as l, Gt as u, H as d, It as f, K as p, Kt as m, L as h, Lt as g, M as _, N as v, Nt as y, O as b, P as x, Pt as S, Qt as C, S as w, U as T, Ut as E, V as D, W as O, Wt as k, Xt as A, Yt as j, Zt as M, _ as N, _t as P, at as ee, b as te, c as F, ct as I, d as ne, dt as re, en as ie, f as ae, ft as oe, g as se, gt as ce, h as le, ht as ue, j as de, k as fe, l as pe, m as me, mt as he, nn as ge, o as _e, pt as ve, q as ye, s as be, tn as xe, u as Se, ut as Ce, vt as we, w as Te, y as Ee, yt as De, z as Oe, zt as ke } from "./chunks/viewerRuntimeHosts-BeyPtIl9.js";
+import { $ as Ae, A as je, Ct as Me, F as Ne, G as Pe, H as Fe, K as Ie, L as Le, Q as Re, St as ze, U as Be, W as Ve, X as He, Z as Ue, _ as We, at as Ge, bt as Ke, ct as qe, dt as Je, et as Ye, ft as Xe, g as Ze, h as Qe, it as $e, j as et, lt as tt, m as L, n as R, o as z, ot as nt, pt as rt, q as it, r as B, rt as at, st as ot, t as st, tt as V, ut as ct, xt as lt, yt as ut } from "./chunks/events-DSLVC_8W.js";
 import { a as dt, i as ft, n as pt, t as mt } from "./chunks/graphTraversal-Sruu0ipL.js";
-import { A as ht, B as gt, C as _t, D as vt, E as yt, F as bt, G as xt, H as St, I as Ct, J as wt, L as Tt, M as Et, N as Dt, O as Ot, P as kt, R as At, S as jt, T as Mt, U as Nt, V as Pt, W as Ft, Y as It, _ as Lt, b as Rt, d as zt, g as Bt, j as Vt, k as Ht, q as Ut, v as Wt, x as Gt, y as Kt, z as qt } from "./chunks/Viewer-CZ9I2Zag.js";
-import { $ as Jt, A as Yt, B as Xt, C as Zt, D as Qt, E as $t, F as en, G as tn, H as nn, I as rn, J as an, K as on, L as sn, M as cn, N as ln, O as un, P as dn, Q as fn, R as pn, S as mn, T as hn, U as gn, V as _n, W as vn, X as yn, Y as bn, Z as xn, a as Sn, c as Cn, d as wn, f as Tn, g as En, h as Dn, i as On, j as kn, k as An, l as jn, m as Mn, n as Nn, o as Pn, p as Fn, q as In, s as Ln, t as Rn, u as zn, w as Bn, z as Vn } from "./chunks/SidebarWorkflowSection-DaUIh32R.js";
-import { _ as Hn, i as Un, n as Wn, p as Gn, t as Kn } from "./chunks/openMajoorSettings-cHyywzYd.js";
-import { a as qn, c as Jn, l as Yn, o as Xn, s as Zn, u as Qn } from "./chunks/floatingViewerManager-KlR-wLQO.js";
+import { A as ht, B as gt, C as _t, D as vt, E as yt, F as bt, G as xt, H as St, I as Ct, J as wt, L as Tt, M as Et, N as Dt, O as Ot, P as kt, R as At, S as jt, T as Mt, U as Nt, V as Pt, W as Ft, Y as It, _ as Lt, b as Rt, d as zt, g as Bt, j as Vt, k as Ht, q as Ut, v as Wt, x as Gt, y as Kt, z as qt } from "./chunks/Viewer-C1jSvHym.js";
+import { $ as Jt, A as Yt, B as Xt, C as Zt, D as Qt, E as $t, F as en, G as tn, H as nn, I as rn, J as an, K as on, L as sn, M as cn, N as ln, O as un, P as dn, Q as fn, R as pn, S as mn, T as hn, U as gn, V as _n, W as vn, X as yn, Y as bn, Z as xn, a as Sn, c as Cn, d as wn, f as Tn, g as En, h as Dn, i as On, j as kn, k as An, l as jn, m as Mn, n as Nn, o as Pn, p as Fn, q as In, s as Ln, t as Rn, u as zn, w as Bn, z as Vn } from "./chunks/SidebarWorkflowSection-BwS0BsAZ.js";
+import { _ as Hn, i as Un, n as Wn, p as Gn, t as Kn } from "./chunks/openMajoorSettings-BaEfvO9h.js";
+import { a as qn, c as Jn, l as Yn, o as Xn, s as Zn, u as Qn } from "./chunks/floatingViewerManager-BtnD0d6Z.js";
 import { A as $n, B as H, C as U, D as er, E as W, F as tr, G as nr, H as rr, I as ir, J as ar, K as or, L as sr, M as cr, N as lr, O as G, R as ur, S as dr, T as K, U as fr, V as pr, W as mr, b as hr, ct as q, dt as J, et as gr, it as _r, j as Y, k as X, lt as vr, nt as Z, q as Q, rt as yr, st as br, tt as xr, ut as Sr, v as Cr, w as wr, x as Tr, y as Er, z as Dr } from "./chunks/mjr-primevue-n1rsQYJg.js";
 import { n as Or, r as kr } from "./chunks/mjr-vue-vendor-D2GeV7Qd.js";
-import { t as Ar } from "./chunks/TagsEditor-D2XWKmOs.js";
+import { t as Ar } from "./chunks/TagsEditor-DTRo7QA7.js";
 import { app as jr } from "../../scripts/app.js";
 function Mr(e = null) {
 	return null;
@@ -1026,7 +1026,7 @@ var Li = {
 	}
 }, Ri = null;
 function zi() {
-	return Ri ||= import("./chunks/viewerOpenRequest-DgSvgf1L.js").then((e) => e.n), Ri;
+	return Ri ||= import("./chunks/viewerOpenRequest-BCoer6gp.js").then((e) => e.n), Ri;
 }
 function Bi(e) {
 	if (!e) return "";
@@ -1543,10 +1543,10 @@ function Ji() {
 //#region ui/features/contextmenu/GridContextMenu.ts
 var Yi = 1, Xi = null, Zi = null;
 function Qi() {
-	return Xi ||= import("./chunks/viewerOpenRequest-DgSvgf1L.js").then((e) => e.n), Xi;
+	return Xi ||= import("./chunks/viewerOpenRequest-BCoer6gp.js").then((e) => e.n), Xi;
 }
 function $i() {
-	return Zi ||= import("./chunks/floatingViewerManager-KlR-wLQO.js").then((e) => e.n), Zi;
+	return Zi ||= import("./chunks/floatingViewerManager-BtnD0d6Z.js").then((e) => e.n), Zi;
 }
 function ea(e) {
 	let t = String(e || "").trim().toLowerCase();
@@ -7542,10 +7542,10 @@ var Lu = {
 		Z(!0);
 		let a = Z(0), s = Z(0), c = /* @__PURE__ */ new WeakMap(), l = 0, u = 0, d = 0, f = 0, p = 0, m = /* @__PURE__ */ new Map(), h = null, g = null;
 		function _() {
-			return h ||= import("./chunks/viewerOpenRequest-DgSvgf1L.js").then((e) => e.n), h;
+			return h ||= import("./chunks/viewerOpenRequest-BCoer6gp.js").then((e) => e.n), h;
 		}
 		function v() {
-			return g ||= import("./chunks/floatingViewerManager-KlR-wLQO.js").then((e) => e.n), g;
+			return g ||= import("./chunks/floatingViewerManager-BtnD0d6Z.js").then((e) => e.n), g;
 		}
 		function y(e) {
 			return (Array.isArray(e) ? e : []).slice().sort((e, t) => {
@@ -8834,10 +8834,10 @@ var Lu = {
 	}
 }, Qu = 240, $u = 120, ed = 80, td = null, nd = null;
 function rd() {
-	return td ||= import("./chunks/viewerOpenRequest-DgSvgf1L.js").then((e) => e.n), td;
+	return td ||= import("./chunks/viewerOpenRequest-BCoer6gp.js").then((e) => e.n), td;
 }
 function id() {
-	return nd ||= import("./chunks/floatingViewerManager-KlR-wLQO.js").then((e) => e.n), nd;
+	return nd ||= import("./chunks/floatingViewerManager-BtnD0d6Z.js").then((e) => e.n), nd;
 }
 function ad(e) {
 	let t = document.createElement("button");
@@ -11081,7 +11081,7 @@ function Pp() {
 var Fp = {
 	__name: "GlobalRuntime",
 	setup(e) {
-		let t = cr(() => import("./chunks/ViewerPortal-delKWZrs.js")), n = Z(!1), r = [
+		let t = cr(() => import("./chunks/ViewerPortal-DqUjGixW.js")), n = Z(!1), r = [
 			B.OPEN_VIEWER,
 			B.MFV_OPEN,
 			B.MFV_TOGGLE,
@@ -24475,7 +24475,7 @@ function NC({ cleanupEntryRuntimeFn: e = jC, teardownLiveStreamTracker: t, teard
 //#region ui/entry.ts
 var PC = null, FC = null, IC = null;
 function LC() {
-	return IC ||= import("./chunks/floatingViewerManager-KlR-wLQO.js").then((e) => e.n), IC;
+	return IC ||= import("./chunks/floatingViewerManager-BtnD0d6Z.js").then((e) => e.n), IC;
 }
 function RC() {
 	IC && IC.then((e) => e?.teardownFloatingViewerManager?.()).catch((e) => console.debug?.("[Majoor] MFV teardown skipped", e));
@@ -24595,7 +24595,7 @@ function rw(e = 1200) {
 	}, Math.max(250, Number(e) || 0));
 }
 function iw(e) {
-	import("./chunks/LiveStreamTracker-_6yDCkkW.js").then((t) => {
+	import("./chunks/LiveStreamTracker-KOzN5Ww4.js").then((t) => {
 		PC = t;
 		try {
 			t.initLiveStreamTracker(e);

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -239,7 +239,44 @@ pause
 ```
 
 ### Remote Access Write Permissions
-If you open ComfyUI from another machine, Majoor blocks write operations by default unless you explicitly allow them.
+If you open ComfyUI from another machine, Majoor may block write operations until you explicitly authorize them. The message does **not** necessarily mean that Windows, Linux, macOS, or your NAS denied filesystem access. Majoor has its own application-level write guard in addition to operating-system permissions.
+
+The guard covers operations that modify Majoor data or files, including ratings and tags, rename, delete, index reset, and other write actions. Accessing ComfyUI through `http://<LAN-IP>:8188` counts as remote access even when the browser and server are on the same private network.
+
+Choose one of the following configurations:
+
+1. **Authenticated LAN or remote access (recommended):** use `Recommended Remote LAN Setup`. Majoor generates or reuses an API token, requires it for writes, and keeps anonymous remote writes disabled.
+2. **Trusted private LAN without a token:** enable `Allow Remote Full Access` in addition to the required operation permissions. Use this only when every device and user on the network is trusted. Never use it for an internet-facing ComfyUI instance, public Wi-Fi, an untrusted shared network, or an unprotected tunnel.
+
+#### Operation permissions shown in Settings
+
+Open **Settings → Majoor Assets Manager → Security** and use these values:
+
+| Setting | Value |
+|---|---:|
+| Allow HTTP Token Transport | Off |
+| Allow Remote Full Access | Off |
+| Require Token For All Writes | Off |
+| API Token | Auto-generated or configured as needed |
+| Recommended Remote LAN Setup | Off |
+| Allow Index Reset | On |
+| Allow Open in Folder | On |
+| Allow Rename | On |
+| Allow Delete | On |
+| Allow Write | On |
+| Safe Mode | Off |
+| Confirm before deleting | On |
+
+![Majoor operation permission settings](images/security-settings-trusted-lan.svg)
+
+These values control which operations Majoor may perform. They are not, by themselves, remote-client authorization. A browser opened through a LAN IP must additionally use one of these paths:
+
+- **Recommended:** enable `Recommended Remote LAN Setup`; keep `Allow Remote Full Access` off. The preset configures a token and authorizes the current browser. On trusted plain-HTTP LAN access, it may also enable `Allow HTTP Token Transport`.
+- **No-token trusted LAN:** enable `Allow Remote Full Access`. This permits remote writes without token authentication and is therefore substantially less secure.
+
+`Require Token For All Writes` controls whether even otherwise-local writes require a token; disabling it does not override the separate non-local-client guard. Refresh the page after applying the settings. Restart ComfyUI if environment variables are configured because environment settings can override UI values.
+
+#### Authenticated setup (recommended)
 
 Recommended setup: define `MAJOOR_API_TOKEN` on the machine that runs ComfyUI, then send the same token from the remote client.
 

--- a/docs/SETTINGS_CONFIGURATION.md
+++ b/docs/SETTINGS_CONFIGURATION.md
@@ -41,6 +41,14 @@ Majoor now exposes the main remote write controls directly in Settings, includin
 
 For the common trusted-LAN case, `Recommended Remote LAN Setup` is the intended one-click path. It generates a server-side token if needed, applies the recommended flags, and authorizes the current browser session immediately.
 
+The following image shows the individual operation permissions. It does not authorize an anonymous remote browser by itself. For LAN access, either enable `Recommended Remote LAN Setup` and use its token, or explicitly enable `Allow Remote Full Access` for a no-token trusted-LAN configuration. Keeping `Confirm before deleting` enabled is strongly recommended.
+
+![Majoor operation permission settings](images/security-settings-trusted-lan.svg)
+
+`Require Token For All Writes` and `Allow Remote Full Access` solve different problems. Disabling the first does not automatically allow non-local clients; the second is the explicit anonymous-remote-access bypass and must never be enabled on an internet-facing or untrusted network.
+
+Majoor security permissions are independent of filesystem permissions. Full Windows or NAS access does not automatically authorize Majoor writes, and a Majoor authorization error does not by itself prove that the operating system rejected the file operation.
+
 ### Token Types And What They Mean
 
 There are two unrelated token concepts in the UI:

--- a/docs/images/security-settings-trusted-lan.svg
+++ b/docs/images/security-settings-trusted-lan.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="720" viewBox="0 0 980 720" role="img" aria-labelledby="title desc">
+  <title id="title">Majoor operation permission settings</title>
+  <desc id="desc">Majoor write, delete, rename, open-folder, and index-reset permissions. Remote clients still require a token or explicit remote full access.</desc>
+  <rect width="980" height="720" rx="18" fill="#171717"/>
+  <rect x="0" width="235" height="720" rx="18" fill="#292929"/>
+  <text x="34" y="50" fill="#f4f4f5" font-family="Arial, sans-serif" font-size="22" font-weight="700">⚙ Settings</text>
+  <text x="34" y="130" fill="#a1a1aa" font-family="Arial, sans-serif" font-size="13" font-weight="700">APPLICATION SETTINGS</text>
+  <rect x="12" y="575" width="211" height="48" rx="6" fill="#45454b"/>
+  <text x="34" y="606" fill="#fff" font-family="Arial, sans-serif" font-size="16" font-weight="700">Majoor Assets Manager</text>
+  <text x="260" y="63" fill="#fff" font-family="Arial, sans-serif" font-size="20" font-weight="700">Security</text>
+  <text x="260" y="94" fill="#f59e0b" font-family="Arial, sans-serif" font-size="13">Operation permissions — remote clients still need a token or explicit Remote Full Access</text>
+  <g font-family="Arial, sans-serif" font-size="16" fill="#a1a1aa">
+    <text x="260" y="139">Allow HTTP Token Transport</text>
+    <text x="260" y="184">Allow Remote Full Access</text>
+    <text x="260" y="229">Require Token For All Writes</text>
+    <text x="260" y="274">API Token</text>
+    <text x="260" y="319">Recommended Remote LAN Setup</text>
+    <text x="260" y="364">Allow Index Reset</text>
+    <text x="260" y="409">Allow Open in Folder</text>
+    <text x="260" y="454">Allow Rename</text>
+    <text x="260" y="499">Allow Delete</text>
+    <text x="260" y="544">Allow Write</text>
+    <text x="260" y="589">Safe Mode</text>
+    <text x="260" y="634">Confirm before deleting</text>
+  </g>
+  <g font-family="Arial, sans-serif" font-size="13" text-anchor="middle">
+    <g fill="#3f3f46">
+      <rect x="820" y="120" width="42" height="24" rx="12"/><circle cx="832" cy="132" r="8" fill="#a1a1aa"/>
+      <rect x="820" y="165" width="42" height="24" rx="12"/><circle cx="832" cy="177" r="8" fill="#a1a1aa"/>
+      <rect x="820" y="210" width="42" height="24" rx="12"/><circle cx="832" cy="222" r="8" fill="#a1a1aa"/>
+      <rect x="820" y="300" width="42" height="24" rx="12"/><circle cx="832" cy="312" r="8" fill="#a1a1aa"/>
+      <rect x="820" y="570" width="42" height="24" rx="12"/><circle cx="832" cy="582" r="8" fill="#a1a1aa"/>
+    </g>
+    <g fill="#60a5fa">
+      <rect x="820" y="345" width="42" height="24" rx="12"/><circle cx="850" cy="357" r="8" fill="#111827"/>
+      <rect x="820" y="390" width="42" height="24" rx="12"/><circle cx="850" cy="402" r="8" fill="#111827"/>
+      <rect x="820" y="435" width="42" height="24" rx="12"/><circle cx="850" cy="447" r="8" fill="#111827"/>
+      <rect x="820" y="480" width="42" height="24" rx="12"/><circle cx="850" cy="492" r="8" fill="#111827"/>
+      <rect x="820" y="525" width="42" height="24" rx="12"/><circle cx="850" cy="537" r="8" fill="#111827"/>
+      <rect x="820" y="615" width="42" height="24" rx="12"/><circle cx="850" cy="627" r="8" fill="#111827"/>
+    </g>
+    <rect x="695" y="250" width="167" height="34" rx="6" fill="#111" stroke="#71717a"/>
+    <text x="778" y="272" fill="#a1a1aa">Auto-generated or configured</text>
+    <g fill="#27272a"><rect x="880" y="120" width="62" height="24" rx="5"/><rect x="880" y="165" width="62" height="24" rx="5"/><rect x="880" y="210" width="62" height="24" rx="5"/><rect x="880" y="300" width="62" height="24" rx="5"/><rect x="880" y="345" width="62" height="24" rx="5"/><rect x="880" y="390" width="62" height="24" rx="5"/><rect x="880" y="435" width="62" height="24" rx="5"/><rect x="880" y="480" width="62" height="24" rx="5"/><rect x="880" y="525" width="62" height="24" rx="5"/><rect x="880" y="570" width="62" height="24" rx="5"/><rect x="880" y="615" width="62" height="24" rx="5"/></g>
+    <g fill="#a1a1aa"><text x="911" y="137">Reset</text><text x="911" y="182">Reset</text><text x="911" y="227">Reset</text><text x="911" y="317">Reset</text><text x="911" y="362">Reset</text><text x="911" y="407">Reset</text><text x="911" y="452">Reset</text><text x="911" y="497">Reset</text><text x="911" y="542">Reset</text><text x="911" y="587">Reset</text><text x="911" y="632">Reset</text></g>
+  </g>
+</svg>

--- a/mjr_am_backend/routes/handlers/viewer.py
+++ b/mjr_am_backend/routes/handlers/viewer.py
@@ -386,6 +386,32 @@ async def _resolve_viewer_file_context(
 def register_viewer_routes(routes: web.RouteTableDef) -> None:
     """Register viewer info and file-serving routes."""
 
+    @routes.get("/mjr/am/viewer/asset/{asset_id}")
+    async def viewer_asset(request: web.Request):
+        """Serve an indexed asset by its stable database id.
+
+        Resolving the canonical filepath on the server avoids rebuilding output,
+        input, custom-root, mapped-drive, or UNC paths in the browser.
+        """
+        raw_id = str(request.match_info.get("asset_id", "") or "").strip()
+        _asset, resolved, _root_limit, error = await _resolve_viewer_asset_context(raw_id)
+        if error:
+            return _json_response(error)
+        if resolved is None:
+            return _json_response(Result.Err("NOT_FOUND", "Asset file not found"))
+        if not _is_allowed_viewer_resource_file(resolved):
+            return _json_response(Result.Err("UNSUPPORTED", "Unsupported file type for viewer"))
+
+        content_type = _guess_content_type_for_file(resolved)
+        resp = web.FileResponse(path=str(resolved))
+        try:
+            resp.headers["Content-Type"] = content_type
+            resp.headers["Cache-Control"] = "private, max-age=3600, stale-while-revalidate=60"
+            resp.headers["X-Content-Type-Options"] = "nosniff"
+        except Exception:
+            pass
+        return resp
+
     @routes.get("/mjr/am/viewer/info")
     async def viewer_info(request: web.Request):
         """

--- a/tests/features/test_viewer_routes.py
+++ b/tests/features/test_viewer_routes.py
@@ -22,6 +22,27 @@ def _json(resp):
 
 
 @pytest.mark.asyncio
+async def test_viewer_asset_serves_canonical_indexed_path(monkeypatch, tmp_path: Path) -> None:
+    app = _app()
+    image = tmp_path / "problem.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+    async def _resolve(raw_id):
+        assert raw_id == "165"
+        return ({"id": 165, "filepath": str(image)}, image, tmp_path, None)
+
+    monkeypatch.setattr(m, "_resolve_viewer_asset_context", _resolve)
+
+    req = make_mocked_request(
+        "GET", "/mjr/am/viewer/asset/165", app=app, match_info={"asset_id": "165"}
+    )
+    resp = await (await app.router.resolve(req)).handler(req)
+    assert isinstance(resp, web.FileResponse)
+    assert resp.headers.get("Content-Type") == "image/png"
+    assert resp.headers.get("X-Content-Type-Options") == "nosniff"
+
+
+@pytest.mark.asyncio
 async def test_viewer_info_includes_model3d_contract(monkeypatch, tmp_path: Path) -> None:
     app = _app()
     model = tmp_path / "mesh.glb"

--- a/ui/api/endpoints.ts
+++ b/ui/api/endpoints.ts
@@ -526,6 +526,14 @@ export function buildAssetViewURL(asset: Record<string, any> | null | undefined)
                 "",
         ).trim(),
     );
+    const declaredType = String(asset?.type || asset?.file_info?.type || "")
+        .toLowerCase()
+        .trim();
+    const assetId = Number(asset?.id ?? asset?.asset_id);
+    const isTemporaryAsset = declaredType === "temp" || rawPath.toLowerCase().includes("/temp/");
+    if (!isTemporaryAsset && Number.isSafeInteger(assetId) && assetId > 0) {
+        return withMtime(`/mjr/am/viewer/asset/${encodeURIComponent(String(assetId))}`);
+    }
     let filename = String(
         asset?.filename || asset?.name || asset?.file_info?.filename || "",
     ).trim();

--- a/ui/app/settings/settingsCore.ts
+++ b/ui/app/settings/settingsCore.ts
@@ -191,7 +191,9 @@ export const DEFAULT_SETTINGS = {
     security: {
         safeMode: false,
         allowWrite: true,
-        allowRemoteWrite: true,
+        requireAuth: false,
+        allowRemoteWrite: false,
+        allowInsecureTokenTransport: false,
         allowDelete: true,
         allowRename: true,
         allowOpenInFolder: true,

--- a/ui/tests/endpoints_asset_view_url.vitest.ts
+++ b/ui/tests/endpoints_asset_view_url.vitest.ts
@@ -3,6 +3,18 @@ import { describe, expect, it } from "vitest";
 import { buildAssetViewURL } from "../api/endpoints.js";
 
 describe("buildAssetViewURL", () => {
+    it("uses the stable asset-id endpoint instead of reconstructing a Windows or NAS path", () => {
+        expect(
+            buildAssetViewURL({
+                id: 165,
+                filename: "problem.png",
+                filepath: "Z:/ComfyUI/output/Ideogram/problem.png",
+                type: "output",
+                mtime: 1234,
+            }),
+        ).toBe("/mjr/am/viewer/asset/165?v=1234");
+    });
+
     it("derives ComfyUI temp bucket URLs from absolute temp paths", () => {
         expect(
             buildAssetViewURL({


### PR DESCRIPTION
## Summary

- serve indexed viewer assets through a stable asset-id endpoint instead of reconstructing Windows, mapped-drive, UNC, or NAS paths in the browser
- align frontend security defaults with backend defaults
- clarify Majoor write authorization versus operating-system and NAS permissions
- add an illustrated security-settings reference to the README and documentation
- rebuild the generated frontend bundle

## Root cause

The viewer inferred ComfyUI buckets and subfolders from filepath strings. That heuristic could select the wrong route or root for Windows and network paths even when the indexed canonical filepath was valid. Remote write guidance also did not clearly distinguish operation permissions, token requirements, and the separate non-local-client guard.

## Impact

Indexed PNG and other supported assets now resolve by database id on the server, where the canonical path is checked against allowed roots before being served. Users also get an explicit decision guide for authenticated remote access versus the less-secure trusted-LAN bypass.

## Validation

- `python scripts/run_quality_gate.py --python-only --skip-tests`
- `npx tsc -p tsconfig.json --noEmit --pretty false`
- `npm run test:js` — 150 files, 806 tests passed
- targeted viewer backend tests — 6 passed, 1 Windows symlink test skipped
- `npm run lint:js`
- `npm run build`
- pre-commit and pre-push changed-file quality gates