### PR TITLE
feat: folder browsing, drag-move, parent navigation & subfolder create for Input/Output scopes

### DIFF
--- a/dist/assets/comfyui-majoor-assetsmanager.css
+++ b/dist/assets/comfyui-majoor-assetsmanager.css
@@ -1,0 +1,2 @@
+.mjr-folder-card.drop-active[data-v-18e248b5]{outline-offset:-2px;background:#4a90e214;outline:2px solid #4a90e2}
+/*$vite$:1*/

--- a/dist/chunks/FloatingViewer-caILYx57.js
+++ b/dist/chunks/FloatingViewer-caILYx57.js
@@ -1,12 +1,12 @@
-import { Xt as e, g as t, y as n } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { B as r, C as i, I as a, M as o, O as s, P as c, R as l, V as u, j as d, m as f, o as p, pt as m, r as h, rt as g, v as _, w as v, x as y } from "./events-CwzwyUFJ.js";
+import { Zt as e, g as t, y as n } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { B as r, C as i, I as a, M as o, O as s, P as c, R as l, V as u, j as d, m as f, o as p, pt as m, r as h, rt as g, v as _, w as v, x as y } from "./events-C2U9lj7y.js";
 import { a as b, i as x, o as S, s as C } from "./graphTraversal-Sruu0ipL.js";
-import { _ as w, g as T, m as E, n as D, p as ee, r as O, w as k } from "./Viewer--Cuhs0TQ.js";
-import { _ as A, r as j } from "./SidebarWorkflowSection-B_0hBSuQ.js";
-import { _ as M, a as N, c as P, d as F, f as I, g as L, h as te, i as ne, l as R, m as z, o as B, p as re, r as V, s as ie, t as ae, u as H, v as U } from "./openMajoorSettings-BFW5B6oQ.js";
-import { a as oe, n as se, r as ce } from "./model3dRenderer-Bzlr-goo.js";
+import { _ as w, g as T, m as E, n as D, p as ee, r as O, w as k } from "./Viewer-pHo9CcXS.js";
+import { _ as A, r as j } from "./SidebarWorkflowSection-2pSEjXh9.js";
+import { _ as M, a as N, c as P, d as F, f as I, g as L, h as te, i as ne, l as R, m as z, o as B, p as re, r as V, s as ie, t as ae, u as H, v as U } from "./openMajoorSettings-D8Sa3D0W.js";
+import { a as oe, n as se, r as ce } from "./model3dRenderer-C365Y-Y-.js";
 import { i as le, o as ue, r as de, t as fe } from "./geninfoParser-D91g5NYg.js";
-import { t as pe } from "./genInfo-fRSdoinb.js";
+import { t as pe } from "./genInfo-DZ6soYaj.js";
 //#region ui/features/viewer/floatingViewerConstants.ts
 var W = Object.freeze({
 	SIMPLE: "simple",

--- a/dist/chunks/LiveStreamTracker-ClU-8zBj.js
+++ b/dist/chunks/LiveStreamTracker-ClU-8zBj.js
@@ -1,5 +1,5 @@
-import { J as e, r as t } from "./events-CwzwyUFJ.js";
-import { t as n } from "./floatingViewerManager-CGdpmtv-.js";
+import { J as e, r as t } from "./events-C2U9lj7y.js";
+import { t as n } from "./floatingViewerManager-C0fDYFQu.js";
 //#region ui/features/viewer/LiveStreamTracker.ts
 var r = !1, i = null, a = null, o = null, s = null, c = null, l = 0, u = 0, d = 400, f = new Set([
 	".png",

--- a/dist/chunks/SidebarWorkflowSection-2pSEjXh9.js
+++ b/dist/chunks/SidebarWorkflowSection-2pSEjXh9.js
@@ -1,11 +1,11 @@
-import { $ as e, At as t, Bt as n, Ct as r, Dt as i, Et as a, Ft as o, Ht as s, I as c, Jt as l, K as u, Kt as d, Lt as f, Mt as p, N as m, Nt as h, O as g, Ot as _, Q as v, R as y, Rt as b, S as x, St as S, T as C, Tt as ee, Ut as te, X as w, Xt as T, Y as E, Yt as ne, Z as re, Zt as D, an as ie, at as ae, ct as oe, et as se, ht as ce, in as le, it as ue, jt as de, k as fe, kt as pe, lt as me, nt as he, p as ge, rt as _e, st as ve, tt as ye, ut as be, w as xe, wt as Se, xt as Ce, zt as we } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { Ct as Te, K as Ee, N as De, T as Oe, c as ke, d as Ae, f as je, h as Me, j as Ne, l as Pe, m as O, o as k, p as Fe, pt as Ie, s as A, tt as Le, u as Re, x as ze, y as Be } from "./events-CwzwyUFJ.js";
-import { F as Ve, K as He, P as Ue, Y as We, f as Ge, m as Ke, p as qe } from "./Viewer--Cuhs0TQ.js";
-import { t as Je } from "./floatingViewerManager-CGdpmtv-.js";
-import { A as Ye, B as j, C as M, D as Xe, E as N, G as Ze, H as P, J as Qe, L as $e, O as F, R as et, S as tt, T as I, W as nt, _ as rt, a as it, b as at, c as ot, ct as L, d as st, dt as R, f as ct, g as lt, h as ut, i as dt, j as ft, k as z, l as pt, lt as mt, m as ht, n as gt, nt as B, o as _t, p as vt, q as yt, r as bt, s as xt, t as St, tt as Ct, u as wt, ut as V, y as Tt } from "./mjr-primevue-n1rsQYJg.js";
-import { t as Et } from "./mjr-vue-vendor-D2GeV7Qd.js";
-import { t as Dt } from "./viewerOpenRequest-DeJyXX9z.js";
-import { a as Ot, i as kt, n as At, o as jt, r as Mt, t as Nt } from "./geninfoParser-D91g5NYg.js";
+import { $ as e, At as t, Bt as n, Ct as r, Dt as i, Et as a, I as o, It as s, K as c, Mt as l, N as u, Nt as d, O as f, Ot as p, Pt as m, Q as h, Qt as g, R as _, Rt as v, S as y, St as b, T as x, Tt as S, Ut as C, Vt as ee, Wt as te, X as w, Xt as T, Y as ne, Yt as re, Z as ie, Zt as E, an as ae, at as oe, ct as se, et as ce, ht as le, it as ue, jt as de, k as D, kt as fe, lt as pe, nt as me, on as he, p as ge, qt as _e, rt as ve, st as ye, tt as be, ut as xe, w as Se, wt as Ce, xt as we, zt as Te } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { Ct as Ee, K as De, N as Oe, T as ke, c as Ae, d as je, f as Me, h as Ne, j as Pe, l as Fe, m as O, o as k, p as Ie, pt as Le, s as A, tt as Re, u as ze, x as Be, y as Ve } from "./events-C2U9lj7y.js";
+import { F as He, K as Ue, P as We, Y as Ge, f as Ke, m as qe, p as Je } from "./Viewer-pHo9CcXS.js";
+import { t as Ye } from "./floatingViewerManager-C0fDYFQu.js";
+import { A as Xe, B as j, C as M, D as Ze, E as N, G as Qe, H as P, J as $e, L as et, O as F, R as tt, S as nt, T as I, W as rt, _ as it, a as at, b as ot, c as st, ct as L, d as ct, dt as R, f as lt, g as ut, h as dt, i as ft, j as pt, k as z, l as mt, lt as ht, m as gt, n as _t, nt as B, o as vt, p as yt, q as bt, r as xt, s as St, t as Ct, tt as wt, u as Tt, ut as V, y as Et } from "./mjr-primevue-BOCpq3qH.js";
+import { t as Dt } from "./mjr-vue-vendor-B7WqP-K6.js";
+import { t as Ot } from "./viewerOpenRequest-BcaSPESm.js";
+import { a as kt, i as At, n as jt, o as Mt, r as Nt, t as Pt } from "./geninfoParser-D91g5NYg.js";
 //#region ui/app/settings/settingsUtils.ts
 var H = (e, t) => {
 	if (typeof e == "boolean") return e;
@@ -28,30 +28,30 @@ var H = (e, t) => {
 }, U = (e, t) => {
 	let n = Number(e);
 	return Number.isFinite(n) ? n : Number(t);
-}, Pt = (e, t, n) => {
+}, Ft = (e, t, n) => {
 	let r = typeof e == "string" ? e.trim() : String(e ?? "");
 	return t.includes(r) ? r : n;
-}, Ft = (e) => e === "__proto__" || e === "prototype" || e === "constructor", It = (e, t) => {
+}, It = (e) => e === "__proto__" || e === "prototype" || e === "constructor", Lt = (e, t) => {
 	let n = { ...e };
 	return !t || typeof t != "object" || Object.keys(t).forEach((r) => {
-		if (Ft(r)) return;
+		if (It(r)) return;
 		let i = t[r];
-		i && typeof i == "object" && !Array.isArray(i) ? n[r] = It(e[r] || {}, i) : i !== void 0 && (n[r] = i);
+		i && typeof i == "object" && !Array.isArray(i) ? n[r] = Lt(e[r] || {}, i) : i !== void 0 && (n[r] = i);
 	}), n;
-}, Lt = Object.freeze({
+}, Rt = Object.freeze({
 	small: 80,
 	medium: 120,
 	large: 180
-}), Rt = Object.freeze([
+}), zt = Object.freeze([
 	"small",
 	"medium",
 	"large"
-]), zt = (e, t) => Math.max(60, Math.min(600, Math.round(U(e, t)))), Bt = (e = {}) => {
+]), Bt = (e, t) => Math.max(60, Math.min(600, Math.round(U(e, t)))), Vt = (e = {}) => {
 	let t = Number(e?.minSize);
-	if (Number.isFinite(t)) return zt(t, A.GRID_MIN_SIZE);
-	let n = Pt(String(e?.minSizePreset || "").toLowerCase(), Rt, "");
-	return n ? Lt[n] : zt(e?.minSize, A.GRID_MIN_SIZE);
-}, Vt = (e = {}) => zt(e?.minSize, A.FEED_GRID_MIN_SIZE), Ht = (e) => {
+	if (Number.isFinite(t)) return Bt(t, A.GRID_MIN_SIZE);
+	let n = Ft(String(e?.minSizePreset || "").toLowerCase(), zt, "");
+	return n ? Rt[n] : Bt(e?.minSize, A.GRID_MIN_SIZE);
+}, Ht = (e = {}) => Bt(e?.minSize, A.FEED_GRID_MIN_SIZE), Ut = (e) => {
 	let t = Math.round(U(e, A.GRID_MIN_SIZE));
 	return t <= 100 ? "small" : t >= 150 ? "large" : "medium";
 }, W = {
@@ -63,7 +63,7 @@ var H = (e, t) => {
 	grid: {
 		pageSize: A.DEFAULT_PAGE_SIZE,
 		minSize: A.GRID_MIN_SIZE,
-		minSizePreset: Ht(A.GRID_MIN_SIZE),
+		minSizePreset: Ut(A.GRID_MIN_SIZE),
 		gap: A.GRID_GAP,
 		showExtBadge: A.GRID_SHOW_BADGES_EXTENSION,
 		showRatingBadge: A.GRID_SHOW_BADGES_RATING,
@@ -121,6 +121,7 @@ var H = (e, t) => {
 		mfvPreviewMethod: A.MFV_PREVIEW_METHOD,
 		ltxavRgbFallback: !1
 	},
+	browser: { showFolders: !0 },
 	rtHydrate: {
 		concurrency: A.RT_HYDRATE_CONCURRENCY,
 		queueMax: A.RT_HYDRATE_QUEUE_MAX,
@@ -209,16 +210,16 @@ var H = (e, t) => {
 		tokenConfigured: !1,
 		tokenHint: ""
 	}
-}, Ut = () => {
+}, Wt = () => {
 	try {
-		let e = Me.get(ie);
+		let e = Ne.get(he);
 		if (!e) return { ...W };
 		let t = JSON.parse(e), n = t && typeof t == "object" && Number.isInteger(t.version) && t.data && typeof t.data == "object";
 		if (!n && !(t && typeof t == "object" && !Array.isArray(t))) return { ...W };
 		if (n && Number(t.version) > 1) return console.warn("[Majoor] settings schema version is newer than this build, using defaults"), { ...W };
 		let r = n ? t.data : t, i = new Set(/* @__PURE__ */ "debug.grid.infiniteScroll.siblings.autoScan.scan.watcher.status.viewer.rtHydrate.observability.feed.sidebar.probeBackend.i18n.paths.db.ratingTagsSync.cache.search.ai.executionGrouping.workflowMinimap.ui.security.safety".split(".")), a = {};
 		if (r && typeof r == "object") for (let [e, t] of Object.entries(r)) i.has(e) && (a[e] = t);
-		let o = It(W, a);
+		let o = Lt(W, a);
 		if (!n) try {
 			G(o);
 		} catch (e) {
@@ -236,24 +237,24 @@ var H = (e, t) => {
 			version: 1,
 			data: t
 		};
-		if (!Me.set("mjrSettings", JSON.stringify(n))) throw Error("SettingsStore rejected the write");
+		if (!Ne.set("mjrSettings", JSON.stringify(n))) throw Error("SettingsStore rejected the write");
 	} catch (e) {
 		console.warn("[Majoor] settings save failed", e);
 		try {
 			let e = Date.now();
-			e - (Number(window?._mjrSettingsSaveFailAt || 0) || 0) > 3e4 && (window._mjrSettingsSaveFailAt = e, He(O("dialog.settingsSaveFailed", "Majoor: Failed to save settings (browser storage full or blocked).")));
+			e - (Number(window?._mjrSettingsSaveFailAt || 0) || 0) > 3e4 && (window._mjrSettingsSaveFailAt = e, Ue(O("dialog.settingsSaveFailed", "Majoor: Failed to save settings (browser storage full or blocked).")));
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			We("mjr-settings-save-failed", { error: String(e?.message || e || "") }, { warnPrefix: "[Majoor]" });
+			Ge("mjr-settings-save-failed", { error: String(e?.message || e || "") }, { warnPrefix: "[Majoor]" });
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}
 }, K = (e) => {
 	let t = Number(A.MAX_PAGE_SIZE) || 2e3;
-	k.DEFAULT_PAGE_SIZE = Math.max(50, Math.min(t, Number(e.grid?.pageSize) || A.DEFAULT_PAGE_SIZE)), k.AUTO_SCAN_ON_STARTUP = !!e.autoScan?.onStartup, k.EXECUTION_GROUPING_ENABLED = !!(e.executionGrouping?.enabled ?? A.EXECUTION_GROUPING_ENABLED), k.STATUS_POLL_INTERVAL = Math.max(1e3, Number(e.status?.pollInterval) || A.STATUS_POLL_INTERVAL), k.DEBUG_SAFE_CALL = !!e.debug?.safeCall, k.DEBUG_SAFE_LISTENERS = !!e.debug?.safeListeners, k.DEBUG_VIEWER = !!e.debug?.viewer, k.GRID_MIN_SIZE = Bt(e.grid), k.FEED_GRID_MIN_SIZE = Vt(e.feed), k.GRID_GAP = Math.max(0, Math.min(40, Math.round(U(e.grid?.gap, A.GRID_GAP)))), k.GRID_SHOW_BADGES_EXTENSION = !!(e.grid?.showExtBadge ?? A.GRID_SHOW_BADGES_EXTENSION), k.GRID_SHOW_BADGES_RATING = !!(e.grid?.showRatingBadge ?? A.GRID_SHOW_BADGES_RATING), k.GRID_SHOW_BADGES_TAGS = !!(e.grid?.showTagsBadge ?? A.GRID_SHOW_BADGES_TAGS), k.GRID_SHOW_DETAILS = !!(e.grid?.showDetails ?? A.GRID_SHOW_DETAILS), k.GRID_SHOW_DETAILS_FILENAME = !!(e.grid?.showFilename ?? A.GRID_SHOW_DETAILS_FILENAME), k.GRID_SHOW_DETAILS_DATE = !!(e.grid?.showDate ?? A.GRID_SHOW_DETAILS_DATE), k.GRID_SHOW_DETAILS_DIMENSIONS = !!(e.grid?.showDimensions ?? A.GRID_SHOW_DETAILS_DIMENSIONS), k.GRID_SHOW_DETAILS_GENTIME = !!(e.grid?.showGenTime ?? A.GRID_SHOW_DETAILS_GENTIME), k.GRID_SHOW_HOVER_INFO = !!(e.grid?.showHoverInfo ?? A.GRID_SHOW_HOVER_INFO), k.GRID_SHOW_WORKFLOW_DOT = !!(e.grid?.showWorkflowDot ?? A.GRID_SHOW_WORKFLOW_DOT);
+	k.DEFAULT_PAGE_SIZE = Math.max(50, Math.min(t, Number(e.grid?.pageSize) || A.DEFAULT_PAGE_SIZE)), k.AUTO_SCAN_ON_STARTUP = !!e.autoScan?.onStartup, k.EXECUTION_GROUPING_ENABLED = !!(e.executionGrouping?.enabled ?? A.EXECUTION_GROUPING_ENABLED), k.STATUS_POLL_INTERVAL = Math.max(1e3, Number(e.status?.pollInterval) || A.STATUS_POLL_INTERVAL), k.DEBUG_SAFE_CALL = !!e.debug?.safeCall, k.DEBUG_SAFE_LISTENERS = !!e.debug?.safeListeners, k.DEBUG_VIEWER = !!e.debug?.viewer, k.GRID_MIN_SIZE = Vt(e.grid), k.FEED_GRID_MIN_SIZE = Ht(e.feed), k.GRID_GAP = Math.max(0, Math.min(40, Math.round(U(e.grid?.gap, A.GRID_GAP)))), k.GRID_SHOW_BADGES_EXTENSION = !!(e.grid?.showExtBadge ?? A.GRID_SHOW_BADGES_EXTENSION), k.GRID_SHOW_BADGES_RATING = !!(e.grid?.showRatingBadge ?? A.GRID_SHOW_BADGES_RATING), k.GRID_SHOW_BADGES_TAGS = !!(e.grid?.showTagsBadge ?? A.GRID_SHOW_BADGES_TAGS), k.GRID_SHOW_DETAILS = !!(e.grid?.showDetails ?? A.GRID_SHOW_DETAILS), k.GRID_SHOW_DETAILS_FILENAME = !!(e.grid?.showFilename ?? A.GRID_SHOW_DETAILS_FILENAME), k.GRID_SHOW_DETAILS_DATE = !!(e.grid?.showDate ?? A.GRID_SHOW_DETAILS_DATE), k.GRID_SHOW_DETAILS_DIMENSIONS = !!(e.grid?.showDimensions ?? A.GRID_SHOW_DETAILS_DIMENSIONS), k.GRID_SHOW_DETAILS_GENTIME = !!(e.grid?.showGenTime ?? A.GRID_SHOW_DETAILS_GENTIME), k.GRID_SHOW_HOVER_INFO = !!(e.grid?.showHoverInfo ?? A.GRID_SHOW_HOVER_INFO), k.GRID_SHOW_WORKFLOW_DOT = !!(e.grid?.showWorkflowDot ?? A.GRID_SHOW_WORKFLOW_DOT);
 	{
 		let t = String(e.grid?.workflowGroupBy ?? A.WORKFLOW_GRID_GROUP_BY).toLowerCase();
 		k.WORKFLOW_GRID_GROUP_BY = [
@@ -300,54 +301,54 @@ var H = (e, t) => {
 	}
 	k.VIEWER_VIDEO_GRADE_THROTTLE_FPS = Math.max(1, Math.min(60, Math.round(U(e.viewer?.videoGradeThrottleFps, A.VIEWER_VIDEO_GRADE_THROTTLE_FPS)))), k.VIEWER_SCOPES_FPS = Math.max(1, Math.min(60, Math.round(U(e.viewer?.scopesFps, A.VIEWER_SCOPES_FPS)))), k.VIEWER_META_TTL_MS = Math.max(1e3, Math.min(10 * 6e4, Math.round(U(e.viewer?.metaTtlMs, A.VIEWER_META_TTL_MS)))), k.VIEWER_META_MAX_ENTRIES = Math.max(50, Math.min(5e3, Math.round(U(e.viewer?.metaMaxEntries, A.VIEWER_META_MAX_ENTRIES)))), k.WORKFLOW_MINIMAP_ENABLED = !!(e.workflowMinimap?.enabled ?? A.WORKFLOW_MINIMAP_ENABLED), k.RT_HYDRATE_CONCURRENCY = Math.max(1, Math.min(16, Math.round(U(e.rtHydrate?.concurrency, A.RT_HYDRATE_CONCURRENCY)))), k.RT_HYDRATE_QUEUE_MAX = Math.max(10, Math.min(5e3, Math.round(U(e.rtHydrate?.queueMax, A.RT_HYDRATE_QUEUE_MAX)))), k.RT_HYDRATE_SEEN_MAX = Math.max(1e3, Math.min(2e5, Math.round(U(e.rtHydrate?.seenMax, A.RT_HYDRATE_SEEN_MAX)))), k.RT_HYDRATE_PRUNE_BUDGET = Math.max(10, Math.min(1e4, Math.round(U(e.rtHydrate?.pruneBudget, A.RT_HYDRATE_PRUNE_BUDGET)))), k.RT_HYDRATE_SEEN_TTL_MS = Math.max(5e3, Math.min(360 * 6e4, Math.round(U(e.rtHydrate?.seenTtlMs, A.RT_HYDRATE_SEEN_TTL_MS)))), k.DELETE_CONFIRMATION = !!e.safety?.confirmDeletion, k.DEBUG_VERBOSE_ERRORS = !!e.observability?.verboseErrors, k.WATCHER_MAX_PENDING = Math.max(10, Math.min(5e3, Math.round(U(e.watcher?.maxPending, 500)))), k.WATCHER_MIN_SIZE = Math.max(0, Math.min(1e6, Math.round(U(e.watcher?.minSize, 100)))), k.WATCHER_MAX_SIZE = Math.max(1e5, Math.min(17179869184, Math.round(U(e.watcher?.maxSize, 4294967296)))), k.DB_TIMEOUT_MS = Math.max(1e3, Math.min(3e4, Math.round(U(e.db?.timeoutMs, 5e3)))), k.DB_MAX_CONNECTIONS = Math.max(1, Math.min(100, Math.round(U(e.db?.maxConnections, 10)))), k.DB_QUERY_TIMEOUT_MS = Math.max(500, Math.min(1e4, Math.round(U(e.db?.queryTimeoutMs, 1e3)))), k.SIDEBAR_ASSET_BADGE_ENABLED = !!(e.sidebar?.assetBadgeEnabled ?? A.SIDEBAR_ASSET_BADGE_ENABLED), k.SEARCH_REQUEST_LIMIT = Math.max(10, Math.min(A.MAX_PAGE_SIZE || 2e3, Math.round(U(e.search?.maxResults, A.SEARCH_DEFAULT_LIMIT))));
 };
-async function Wt() {
+async function Gt() {
 	try {
 		let e = await ue();
 		if (!e?.ok) return;
 		let t = e.data?.prefs;
 		if (!t || typeof t != "object") return;
-		let n = Ut();
+		let n = Wt();
 		if (n.security = n.security || {}, n.security.safeMode = H(t.safe_mode, n.security.safeMode), n.security.allowWrite = H(t.allow_write, n.security.allowWrite), n.security.requireAuth = H(t.require_auth, n.security.requireAuth), n.security.allowRemoteWrite = H(t.allow_remote_write, n.security.allowRemoteWrite), n.security.allowInsecureTokenTransport = H(t.allow_insecure_token_transport, n.security.allowInsecureTokenTransport), n.security.allowDelete = H(t.allow_delete, n.security.allowDelete), n.security.allowRename = H(t.allow_rename, n.security.allowRename), n.security.allowOpenInFolder = H(t.allow_open_in_folder, n.security.allowOpenInFolder), n.security.allowResetIndex = H(t.allow_reset_index, n.security.allowResetIndex), n.security.tokenConfigured = H(t.token_configured, n.security.tokenConfigured), n.security.tokenHint = String(t.token_hint || "").trim(), !String(n.security.apiToken || "").trim()) try {
-			let e = await y(), t = String(e?.data?.token || "").trim();
-			e?.ok && t && ne(t);
+			let e = await _(), t = String(e?.data?.token || "").trim();
+			e?.ok && t && T(t);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		G(n), K(n), We("mjr-settings-changed", { key: "security" }, { warnPrefix: "[Majoor]" });
+		G(n), K(n), Ge("mjr-settings-changed", { key: "security" }, { warnPrefix: "[Majoor]" });
 	} catch (e) {
 		console.warn("[Majoor] failed to sync backend security settings", e);
 	}
 }
-async function Gt() {
+async function Kt() {
 	try {
-		let e = await ve();
+		let e = await ye();
 		if (!e?.ok) return;
 		let t = e.data?.prefs;
 		if (!t || typeof t != "object") return;
-		let n = Ut();
-		n.ai = n.ai || {}, n.ai.vectorSearchEnabled = H(t.enabled, n.ai.vectorSearchEnabled ?? !0), n.ai.vectorCaptionOnIndex = H(t.caption_on_index ?? t.captionOnIndex, n.ai.vectorCaptionOnIndex ?? !1), n.ai.vectorIndexOnScan = H(t.index_on_scan ?? t.indexOnScan, n.ai.vectorIndexOnScan ?? !1), n.ai.vectorUnloadAfterUse = H(t.unload_after_use ?? t.unloadAfterUse, n.ai.vectorUnloadAfterUse ?? !1), n.ai.vectorConcurrency = Math.max(1, Math.min(16, Math.floor(Number(t.concurrency ?? n.ai.vectorConcurrency ?? 1) || 1))), G(n), K(n), We("mjr-settings-changed", { key: "ai.vectorSearch" }, { warnPrefix: "[Majoor]" });
+		let n = Wt();
+		n.ai = n.ai || {}, n.ai.vectorSearchEnabled = H(t.enabled, n.ai.vectorSearchEnabled ?? !0), n.ai.vectorCaptionOnIndex = H(t.caption_on_index ?? t.captionOnIndex, n.ai.vectorCaptionOnIndex ?? !1), n.ai.vectorIndexOnScan = H(t.index_on_scan ?? t.indexOnScan, n.ai.vectorIndexOnScan ?? !1), n.ai.vectorUnloadAfterUse = H(t.unload_after_use ?? t.unloadAfterUse, n.ai.vectorUnloadAfterUse ?? !1), n.ai.vectorConcurrency = Math.max(1, Math.min(16, Math.floor(Number(t.concurrency ?? n.ai.vectorConcurrency ?? 1) || 1))), G(n), K(n), Ge("mjr-settings-changed", { key: "ai.vectorSearch" }, { warnPrefix: "[Majoor]" });
 	} catch (e) {
 		console.warn("[Majoor] failed to sync backend vector search settings", e);
 	}
 }
-async function Kt() {
+async function qt() {
 	try {
-		let e = await E();
+		let e = await ne();
 		if (!e?.ok) return;
 		let t = e.data?.prefs;
 		if (!t || typeof t != "object") return;
-		let n = Ut();
-		n.executionGrouping = n.executionGrouping || {}, n.executionGrouping.enabled = H(t.enabled, n.executionGrouping.enabled ?? A.EXECUTION_GROUPING_ENABLED), G(n), K(n), We("mjr-settings-changed", { key: "executionGrouping.enabled" }, { warnPrefix: "[Majoor]" });
+		let n = Wt();
+		n.executionGrouping = n.executionGrouping || {}, n.executionGrouping.enabled = H(t.enabled, n.executionGrouping.enabled ?? A.EXECUTION_GROUPING_ENABLED), G(n), K(n), Ge("mjr-settings-changed", { key: "executionGrouping.enabled" }, { warnPrefix: "[Majoor]" });
 	} catch (e) {
 		console.warn("[Majoor] failed to sync backend execution grouping settings", e);
 	}
 }
 //#endregion
 //#region ui/app/settings/settingsRuntime.ts
-var qt = "mjr-runtime-status-dashboard", Jt = 3e4;
-function Yt() {
+var Jt = "mjr-runtime-status-dashboard", Yt = 3e4;
+function Xt() {
 	try {
-		let e = Ut(), t = String(e?.observability?.runtimeDashboardMode || W.observability.runtimeDashboardMode);
+		let e = Wt(), t = String(e?.observability?.runtimeDashboardMode || W.observability.runtimeDashboardMode);
 		return [
 			"autoHide30",
 			"always",
@@ -357,28 +358,28 @@ function Yt() {
 		return "autoHide30";
 	}
 }
-function Xt() {
+function Zt() {
 	try {
-		document.getElementById(qt)?.remove?.();
+		document.getElementById(Jt)?.remove?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Zt() {
+function Qt() {
 	try {
 		window.__MJR_RUNTIME_STATUS_HIDE_TIMEOUT__ && (clearTimeout(window.__MJR_RUNTIME_STATUS_HIDE_TIMEOUT__), window.__MJR_RUNTIME_STATUS_HIDE_TIMEOUT__ = null);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Qt(e, t) {
+function $t(e, t) {
 	let n = t === "auth" ? "__mjrAuthLine" : "__mjrMetricsLine";
 	if (e?.[n]) return e[n];
 	let r = document.createElement("div");
 	return r.style.whiteSpace = "nowrap", r.style.lineHeight = "1.35", t === "auth" && (r.style.marginTop = "4px", r.style.fontWeight = "600"), e.appendChild(r), e[n] = r, r;
 }
-function $t(e) {
-	let t = String(e?.token_hint || "").trim(), n = l(), r = t || (n ? "(session)" : ""), i = e?.allow_write !== !1, a = e?.require_auth === !0, o = e?.token_configured === !0;
+function en(e) {
+	let t = String(e?.token_hint || "").trim(), n = re(), r = t || (n ? "(session)" : ""), i = e?.allow_write !== !1, a = e?.require_auth === !0, o = e?.token_configured === !0;
 	return i ? n ? {
 		text: O("runtime.writeAuthActive", "Write auth: active {tokenHint}", { tokenHint: r || "(session)" }),
 		color: "#7ee0a0"
@@ -399,10 +400,10 @@ function $t(e) {
 		color: "#ff9b9b"
 	};
 }
-function en() {
+function tn() {
 	try {
-		if (Yt() === "hidden" || window.__MJR_RUNTIME_STATUS_HIDDEN__) return Xt(), null;
-		let e = document.querySelector(".mjr-assets-manager.mjr-am-container"), t = document.getElementById(qt);
+		if (Xt() === "hidden" || window.__MJR_RUNTIME_STATUS_HIDDEN__) return Zt(), null;
+		let e = document.querySelector(".mjr-assets-manager.mjr-am-container"), t = document.getElementById(Jt);
 		if (!e) {
 			try {
 				t?.remove?.();
@@ -417,18 +418,18 @@ function en() {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let n = document.getElementById(qt);
-		return n ? n.parentElement !== e && e.appendChild(n) : (n = document.createElement("div"), n.id = qt, n.style.position = "absolute", n.style.bottom = "10px", n.style.right = "10px", n.style.zIndex = "9999", n.style.padding = "6px 10px", n.style.borderRadius = "10px", n.style.border = "1px solid rgba(255,255,255,0.16)", n.style.background = "rgba(0,0,0,0.45)", n.style.backdropFilter = "blur(4px)", n.style.color = "var(--content-fg, #fff)", n.style.fontSize = "11px", n.style.pointerEvents = "none", n.style.display = "flex", n.style.flexDirection = "column", e.appendChild(n)), n;
+		let n = document.getElementById(Jt);
+		return n ? n.parentElement !== e && e.appendChild(n) : (n = document.createElement("div"), n.id = Jt, n.style.position = "absolute", n.style.bottom = "10px", n.style.right = "10px", n.style.zIndex = "9999", n.style.padding = "6px 10px", n.style.borderRadius = "10px", n.style.border = "1px solid rgba(255,255,255,0.16)", n.style.background = "rgba(0,0,0,0.45)", n.style.backdropFilter = "blur(4px)", n.style.color = "var(--content-fg, #fff)", n.style.fontSize = "11px", n.style.pointerEvents = "none", n.style.display = "flex", n.style.flexDirection = "column", e.appendChild(n)), n;
 	} catch {
 		return null;
 	}
 }
-async function tn() {
-	let e = en();
+async function nn() {
+	let e = tn();
 	if (!e) return !1;
-	let t = Qt(e, "metrics"), n = Qt(e, "auth");
+	let t = $t(e, "metrics"), n = $t(e, "auth");
 	try {
-		let [r, i] = await Promise.all([_e(), ue()]), a = O("runtime.unavailable", "Runtime: unavailable");
+		let [r, i] = await Promise.all([ve(), ue()]), a = O("runtime.unavailable", "Runtime: unavailable");
 		if (!r?.ok || !r?.data) t.textContent = a;
 		else {
 			let e = r.data.db || {}, n = r.data.index || {}, i = r.data.watcher || {}, o = Number(e.active_connections || 0), s = Number(n.enrichment_queue_length || 0), c = Number(i.pending_files || 0);
@@ -442,27 +443,27 @@ async function tn() {
 				pending: c
 			});
 		}
-		let o = $t(i?.data?.prefs || null);
+		let o = en(i?.data?.prefs || null);
 		return n.textContent = o.text, n.style.color = o.color, e.title = `${a}\n${o.text}`, !0;
 	} catch {
 		return t.textContent = O("runtime.unavailable", "Runtime: unavailable"), n.textContent = O("runtime.writeAuthUnknown", "Write auth: unknown"), n.style.color = "#c8ced8", e.title = `${O("runtime.unavailable", "Runtime: unavailable")}\n${n.textContent}`, !0;
 	}
 }
-function nn() {
+function rn() {
 	try {
-		let e = Yt();
+		let e = Xt();
 		if (e === "hidden") {
-			window.__MJR_RUNTIME_STATUS_HIDDEN__ = !0, Zt(), Xt();
+			window.__MJR_RUNTIME_STATUS_HIDDEN__ = !0, Qt(), Zt();
 			return;
 		}
 		window.__MJR_RUNTIME_STATUS_SETTINGS_LISTENER__ || (window.__MJR_RUNTIME_STATUS_SETTINGS_LISTENER__ = (e) => {
 			if (e?.detail?.key !== "observability.runtimeDashboardMode") return;
-			let t = Yt();
-			window.__MJR_RUNTIME_STATUS_HIDDEN__ = t === "hidden", Zt(), Xt(), t !== "hidden" && nn();
-		}, window.addEventListener?.("mjr-settings-changed", window.__MJR_RUNTIME_STATUS_SETTINGS_LISTENER__)), window.__MJR_RUNTIME_STATUS_HIDDEN__ = !1, Zt(), e === "autoHide30" && (window.__MJR_RUNTIME_STATUS_HIDE_TIMEOUT__ = setTimeout(() => {
-			window.__MJR_RUNTIME_STATUS_HIDDEN__ = !0, Xt();
-		}, Jt)), tn().catch(() => {}), window.__MJR_RUNTIME_STATUS_INFLIGHT__ ?? (window.__MJR_RUNTIME_STATUS_INFLIGHT__ = !1), window.__MJR_RUNTIME_STATUS_MISS_COUNT__ ?? (window.__MJR_RUNTIME_STATUS_MISS_COUNT__ = 0), window.__MJR_RUNTIME_STATUS_INTERVAL__ || (window.__MJR_RUNTIME_STATUS_INTERVAL__ = setInterval(() => {
-			window.__MJR_RUNTIME_STATUS_INFLIGHT__ || (window.__MJR_RUNTIME_STATUS_INFLIGHT__ = !0, tn().then((e) => {
+			let t = Xt();
+			window.__MJR_RUNTIME_STATUS_HIDDEN__ = t === "hidden", Qt(), Zt(), t !== "hidden" && rn();
+		}, window.addEventListener?.("mjr-settings-changed", window.__MJR_RUNTIME_STATUS_SETTINGS_LISTENER__)), window.__MJR_RUNTIME_STATUS_HIDDEN__ = !1, Qt(), e === "autoHide30" && (window.__MJR_RUNTIME_STATUS_HIDE_TIMEOUT__ = setTimeout(() => {
+			window.__MJR_RUNTIME_STATUS_HIDDEN__ = !0, Zt();
+		}, Yt)), nn().catch(() => {}), window.__MJR_RUNTIME_STATUS_INFLIGHT__ ?? (window.__MJR_RUNTIME_STATUS_INFLIGHT__ = !1), window.__MJR_RUNTIME_STATUS_MISS_COUNT__ ?? (window.__MJR_RUNTIME_STATUS_MISS_COUNT__ = 0), window.__MJR_RUNTIME_STATUS_INTERVAL__ || (window.__MJR_RUNTIME_STATUS_INTERVAL__ = setInterval(() => {
+			window.__MJR_RUNTIME_STATUS_INFLIGHT__ || (window.__MJR_RUNTIME_STATUS_INFLIGHT__ = !0, nn().then((e) => {
 				if (e) {
 					window.__MJR_RUNTIME_STATUS_MISS_COUNT__ = 0;
 					return;
@@ -478,8 +479,8 @@ function nn() {
 }
 //#endregion
 //#region ui/utils/debounce.ts
-var rn = 300;
-function an(e, t = rn) {
+var an = 300;
+function on(e, t = an) {
 	let n, r = (...r) => {
 		clearTimeout(n), n = setTimeout(() => e(...r), t);
 	};
@@ -491,36 +492,36 @@ function an(e, t = rn) {
 }
 //#endregion
 //#region ui/app/settings/settingsGrid.ts
-var q = "Majoor", on = "Majoor Assets Manager";
-function sn(e, t, n) {
+var q = "Majoor", sn = "Majoor Assets Manager";
+function cn(e, t, n) {
 	let r = (e, t) => [
-		on,
+		sn,
 		e,
 		t
 	], i = (e) => [
-		on,
+		sn,
 		O("cat.cards", "Cards"),
 		e
 	], a = (e) => [
-		on,
+		sn,
 		O("cat.badges", "Badges"),
 		e
 	], o = (e) => [
-		on,
+		sn,
 		O("cat.badges", "Badges"),
 		e
 	], s = (e, t) => {
 		let n = String(e || "").trim();
 		return /^[0-9a-fA-F]{6}$/.test(n) && (n = `#${n}`), /^#[0-9a-fA-F]{6}$/.test(n) ? n.toUpperCase() : t;
 	};
-	t.grid?.minSizePreset || (t.grid = t.grid || {}, t.grid.minSizePreset = Ht(t.grid.minSize), G(t)), e({
+	t.grid?.minSizePreset || (t.grid = t.grid || {}, t.grid.minSizePreset = Ut(t.grid.minSize), G(t)), e({
 		id: `${q}.Cards.ThumbSize`,
 		category: i(O("setting.grid.cardSize.group", "Card size")),
 		name: O("setting.grid.cardSize.name", "Majoor: Card Size"),
 		tooltip: O("setting.grid.cardSize.desc", "Choose the card size preset used by the grid layout."),
 		type: "combo",
 		defaultValue: (() => {
-			let e = Pt(String(t.grid?.minSizePreset || "").toLowerCase(), Rt, Ht(t.grid?.minSize)), n = {
+			let e = Ft(String(t.grid?.minSizePreset || "").toLowerCase(), zt, Ut(t.grid?.minSize)), n = {
 				small: O("setting.grid.cardSize.small", "Small"),
 				medium: O("setting.grid.cardSize.medium", "Medium"),
 				large: O("setting.grid.cardSize.large", "Large")
@@ -534,7 +535,7 @@ function sn(e, t, n) {
 		],
 		onChange: (e) => {
 			let r = String(e || "").trim().toLowerCase(), i = O("setting.grid.cardSize.small", "Small").toLowerCase(), a = O("setting.grid.cardSize.medium", "Medium").toLowerCase(), o = O("setting.grid.cardSize.large", "Large").toLowerCase(), s = "medium";
-			r === i || r === "small" || r === "petit" ? s = "small" : r === o || r === "large" || r === "grand" ? s = "large" : (r === a || r === "medium" || r === "moyen") && (s = "medium"), t.grid.minSizePreset = s, t.grid.minSize = Lt[s], G(t), K(t), n("grid.minSizePreset");
+			r === i || r === "small" || r === "petit" ? s = "small" : r === o || r === "large" || r === "grand" ? s = "large" : (r === a || r === "medium" || r === "moyen") && (s = "medium"), t.grid.minSizePreset = s, t.grid.minSize = Rt[s], G(t), K(t), n("grid.minSizePreset");
 		}
 	}), e({
 		id: `${q}.Cards.CustomThumbSize`,
@@ -550,7 +551,7 @@ function sn(e, t, n) {
 		},
 		onChange: (e) => {
 			let r = Math.max(60, Math.min(600, Math.round(Number(e) || 120)));
-			t.grid.minSize = r, t.grid.minSizePreset = Ht(r), G(t), K(t), n("grid.minSize");
+			t.grid.minSize = r, t.grid.minSizePreset = Ut(r), G(t), K(t), n("grid.minSize");
 		}
 	}), e({
 		id: `${q}.Grid.ShowDetails`,
@@ -897,15 +898,15 @@ function sn(e, t, n) {
 }
 //#endregion
 //#region ui/app/settings/settingsViewer.ts
-var cn = "Majoor", ln = "Majoor Assets Manager";
-function un(t, n, r) {
-	let i = (e, t) => [
-		ln,
+var ln = "Majoor", un = "Majoor Assets Manager";
+function dn(t, n, r) {
+	let a = (e, t) => [
+		un,
 		e,
 		t
-	], o = (e) => i(O("cat.viewer", "Viewer"), e), s = (e) => i(O("cat.floatingViewer", "Floating Viewer"), e);
+	], o = (e) => a(O("cat.viewer", "Viewer"), e), s = (e) => a(O("cat.floatingViewer", "Floating Viewer"), e);
 	t({
-		id: `${cn}.Viewer.AllowPanAtZoom1`,
+		id: `${ln}.Viewer.AllowPanAtZoom1`,
 		category: o(O("setting.viewer.pan.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.pan.name"),
 		tooltip: O("setting.viewer.pan.desc"),
@@ -915,7 +916,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.allowPanAtZoom1 = !!e, G(n), K(n), r("viewer.allowPanAtZoom1");
 		}
 	}), t({
-		id: `${cn}.Viewer.DisableWebGL`,
+		id: `${ln}.Viewer.DisableWebGL`,
 		category: o("Disable WebGL Video"),
 		name: "Disable WebGL Video",
 		tooltip: "Use CPU rendering (Canvas 2D) for video playback. Fixes 'black screen' issues on incompatible hardware/browsers.",
@@ -925,7 +926,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.disableWebGL = !!e, G(n), K(n), r("viewer.disableWebGL");
 		}
 	}), t({
-		id: `${cn}.Viewer.PauseDuringExecution`,
+		id: `${ln}.Viewer.PauseDuringExecution`,
 		category: o(O("setting.viewer.pauseExecution.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.pauseExecution.name"),
 		tooltip: O("setting.viewer.pauseExecution.desc"),
@@ -935,7 +936,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.pauseDuringExecution = !!e, G(n), K(n), r("viewer.pauseDuringExecution");
 		}
 	}), t({
-		id: `${cn}.Viewer.FloatingPauseDuringExecution`,
+		id: `${ln}.Viewer.FloatingPauseDuringExecution`,
 		category: s(O("setting.viewer.floatingPauseExecution.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.floatingPauseExecution.name"),
 		tooltip: O("setting.viewer.floatingPauseExecution.desc"),
@@ -945,7 +946,24 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.floatingPauseDuringExecution = !!e, G(n), K(n), r("viewer.floatingPauseDuringExecution");
 		}
 	}), t({
-		id: `${cn}.Viewer.MfvLiveDefault`,
+		id: `${ln}.Browser.ShowFolders`,
+		category: o("Browser"),
+		name: "Show folders in Input / Output panels",
+		tooltip: "When enabled, subdirectories under the Input and Output roots are shown as folder cards in the browser grid. Disable to see only files.",
+		type: "boolean",
+		defaultValue: !!(n.browser?.showFolders ?? !0),
+		onChange: async (e) => {
+			let t = !!e, i = !!(n.browser?.showFolders ?? !0);
+			n.browser = n.browser || {}, n.browser.showFolders = t, G(n), K(n), r("browser.showFolders");
+			try {
+				let e = await b(t);
+				if (!e?.ok) throw Error(e?.error || "Failed to update show folders setting");
+			} catch (e) {
+				n.browser.showFolders = i, G(n), K(n), r("browser.showFolders"), E(e?.message || "Failed to update show folders setting", "error");
+			}
+		}
+	}), t({
+		id: `${ln}.Viewer.MfvLiveDefault`,
 		category: s(O("setting.viewer.mfvLiveDefault.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.mfvLiveDefault.name"),
 		tooltip: O("setting.viewer.mfvLiveDefault.desc"),
@@ -955,7 +973,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.mfvLiveDefault = !!e, G(n), K(n), r("viewer.mfvLiveDefault");
 		}
 	}), t({
-		id: `${cn}.Viewer.MfvPreviewDefault`,
+		id: `${ln}.Viewer.MfvPreviewDefault`,
 		category: s(O("setting.viewer.mfvPreviewDefault.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.mfvPreviewDefault.name"),
 		tooltip: O("setting.viewer.mfvPreviewDefault.desc"),
@@ -965,7 +983,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.mfvPreviewDefault = !!e, G(n), K(n), r("viewer.mfvPreviewDefault");
 		}
 	}), t({
-		id: `${cn}.Viewer.MfvSidebarPosition`,
+		id: `${ln}.Viewer.MfvSidebarPosition`,
 		category: s("Node Parameters sidebar position"),
 		name: "Node Parameters sidebar position",
 		tooltip: "Position of the Node Parameters sidebar in the Floating Viewer (right, left, or bottom).",
@@ -985,7 +1003,7 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.mfvSidebarPosition = t, G(n), K(n), r("viewer.mfvSidebarPosition");
 		}
 	}), t({
-		id: `${cn}.Viewer.MfvPreviewMethod`,
+		id: `${ln}.Viewer.MfvPreviewMethod`,
 		category: s(O("setting.viewer.mfvPreviewMethod.name").replace("Majoor: ", "")),
 		name: O("setting.viewer.mfvPreviewMethod.name"),
 		tooltip: O("setting.viewer.mfvPreviewMethod.desc"),
@@ -1009,27 +1027,27 @@ function un(t, n, r) {
 			n.viewer = n.viewer || {}, n.viewer.mfvPreviewMethod = t, G(n), K(n), r("viewer.mfvPreviewMethod");
 		}
 	}), t({
-		id: `${cn}.Viewer.LtxavRgbFallback`,
+		id: `${ln}.Viewer.LtxavRgbFallback`,
 		category: s("LTXAV preview fallback"),
 		name: "Majoor: LTXAV RGB Preview Fallback (experimental)",
 		tooltip: "Reuse LTXV RGB projection for LTXAV when native latent preview is unavailable. Experimental; quality may be approximate.",
 		type: "boolean",
 		defaultValue: !!n.viewer?.ltxavRgbFallback,
 		onChange: async (e) => {
-			let t = !!e, i = !!n.viewer?.ltxavRgbFallback;
+			let t = !!e, a = !!n.viewer?.ltxavRgbFallback;
 			n.viewer = n.viewer || {}, n.viewer.ltxavRgbFallback = t, G(n), K(n), r("viewer.ltxavRgbFallback");
 			try {
-				let e = await a(t);
+				let e = await i(t);
 				if (!e?.ok) throw Error(e?.error || "Failed to update LTXAV RGB preview fallback setting");
 			} catch (e) {
-				n.viewer.ltxavRgbFallback = i, G(n), K(n), r("viewer.ltxavRgbFallback"), T(e?.message || "Failed to update LTXAV RGB preview fallback setting", "error");
+				n.viewer.ltxavRgbFallback = a, G(n), K(n), r("viewer.ltxavRgbFallback"), E(e?.message || "Failed to update LTXAV RGB preview fallback setting", "error");
 			}
 		}
 	});
 	try {
 		e().then((e) => {
 			if (!e?.ok) return;
-			let t = !!e?.data?.prefs?.enabled, i = Ut();
+			let t = !!e?.data?.prefs?.enabled, i = Wt();
 			i.viewer = i.viewer || {}, !!i.viewer.ltxavRgbFallback !== t && (i.viewer.ltxavRgbFallback = t, Object.assign(n, i), G(i), K(i), r("viewer.ltxavRgbFallback"));
 		}).catch(() => {});
 	} catch (e) {
@@ -1037,7 +1055,7 @@ function un(t, n, r) {
 	}
 	((e, i, a, s) => {
 		t({
-			id: `${cn}.WorkflowMinimap.${e}`,
+			id: `${ln}.WorkflowMinimap.${e}`,
 			category: o(O(a).replace("Majoor: ", "")),
 			name: O(a),
 			tooltip: O(s),
@@ -1051,73 +1069,73 @@ function un(t, n, r) {
 }
 //#endregion
 //#region ui/app/settings/settingsScanning.ts
-var dn = "Majoor", fn = "Majoor Assets Manager";
-function pn(e, t, n) {
-	let r = (e, t) => [
-		fn,
+var fn = "Majoor", pn = "Majoor Assets Manager";
+function mn(e, t, i) {
+	let o = (e, t) => [
+		pn,
 		e,
 		t
 	];
 	e({
-		id: `${dn}.ExecutionGrouping.Enabled`,
-		category: r(O("cat.scanning"), "Execution grouping"),
+		id: `${fn}.ExecutionGrouping.Enabled`,
+		category: o(O("cat.scanning"), "Execution grouping"),
 		name: "Execution job/stack grouping",
 		tooltip: "Enable or disable all live job_id / stack_id tracking, grouping, and stack finalization logic.",
 		type: "boolean",
 		defaultValue: !!(t.executionGrouping?.enabled ?? A.EXECUTION_GROUPING_ENABLED),
 		onChange: async (e) => {
-			let r = !!(t.executionGrouping?.enabled ?? A.EXECUTION_GROUPING_ENABLED), i = !!e;
-			t.executionGrouping = t.executionGrouping || {}, t.executionGrouping.enabled = i, G(t), K(t), n("executionGrouping.enabled");
+			let n = !!(t.executionGrouping?.enabled ?? A.EXECUTION_GROUPING_ENABLED), a = !!e;
+			t.executionGrouping = t.executionGrouping || {}, t.executionGrouping.enabled = a, G(t), K(t), i("executionGrouping.enabled");
 			try {
-				let e = await S(i);
+				let e = await r(a);
 				if (!e?.ok) throw Error(e?.error || "Failed to update execution grouping setting");
-				t.executionGrouping.enabled = !!e?.data?.prefs?.enabled, G(t), K(t), n("executionGrouping.enabled");
+				t.executionGrouping.enabled = !!e?.data?.prefs?.enabled, G(t), K(t), i("executionGrouping.enabled");
 			} catch (e) {
-				t.executionGrouping.enabled = r, G(t), K(t), n("executionGrouping.enabled"), T(e?.message || "Failed to update execution grouping setting", "error");
+				t.executionGrouping.enabled = n, G(t), K(t), i("executionGrouping.enabled"), E(e?.message || "Failed to update execution grouping setting", "error");
 			}
 		}
 	}), e({
-		id: `${dn}.AutoScan.OnStartup`,
-		category: r(O("cat.scanning"), O("setting.scan.startup.name").replace("Majoor: ", "")),
+		id: `${fn}.AutoScan.OnStartup`,
+		category: o(O("cat.scanning"), O("setting.scan.startup.name").replace("Majoor: ", "")),
 		name: O("setting.scan.startup.name"),
 		tooltip: O("setting.scan.startup.desc"),
 		type: "boolean",
 		defaultValue: !!t.autoScan?.onStartup,
 		onChange: (e) => {
-			t.autoScan = t.autoScan || {}, t.autoScan.onStartup = !!e, G(t), K(t), n("autoScan.onStartup");
+			t.autoScan = t.autoScan || {}, t.autoScan.onStartup = !!e, G(t), K(t), i("autoScan.onStartup");
 		}
 	}), e({
-		id: `${dn}.Scan.FastMode`,
-		category: r(O("cat.scanning"), "Scan mode"),
+		id: `${fn}.Scan.FastMode`,
+		category: o(O("cat.scanning"), "Scan mode"),
 		name: "Fast scan mode",
 		tooltip: "Use fast scan mode for manual backfill scans (skip heavier metadata work during scan).",
 		type: "boolean",
 		defaultValue: !!(t.scan?.fastMode ?? !0),
 		onChange: (e) => {
-			t.scan = t.scan || {}, t.scan.fastMode = !!e, G(t), n("scan.fastMode");
+			t.scan = t.scan || {}, t.scan.fastMode = !!e, G(t), i("scan.fastMode");
 		}
 	}), e({
-		id: `${dn}.Scan.JpegXL`,
-		category: r(O("cat.scanning"), "Image formats"),
+		id: `${fn}.Scan.JpegXL`,
+		category: o(O("cat.scanning"), "Image formats"),
 		name: "JPEG XL (JXL) support (Experimental)",
 		tooltip: "Index and preview .jxl images. Preview generation requires JPEG XL support in Pillow or FFmpeg. Run a new scan after enabling.",
 		type: "boolean",
 		defaultValue: !!t.scan?.jxlEnabled,
 		onChange: async (e) => {
-			let r = !!t.scan?.jxlEnabled, i = !!e;
-			t.scan = t.scan || {}, t.scan.jxlEnabled = i, G(t), n("scan.jxlEnabled");
+			let n = !!t.scan?.jxlEnabled, r = !!e;
+			t.scan = t.scan || {}, t.scan.jxlEnabled = r, G(t), i("scan.jxlEnabled");
 			try {
-				let e = await ee(i);
+				let e = await a(r);
 				if (!e?.ok) throw Error(e?.error || "Failed to update JPEG XL support");
 			} catch (e) {
-				t.scan.jxlEnabled = r, G(t), n("scan.jxlEnabled"), T(e?.message || "Failed to update JPEG XL support", "error");
+				t.scan.jxlEnabled = n, G(t), i("scan.jxlEnabled"), E(e?.message || "Failed to update JPEG XL support", "error");
 			}
 		}
-	}), v().then((e) => {
-		e?.ok && (t.scan = t.scan || {}, t.scan.jxlEnabled = !!e?.data?.prefs?.enabled, G(t), n("scan.jxlEnabled"));
+	}), h().then((e) => {
+		e?.ok && (t.scan = t.scan || {}, t.scan.jxlEnabled = !!e?.data?.prefs?.enabled, G(t), i("scan.jxlEnabled"));
 	}).catch(() => {}), e({
-		id: `${dn}.RtHydrate.Concurrency`,
-		category: r(O("cat.scanning"), "Hydration"),
+		id: `${fn}.RtHydrate.Concurrency`,
+		category: o(O("cat.scanning"), "Hydration"),
 		name: "Hydrate Concurrency",
 		tooltip: "Maximum concurrent hydration requests for rating/tags.",
 		type: "number",
@@ -1128,51 +1146,51 @@ function pn(e, t, n) {
 			step: 1
 		},
 		onChange: (e) => {
-			t.rtHydrate = t.rtHydrate || {}, t.rtHydrate.concurrency = Math.max(1, Math.min(20, Math.round(U(e, A.RT_HYDRATE_CONCURRENCY || 5)))), G(t), K(t), n("rtHydrate.concurrency");
+			t.rtHydrate = t.rtHydrate || {}, t.rtHydrate.concurrency = Math.max(1, Math.min(20, Math.round(U(e, A.RT_HYDRATE_CONCURRENCY || 5)))), G(t), K(t), i("rtHydrate.concurrency");
 		}
 	});
-	let i = (e, t, n, r) => {
+	let s = (e, t, n, r) => {
 		let i = Math.round(U(e, t));
 		return Math.max(n, Math.min(r, i));
-	}, a = (e = {}) => {
-		let r = [];
+	}, c = (e = {}) => {
+		let n = [];
 		if (t.watcher = t.watcher || {}, typeof e.debounce_ms == "number") {
-			let n = Math.max(50, Math.min(5e3, Math.round(e.debounce_ms)));
-			t.watcher.debounceMs !== n && (t.watcher.debounceMs = n, r.push("watcher.debounceMs"));
+			let r = Math.max(50, Math.min(5e3, Math.round(e.debounce_ms)));
+			t.watcher.debounceMs !== r && (t.watcher.debounceMs = r, n.push("watcher.debounceMs"));
 		}
 		if (typeof e.dedupe_ttl_ms == "number") {
-			let n = Math.max(100, Math.min(3e4, Math.round(e.dedupe_ttl_ms)));
-			t.watcher.dedupeTtlMs !== n && (t.watcher.dedupeTtlMs = n, r.push("watcher.dedupeTtlMs"));
+			let r = Math.max(100, Math.min(3e4, Math.round(e.dedupe_ttl_ms)));
+			t.watcher.dedupeTtlMs !== r && (t.watcher.dedupeTtlMs = r, n.push("watcher.dedupeTtlMs"));
 		}
-		r.length && (G(t), r.forEach((e) => n(e)));
-	}, o = async () => {
+		n.length && (G(t), n.forEach((e) => i(e)));
+	}, l = async () => {
 		try {
-			let e = await oe();
+			let e = await se();
 			if (!e?.ok) return;
-			a(e.data || {});
+			c(e.data || {});
 		} catch (e) {
 			console.debug?.(e);
 		}
 	};
 	e({
-		id: `${dn}.Watcher.Enabled`,
-		category: r(O("cat.scanning"), O("setting.watcher.enabled.label", "Enable watcher")),
+		id: `${fn}.Watcher.Enabled`,
+		category: o(O("cat.scanning"), O("setting.watcher.enabled.label", "Enable watcher")),
 		name: O("setting.watcher.name"),
 		tooltip: O("setting.watcher.desc") + " (env: MJR_ENABLE_WATCHER)",
 		type: "boolean",
 		defaultValue: !!t.watcher?.enabled,
 		onChange: async (e) => {
-			t.watcher = t.watcher || {}, t.watcher.enabled = !!e, G(t), n("watcher.enabled");
+			t.watcher = t.watcher || {}, t.watcher.enabled = !!e, G(t), i("watcher.enabled");
 			try {
-				let r = await f(!!e);
-				r?.ok || (t.watcher.enabled = !e, G(t), n("watcher.enabled"), T(r?.error || O("toast.failedToggleWatcher", "Failed to toggle watcher"), "error"));
+				let n = await v(!!e);
+				n?.ok || (t.watcher.enabled = !e, G(t), i("watcher.enabled"), E(n?.error || O("toast.failedToggleWatcher", "Failed to toggle watcher"), "error"));
 			} catch {
-				t.watcher.enabled = !e, G(t), n("watcher.enabled");
+				t.watcher.enabled = !e, G(t), i("watcher.enabled");
 			}
 		}
 	}), e({
-		id: `${dn}.Watcher.DebounceDelay`,
-		category: r(O("cat.scanning"), O("setting.watcher.debounce.label", "Watcher debounce delay")),
+		id: `${fn}.Watcher.DebounceDelay`,
+		category: o(O("cat.scanning"), O("setting.watcher.debounce.label", "Watcher debounce delay")),
 		name: O("setting.watcher.debounce.name"),
 		tooltip: O("setting.watcher.debounce.desc") + " (env: MJR_WATCHER_DEBOUNCE_MS)",
 		type: "number",
@@ -1183,22 +1201,22 @@ function pn(e, t, n) {
 			step: 50
 		},
 		onChange: async (e) => {
-			let r = A.WATCHER_DEBOUNCE_MS, a = i(e, r, 50, 6e4), o = t.watcher?.debounceMs ?? r;
+			let r = A.WATCHER_DEBOUNCE_MS, a = s(e, r, 50, 6e4), o = t.watcher?.debounceMs ?? r;
 			if (a !== o) {
 				t.watcher = t.watcher || {}, t.watcher.debounceMs = a, G(t);
 				try {
-					let e = await we({ debounce_ms: a });
+					let e = await n({ debounce_ms: a });
 					if (!e?.ok) throw Error(e?.error || O("setting.watcher.debounce.error"));
 					let r = Math.round(Number(e?.data?.debounce_ms ?? a));
-					t.watcher.debounceMs = r, G(t), n("watcher.debounceMs");
+					t.watcher.debounceMs = r, G(t), i("watcher.debounceMs");
 				} catch (e) {
-					t.watcher.debounceMs = o, G(t), n("watcher.debounceMs"), T(e?.message || O("setting.watcher.debounce.error"), "error");
+					t.watcher.debounceMs = o, G(t), i("watcher.debounceMs"), E(e?.message || O("setting.watcher.debounce.error"), "error");
 				}
 			}
 		}
 	}), e({
-		id: `${dn}.Watcher.DedupeWindow`,
-		category: r(O("cat.scanning"), O("setting.watcher.dedupe.label", "Watcher dedupe window")),
+		id: `${fn}.Watcher.DedupeWindow`,
+		category: o(O("cat.scanning"), O("setting.watcher.dedupe.label", "Watcher dedupe window")),
 		name: O("setting.watcher.dedupe.name"),
 		tooltip: O("setting.watcher.dedupe.desc") + " (env: MJR_WATCHER_DEDUPE_TTL_MS)",
 		type: "number",
@@ -1209,22 +1227,22 @@ function pn(e, t, n) {
 			step: 100
 		},
 		onChange: async (e) => {
-			let r = A.WATCHER_DEDUPE_TTL_MS, a = i(e, r, 100, 12e4), o = t.watcher?.dedupeTtlMs ?? r;
+			let r = A.WATCHER_DEDUPE_TTL_MS, a = s(e, r, 100, 12e4), o = t.watcher?.dedupeTtlMs ?? r;
 			if (a !== o) {
 				t.watcher = t.watcher || {}, t.watcher.dedupeTtlMs = a, G(t);
 				try {
-					let e = await we({ dedupe_ttl_ms: a });
+					let e = await n({ dedupe_ttl_ms: a });
 					if (!e?.ok) throw Error(e?.error || O("setting.watcher.dedupe.error"));
 					let r = Math.round(Number(e?.data?.dedupe_ttl_ms ?? a));
-					t.watcher.dedupeTtlMs = r, G(t), n("watcher.dedupeTtlMs");
+					t.watcher.dedupeTtlMs = r, G(t), i("watcher.dedupeTtlMs");
 				} catch (e) {
-					t.watcher.dedupeTtlMs = o, G(t), n("watcher.dedupeTtlMs"), T(e?.message || O("setting.watcher.dedupe.error"), "error");
+					t.watcher.dedupeTtlMs = o, G(t), i("watcher.dedupeTtlMs"), E(e?.message || O("setting.watcher.dedupe.error"), "error");
 				}
 			}
 		}
 	}), e({
-		id: `${dn}.Watcher.MaxPending`,
-		category: r(O("cat.scanning"), "Watcher queue"),
+		id: `${fn}.Watcher.MaxPending`,
+		category: o(O("cat.scanning"), "Watcher queue"),
 		name: "Watcher: max pending files",
 		tooltip: "Maximum number of pending watcher files kept in memory.",
 		type: "number",
@@ -1235,11 +1253,11 @@ function pn(e, t, n) {
 			step: 10
 		},
 		onChange: (e) => {
-			t.watcher = t.watcher || {}, t.watcher.maxPending = Math.max(10, Math.min(5e3, Math.round(U(e, 500)))), G(t), K(t), n("watcher.maxPending");
+			t.watcher = t.watcher || {}, t.watcher.maxPending = Math.max(10, Math.min(5e3, Math.round(U(e, 500)))), G(t), K(t), i("watcher.maxPending");
 		}
 	}), e({
-		id: `${dn}.Watcher.MinSize`,
-		category: r(O("cat.scanning"), "Watcher file size"),
+		id: `${fn}.Watcher.MinSize`,
+		category: o(O("cat.scanning"), "Watcher file size"),
 		name: "Watcher: min size (bytes)",
 		tooltip: "Minimum file size indexed by watcher.",
 		type: "number",
@@ -1250,11 +1268,11 @@ function pn(e, t, n) {
 			step: 100
 		},
 		onChange: (e) => {
-			t.watcher = t.watcher || {}, t.watcher.minSize = Math.max(0, Math.min(1e6, Math.round(U(e, 100)))), G(t), K(t), n("watcher.minSize");
+			t.watcher = t.watcher || {}, t.watcher.minSize = Math.max(0, Math.min(1e6, Math.round(U(e, 100)))), G(t), K(t), i("watcher.minSize");
 		}
 	}), e({
-		id: `${dn}.Watcher.MaxSize`,
-		category: r(O("cat.scanning"), "Watcher file size"),
+		id: `${fn}.Watcher.MaxSize`,
+		category: o(O("cat.scanning"), "Watcher file size"),
 		name: "Watcher: max size (bytes)",
 		tooltip: "Maximum file size indexed by watcher.",
 		type: "number",
@@ -1265,39 +1283,39 @@ function pn(e, t, n) {
 			step: 1e5
 		},
 		onChange: (e) => {
-			t.watcher = t.watcher || {}, t.watcher.maxSize = Math.max(1e5, Math.min(17179869184, Math.round(U(e, 4294967296)))), G(t), K(t), n("watcher.maxSize");
+			t.watcher = t.watcher || {}, t.watcher.maxSize = Math.max(1e5, Math.min(17179869184, Math.round(U(e, 4294967296)))), G(t), K(t), i("watcher.maxSize");
 		}
 	});
 	try {
-		o().catch(() => {});
+		l().catch(() => {});
 	} catch (e) {
 		console.debug?.(e);
 	}
 	e({
-		id: `${dn}.RatingTagsSync.Enabled`,
-		category: r(O("cat.scanning"), O("setting.sync.rating.name").replace("Majoor: ", "")),
+		id: `${fn}.RatingTagsSync.Enabled`,
+		category: o(O("cat.scanning"), O("setting.sync.rating.name").replace("Majoor: ", "")),
 		name: O("setting.sync.rating.name"),
 		tooltip: O("setting.sync.rating.desc"),
 		type: "boolean",
 		defaultValue: !!t.ratingTagsSync?.enabled,
 		onChange: (e) => {
-			t.ratingTagsSync = t.ratingTagsSync || {}, t.ratingTagsSync.enabled = !!e, G(t), n("ratingTagsSync.enabled");
+			t.ratingTagsSync = t.ratingTagsSync || {}, t.ratingTagsSync.enabled = !!e, G(t), i("ratingTagsSync.enabled");
 		}
 	});
 }
 //#endregion
 //#region ui/app/settings/settingsFeed.ts
-var mn = "Majoor", hn = "Majoor Assets Manager";
-function gn(e, t, n) {
+var hn = "Majoor", gn = "Majoor Assets Manager";
+function _n(e, t, n) {
 	let r = (e) => [
-		hn,
+		gn,
 		O("cat.feed", "Generated Feed"),
 		e
 	], i = () => {
 		t.feed = t.feed || {};
 	};
 	e({
-		id: `${mn}.Feed.CardSize`,
+		id: `${hn}.Feed.CardSize`,
 		category: r("Card size"),
 		name: "Feed card size (px)",
 		tooltip: "Set the minimum card width used by the Generated Feed layout (60-600 px).",
@@ -1312,7 +1330,7 @@ function gn(e, t, n) {
 			i(), t.feed.minSize = Math.max(60, Math.min(600, Math.round(Number(e) || 120))), G(t), K(t), n("feed.minSize");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowInfo`,
+		id: `${hn}.Feed.ShowInfo`,
 		category: r("Show info section"),
 		name: "Show card info section",
 		tooltip: "Show or hide the entire info section (filename, metadata, dots) below thumbnails in the Generated Feed.",
@@ -1322,7 +1340,7 @@ function gn(e, t, n) {
 			i(), t.feed.showInfo = !!e, G(t), K(t), n("feed.showInfo");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowFilename`,
+		id: `${hn}.Feed.ShowFilename`,
 		category: r("Show filename"),
 		name: "Show filename",
 		tooltip: "Display the filename on feed cards.",
@@ -1332,7 +1350,7 @@ function gn(e, t, n) {
 			i(), t.feed.showFilename = !!e, G(t), K(t), n("feed.showFilename");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowDimensions`,
+		id: `${hn}.Feed.ShowDimensions`,
 		category: r("Show dimensions"),
 		name: "Show dimensions",
 		tooltip: "Display resolution (WxH) and duration on feed cards.",
@@ -1342,7 +1360,7 @@ function gn(e, t, n) {
 			i(), t.feed.showDimensions = !!e, G(t), K(t), n("feed.showDimensions");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowDate`,
+		id: `${hn}.Feed.ShowDate`,
 		category: r("Show date/time"),
 		name: "Show date/time",
 		tooltip: "Display date and time on feed cards.",
@@ -1352,7 +1370,7 @@ function gn(e, t, n) {
 			i(), t.feed.showDate = !!e, G(t), K(t), n("feed.showDate");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowGenTime`,
+		id: `${hn}.Feed.ShowGenTime`,
 		category: r("Show generation time"),
 		name: "Show generation time",
 		tooltip: "Display the generation time badge on feed cards.",
@@ -1362,7 +1380,7 @@ function gn(e, t, n) {
 			i(), t.feed.showGenTime = !!e, G(t), K(t), n("feed.showGenTime");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowWorkflowDot`,
+		id: `${hn}.Feed.ShowWorkflowDot`,
 		category: r("Show workflow dot"),
 		name: "Show workflow indicator",
 		tooltip: "Display the workflow availability dot on feed cards.",
@@ -1372,7 +1390,7 @@ function gn(e, t, n) {
 			i(), t.feed.showWorkflowDot = !!e, G(t), K(t), n("feed.showWorkflowDot");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowExtBadge`,
+		id: `${hn}.Feed.ShowExtBadge`,
 		category: r("Show format badges"),
 		name: "Show format badges",
 		tooltip: "Display format badges (e.g. JPG, MP4) on feed card thumbnails.",
@@ -1382,7 +1400,7 @@ function gn(e, t, n) {
 			i(), t.feed.showExtBadge = !!e, G(t), K(t), n("feed.showExtBadge");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowRatingBadge`,
+		id: `${hn}.Feed.ShowRatingBadge`,
 		category: r("Show rating badges"),
 		name: "Show ratings",
 		tooltip: "Display star ratings on feed card thumbnails.",
@@ -1392,7 +1410,7 @@ function gn(e, t, n) {
 			i(), t.feed.showRatingBadge = !!e, G(t), K(t), n("feed.showRatingBadge");
 		}
 	}), e({
-		id: `${mn}.Feed.ShowTagsBadge`,
+		id: `${hn}.Feed.ShowTagsBadge`,
 		category: r("Show tags badges"),
 		name: "Show tags",
 		tooltip: "Display tag indicators on feed card thumbnails.",
@@ -1405,7 +1423,7 @@ function gn(e, t, n) {
 }
 //#endregion
 //#region ui/app/settings/settingsSecurity.ts
-var _n = "Majoor", vn = "Majoor Assets Manager", yn = 16, bn = {
+var vn = "Majoor", yn = "Majoor Assets Manager", bn = 16, xn = {
 	safeMode: !1,
 	allowWrite: !0,
 	allowDelete: !0,
@@ -1413,54 +1431,54 @@ var _n = "Majoor", vn = "Majoor Assets Manager", yn = 16, bn = {
 	allowOpenInFolder: !0,
 	allowResetIndex: !0
 };
-function xn(e) {
+function Sn(e) {
 	return !!e;
 }
-function Sn(e, t) {
-	return xn(e) === xn(t);
-}
-function Cn(e) {
-	return typeof e == "string" ? e.trim() : "";
+function Cn(e, t) {
+	return Sn(e) === Sn(t);
 }
 function wn(e) {
+	return typeof e == "string" ? e.trim() : "";
+}
+function Tn(e) {
 	let t = String(e || "").trim().toLowerCase();
 	return t === "localhost" || t === "127.0.0.1" || t === "::1";
 }
-function Tn() {
+function En() {
 	return globalThis.location || globalThis.window?.location || null;
 }
-function En() {
-	let e = Tn();
+function Dn() {
+	let e = En();
 	if (!e) return !1;
 	let t = String(e.protocol || "").toLowerCase(), n = String(e.hostname || "").trim();
-	return t === "http:" && !wn(n);
+	return t === "http:" && !Tn(n);
 }
-function Dn(e) {
+function On(e) {
 	let t = globalThis.crypto;
 	if (!t?.getRandomValues) throw Error("Secure token generation requires crypto.getRandomValues().");
 	return t.getRandomValues(e);
 }
-function On(e) {
+function kn(e) {
 	let t = Math.max(4, Number(e) || 0), n = new Uint8Array(t);
-	return Dn(n), Array.from(n, (e) => e.toString(16).padStart(2, "0")).join("");
+	return On(n), Array.from(n, (e) => e.toString(16).padStart(2, "0")).join("");
 }
-function kn() {
-	return `mjr_${On(18)}`;
-}
-function An(e) {
-	return String(e?.apiToken || "").trim().length >= yn && H(e?.allowWrite, !0) && H(e?.requireAuth, !1) && !H(e?.allowRemoteWrite, !1);
+function An() {
+	return `mjr_${kn(18)}`;
 }
 function jn(e) {
+	return String(e?.apiToken || "").trim().length >= bn && H(e?.allowWrite, !0) && H(e?.requireAuth, !1) && !H(e?.allowRemoteWrite, !1);
+}
+function Mn(e) {
 	let t = String((e && typeof e == "object" ? e : {}).apiToken || "").trim();
 	return {
-		apiToken: t.length >= yn ? t : kn(),
+		apiToken: t.length >= bn ? t : An(),
 		allowWrite: !0,
 		requireAuth: !0,
 		allowRemoteWrite: !1,
-		allowInsecureTokenTransport: En()
+		allowInsecureTokenTransport: Dn()
 	};
 }
-function Mn(e) {
+function Nn(e) {
 	let t = e || {};
 	return {
 		safe_mode: H(t.safeMode, !1),
@@ -1475,44 +1493,44 @@ function Mn(e) {
 		...String(t.apiToken || "").trim() ? { api_token: String(t.apiToken || "").trim() } : {}
 	};
 }
-function Nn(e) {
-	return de(Mn(e));
-}
 function Pn(e) {
+	return l(Nn(e));
+}
+function Fn(e) {
 	let t = String(e?.security?.tokenHint || "").trim();
 	return t ? O("setting.sec.token.placeholderConfigured", "Token configured on server ({tokenHint}). Leave blank to keep the current server token.", { tokenHint: t }) : e?.security?.tokenConfigured ? O("setting.sec.token.placeholderConfiguredGeneric", "Token configured on server. Leave blank to keep the current server token.") : O("setting.sec.token.placeholder", "Auto-generated for this browser session.");
 }
-function Fn(e, t, n) {
+function In(e, t, n) {
 	let r = (e, t) => [
-		vn,
+		yn,
 		e,
 		t
 	];
 	e({
-		id: `${_n}.Safety.ConfirmDeletion`,
+		id: `${vn}.Safety.ConfirmDeletion`,
 		category: r(O("cat.security"), "Confirm before deleting"),
 		name: "Confirm before deleting",
 		tooltip: "Show a confirmation dialog before deleting files. Disabling this allows instant deletion.",
 		type: "boolean",
 		defaultValue: t.safety?.confirmDeletion !== !1,
 		onChange: (e) => {
-			Sn(t.safety?.confirmDeletion !== !1, e) || (t.safety = t.safety || {}, t.safety.confirmDeletion = !!e, G(t), K(t), n("safety.confirmDeletion"));
+			Cn(t.safety?.confirmDeletion !== !1, e) || (t.safety = t.safety || {}, t.safety.confirmDeletion = !!e, G(t), K(t), n("safety.confirmDeletion"));
 		}
 	});
 	let i = (i, a, o, s = "cat.security") => {
 		e({
-			id: `${_n}.Security.${i}`,
+			id: `${vn}.Security.${i}`,
 			category: r(O(s), O(a).replace("Majoor: ", "")),
 			name: O(a),
 			tooltip: O(o),
 			type: "boolean",
-			defaultValue: H(t.security?.[i], bn[i] ?? !1),
+			defaultValue: H(t.security?.[i], xn[i] ?? !1),
 			onChange: (e) => {
-				if (!Sn(t.security?.[i], e)) {
+				if (!Cn(t.security?.[i], e)) {
 					t.security = t.security || {}, t.security[i] = !!e, G(t), n(`security.${i}`);
 					try {
-						Nn(t.security).then((e) => {
-							e?.ok && e.data?.prefs ? Wt() : e && e.ok === !1 && console.warn("[Majoor] backend security settings update failed", e.error || e);
+						Pn(t.security).then((e) => {
+							e?.ok && e.data?.prefs ? Gt() : e && e.ok === !1 && console.warn("[Majoor] backend security settings update failed", e.error || e);
 						}).catch(() => {});
 					} catch (e) {
 						console.debug?.(e);
@@ -1522,50 +1540,50 @@ function Fn(e, t, n) {
 		});
 	};
 	i("safeMode", "setting.sec.safe.name", "setting.sec.safe.desc"), i("allowWrite", "setting.sec.write.name", "setting.sec.write.desc"), i("allowDelete", "setting.sec.del.name", "setting.sec.del.desc"), i("allowRename", "setting.sec.ren.name", "setting.sec.ren.desc"), i("allowOpenInFolder", "setting.sec.open.name", "setting.sec.open.desc"), i("allowResetIndex", "setting.sec.reset.name", "setting.sec.reset.desc"), e({
-		id: `${_n}.Security.RemoteLanPreset`,
+		id: `${vn}.Security.RemoteLanPreset`,
 		category: r(O("cat.remote"), O("setting.sec.remoteLanPreset.name").replace("Majoor: ", "")),
 		name: O("setting.sec.remoteLanPreset.name"),
 		tooltip: O("setting.sec.remoteLanPreset.desc"),
 		type: "boolean",
-		defaultValue: An(t.security),
+		defaultValue: jn(t.security),
 		onChange: (e) => {
-			if (t.security = t.security || {}, Sn(t.security.remoteLanPreset, e)) return;
+			if (t.security = t.security || {}, Cn(t.security.remoteLanPreset, e)) return;
 			if (t.security.remoteLanPreset = !!e, !e) {
 				G(t), n("security.remoteLanPreset");
 				return;
 			}
 			let r;
 			try {
-				r = jn(t.security);
+				r = Mn(t.security);
 			} catch (e) {
-				T(e?.message || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error");
+				E(e?.message || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error");
 				return;
 			}
-			Object.assign(t.security, r), t.security.tokenConfigured = !0, t.security.tokenHint = String(r.apiToken || "").trim() ? `...${String(r.apiToken).trim().slice(-4)}` : "", r.apiToken && ne(r.apiToken), G(t), n("security.remoteLanPreset"), n("security.apiToken"), n("security.allowWrite"), n("security.requireAuth"), n("security.allowRemoteWrite"), n("security.allowInsecureTokenTransport");
+			Object.assign(t.security, r), t.security.tokenConfigured = !0, t.security.tokenHint = String(r.apiToken || "").trim() ? `...${String(r.apiToken).trim().slice(-4)}` : "", r.apiToken && T(r.apiToken), G(t), n("security.remoteLanPreset"), n("security.apiToken"), n("security.allowWrite"), n("security.requireAuth"), n("security.allowRemoteWrite"), n("security.allowInsecureTokenTransport");
 			try {
-				Nn(t.security).then((e) => {
-					e?.ok && e.data?.prefs ? (Wt(), T(O("toast.remoteLanPresetApplied", "Recommended remote LAN setup applied. This browser session is now authorized for Majoor write operations."), "success")) : e && e.ok === !1 && (T(e.error || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error"), console.warn("[Majoor] backend remote LAN preset update failed", e.error || e));
+				Pn(t.security).then((e) => {
+					e?.ok && e.data?.prefs ? (Gt(), E(O("toast.remoteLanPresetApplied", "Recommended remote LAN setup applied. This browser session is now authorized for Majoor write operations."), "success")) : e && e.ok === !1 && (E(e.error || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error"), console.warn("[Majoor] backend remote LAN preset update failed", e.error || e));
 				}).catch((e) => {
-					T(e?.message || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error");
+					E(e?.message || O("toast.remoteLanPresetFailed", "Failed to apply the recommended remote LAN setup."), "error");
 				});
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
 	}), e({
-		id: `${_n}.Security.ApiToken`,
+		id: `${vn}.Security.ApiToken`,
 		category: r(O("cat.remote"), O("setting.sec.token.name").replace("Majoor: ", "")),
 		name: O("setting.sec.token.name", "Majoor: API Token"),
 		tooltip: O("setting.sec.token.desc", "Store the API token used for write operations. Majoor sends it via X-MJR-Token and Authorization headers."),
 		type: "text",
 		defaultValue: t.security?.apiToken || "",
-		attrs: { placeholder: Pn(t) },
+		attrs: { placeholder: Fn(t) },
 		onChange: (e) => {
 			t.security = t.security || {};
-			let r = Cn(e);
-			if (Cn(t.security.apiToken) !== r && (t.security.apiToken = r, t.security.apiToken && (t.security.tokenConfigured = !0, t.security.tokenHint = `...${t.security.apiToken.slice(-4)}`, ne(t.security.apiToken)), G(t), n("security.apiToken"), t.security.apiToken)) try {
-				de({ api_token: t.security.apiToken }).then((e) => {
-					e?.ok && e.data?.prefs ? Wt() : e && e.ok === !1 && console.warn("[Majoor] backend token update failed", e.error || e);
+			let r = wn(e);
+			if (wn(t.security.apiToken) !== r && (t.security.apiToken = r, t.security.apiToken && (t.security.tokenConfigured = !0, t.security.tokenHint = `...${t.security.apiToken.slice(-4)}`, T(t.security.apiToken)), G(t), n("security.apiToken"), t.security.apiToken)) try {
+				l({ api_token: t.security.apiToken }).then((e) => {
+					e?.ok && e.data?.prefs ? Gt() : e && e.ok === !1 && console.warn("[Majoor] backend token update failed", e.error || e);
 				}).catch(() => {});
 			} catch (e) {
 				console.debug?.(e);
@@ -1575,143 +1593,47 @@ function Fn(e, t, n) {
 }
 //#endregion
 //#region ui/app/settings/settingsAdvanced.ts
-var J = "Majoor", In = "Majoor Assets Manager";
-function Ln(e, a, s, c) {
-	let l = (e, t) => [
-		In,
+var J = "Majoor", Ln = "Majoor Assets Manager";
+function Rn(e, n, r, i) {
+	let a = (e, t) => [
+		Ln,
 		e,
 		t
-	], f = String(a.paths?.outputDirectory || ""), m = null, h = 0, g = null;
+	], o = String(n.paths?.outputDirectory || ""), l = null, u = 0, f = null;
 	e({
 		id: `${J}.Paths.OutputDirectory`,
-		category: l(O("cat.advanced"), "Paths / Output"),
+		category: a(O("cat.advanced"), "Paths / Output"),
 		name: "Majoor: Generation Output Directory",
 		tooltip: "Override the ComfyUI generation output directory used by Majoor (equivalent to --output-directory). Leave empty to keep the current backend default.",
 		type: "text",
-		defaultValue: String(a.paths?.outputDirectory || ""),
+		defaultValue: String(n.paths?.outputDirectory || ""),
 		attrs: { placeholder: "D:\\\\____COMFY_OUTPUTS" },
 		onChange: async (e) => {
 			let t = String(e || "").trim();
-			a.paths = a.paths || {}, a.paths.outputDirectory = t, G(a);
+			n.paths = n.paths || {}, n.paths.outputDirectory = t, G(n);
 			try {
-				m &&= (clearTimeout(m), null);
+				l &&= (clearTimeout(l), null);
 			} catch (e) {
 				console.debug?.(e);
 			}
-			m = setTimeout(async () => {
-				m = null;
-				let e = ++h;
+			l = setTimeout(async () => {
+				l = null;
+				let e = ++u;
 				try {
-					g?.abort?.();
+					f?.abort?.();
 				} catch (e) {
 					console.debug?.(e);
 				}
-				g = typeof AbortController < "u" ? new AbortController() : null;
+				f = typeof AbortController < "u" ? new AbortController() : null;
 				try {
-					let n = await _(t, g ? { signal: g.signal } : {});
-					if (e !== h) return;
-					if (!n?.ok) throw Error(n?.error || O("toast.failedSetOutputDirectory", "Failed to set output directory"));
-					let r = String(n?.data?.output_directory || t).trim();
-					a.paths.outputDirectory = r, f = r, G(a), s("paths.outputDirectory");
+					let i = await fe(t, f ? { signal: f.signal } : {});
+					if (e !== u) return;
+					if (!i?.ok) throw Error(i?.error || O("toast.failedSetOutputDirectory", "Failed to set output directory"));
+					let a = String(i?.data?.output_directory || t).trim();
+					n.paths.outputDirectory = a, o = a, G(n), r("paths.outputDirectory");
 				} catch (t) {
-					if (e !== h || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
-					a.paths.outputDirectory = f, G(a), s("paths.outputDirectory"), T(t?.message || O("toast.failedSetOutputDirectory", "Failed to set output directory"), "error");
-				}
-			}, 700);
-		}
-	});
-	try {
-		ye().then((e) => {
-			if (!e?.ok) return;
-			let t = String(e?.data?.output_directory || "").trim();
-			a.paths = a.paths || {}, a.paths.outputDirectory !== t && (a.paths.outputDirectory = t, f = t, G(a), s("paths.outputDirectory"));
-		}).catch(() => {});
-	} catch (e) {
-		console.debug?.(e);
-	}
-	let v = String(a.paths?.indexDirectory || ""), y = null, b = 0, x = null;
-	e({
-		id: `${J}.Paths.IndexDirectory`,
-		category: l(O("cat.advanced"), "Paths / Index"),
-		name: "Majoor: Index Database Directory",
-		tooltip: "Override the Majoor index database directory. Use this to keep the SQLite index on a different local disk. Requires restart.",
-		type: "text",
-		defaultValue: String(a.paths?.indexDirectory || ""),
-		attrs: { placeholder: "D:\\MajoorIndex" },
-		onChange: async (e) => {
-			let t = String(e || "").trim();
-			a.paths = a.paths || {}, a.paths.indexDirectory = t, G(a);
-			try {
-				y &&= (clearTimeout(y), null);
-			} catch (e) {
-				console.debug?.(e);
-			}
-			y = setTimeout(async () => {
-				y = null;
-				let e = ++b;
-				try {
-					x?.abort?.();
-				} catch (e) {
-					console.debug?.(e);
-				}
-				x = typeof AbortController < "u" ? new AbortController() : null;
-				try {
-					let n = await Se(t, x ? { signal: x.signal } : {});
-					if (e !== b) return;
-					if (!n?.ok) throw Error(n?.error || O("toast.failedSetIndexDirectory", "Failed to set index directory"));
-					let r = String(n?.data?.index_directory || t).trim(), i = r !== v;
-					a.paths.indexDirectory = r, v = r, G(a), s("paths.indexDirectory"), i && T(O("toast.indexDirectorySavedRestart", "Index directory saved. Restart ComfyUI to apply."), "success", void 0, { history: { trackId: "settings:index-directory-saved" } });
-				} catch (t) {
-					if (e !== b || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
-					a.paths.indexDirectory = v, G(a), s("paths.indexDirectory"), T(t?.message || O("toast.failedSetIndexDirectory", "Failed to set index directory"), "error");
-				}
-			}, 700);
-		}
-	});
-	try {
-		re().then((e) => {
-			if (!e?.ok) return;
-			let t = String(e?.data?.index_directory || "").trim();
-			a.paths = a.paths || {}, a.paths.indexDirectory !== t && (a.paths.indexDirectory = t, v = t, G(a), s("paths.indexDirectory"));
-		}).catch(() => {});
-	} catch (e) {
-		console.debug?.(e);
-	}
-	let S = String(a.paths?.workflowRoots || ""), C = null, ee = 0, te = null;
-	e({
-		id: `${J}.Paths.WorkflowRoots`,
-		category: l(O("cat.advanced"), "Paths / Workflows"),
-		name: "Majoor: Workflow Roots",
-		tooltip: "Folders scanned by the Workflow tab. Use one folder per line, or separate folders with semicolons. Leave empty to use ComfyUI defaults and MJR_AM_WORKFLOW_DIRECTORY.",
-		type: "text",
-		defaultValue: String(a.paths?.workflowRoots || ""),
-		attrs: { placeholder: "D:\\\\ComfyUI\\\\user\\\\default\\\\workflows" },
-		onChange: async (e) => {
-			let t = String(e || "").trim();
-			a.paths = a.paths || {}, a.paths.workflowRoots = t, G(a);
-			try {
-				C &&= (clearTimeout(C), null);
-			} catch (e) {
-				console.debug?.(e);
-			}
-			C = setTimeout(async () => {
-				C = null;
-				let e = ++ee;
-				try {
-					te?.abort?.();
-				} catch (e) {
-					console.debug?.(e);
-				}
-				te = typeof AbortController < "u" ? new AbortController() : null;
-				try {
-					let n = await o(t, te ? { signal: te.signal } : {});
-					if (e !== ee) return;
-					if (!n?.ok) throw Error(n?.error || O("toast.failedSetWorkflowRoots", "Failed to set workflow roots"));
-					let r = String(n?.data?.workflow_roots_text || t).trim();
-					a.paths.workflowRoots = r, S = r, G(a), s("paths.workflowRoots"), T(O("toast.workflowRootsSaved", "Workflow roots saved"), "success", 1800);
-				} catch (t) {
-					if (e !== ee || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
-					a.paths.workflowRoots = S, G(a), s("paths.workflowRoots"), T(t?.message || O("toast.failedSetWorkflowRoots", "Failed to set workflow roots"), "error");
+					if (e !== u || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
+					n.paths.outputDirectory = o, G(n), r("paths.outputDirectory"), E(t?.message || O("toast.failedSetOutputDirectory", "Failed to set output directory"), "error");
 				}
 			}, 700);
 		}
@@ -1719,35 +1641,131 @@ function Ln(e, a, s, c) {
 	try {
 		be().then((e) => {
 			if (!e?.ok) return;
-			let t = String(e?.data?.workflow_roots_text || "").trim();
-			a.paths = a.paths || {}, a.paths.workflowRoots !== t && (a.paths.workflowRoots = t, S = t, G(a), s("paths.workflowRoots"));
+			let t = String(e?.data?.output_directory || "").trim();
+			n.paths = n.paths || {}, n.paths.outputDirectory !== t && (n.paths.outputDirectory = t, o = t, G(n), r("paths.outputDirectory"));
 		}).catch(() => {});
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let E = Pe().map((e) => e.code), ne = ["auto", ...E];
+	let m = String(n.paths?.indexDirectory || ""), h = null, _ = 0, v = null;
+	e({
+		id: `${J}.Paths.IndexDirectory`,
+		category: a(O("cat.advanced"), "Paths / Index"),
+		name: "Majoor: Index Database Directory",
+		tooltip: "Override the Majoor index database directory. Use this to keep the SQLite index on a different local disk. Requires restart.",
+		type: "text",
+		defaultValue: String(n.paths?.indexDirectory || ""),
+		attrs: { placeholder: "D:\\MajoorIndex" },
+		onChange: async (e) => {
+			let t = String(e || "").trim();
+			n.paths = n.paths || {}, n.paths.indexDirectory = t, G(n);
+			try {
+				h &&= (clearTimeout(h), null);
+			} catch (e) {
+				console.debug?.(e);
+			}
+			h = setTimeout(async () => {
+				h = null;
+				let e = ++_;
+				try {
+					v?.abort?.();
+				} catch (e) {
+					console.debug?.(e);
+				}
+				v = typeof AbortController < "u" ? new AbortController() : null;
+				try {
+					let i = await S(t, v ? { signal: v.signal } : {});
+					if (e !== _) return;
+					if (!i?.ok) throw Error(i?.error || O("toast.failedSetIndexDirectory", "Failed to set index directory"));
+					let a = String(i?.data?.index_directory || t).trim(), o = a !== m;
+					n.paths.indexDirectory = a, m = a, G(n), r("paths.indexDirectory"), o && E(O("toast.indexDirectorySavedRestart", "Index directory saved. Restart ComfyUI to apply."), "success", void 0, { history: { trackId: "settings:index-directory-saved" } });
+				} catch (t) {
+					if (e !== _ || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
+					n.paths.indexDirectory = m, G(n), r("paths.indexDirectory"), E(t?.message || O("toast.failedSetIndexDirectory", "Failed to set index directory"), "error");
+				}
+			}, 700);
+		}
+	});
+	try {
+		ie().then((e) => {
+			if (!e?.ok) return;
+			let t = String(e?.data?.index_directory || "").trim();
+			n.paths = n.paths || {}, n.paths.indexDirectory !== t && (n.paths.indexDirectory = t, m = t, G(n), r("paths.indexDirectory"));
+		}).catch(() => {});
+	} catch (e) {
+		console.debug?.(e);
+	}
+	let y = String(n.paths?.workflowRoots || ""), b = null, x = 0, C = null;
+	e({
+		id: `${J}.Paths.WorkflowRoots`,
+		category: a(O("cat.advanced"), "Paths / Workflows"),
+		name: "Majoor: Workflow Roots",
+		tooltip: "Folders scanned by the Workflow tab. Use one folder per line, or separate folders with semicolons. Leave empty to use ComfyUI defaults and MJR_AM_WORKFLOW_DIRECTORY.",
+		type: "text",
+		defaultValue: String(n.paths?.workflowRoots || ""),
+		attrs: { placeholder: "D:\\\\ComfyUI\\\\user\\\\default\\\\workflows" },
+		onChange: async (e) => {
+			let t = String(e || "").trim();
+			n.paths = n.paths || {}, n.paths.workflowRoots = t, G(n);
+			try {
+				b &&= (clearTimeout(b), null);
+			} catch (e) {
+				console.debug?.(e);
+			}
+			b = setTimeout(async () => {
+				b = null;
+				let e = ++x;
+				try {
+					C?.abort?.();
+				} catch (e) {
+					console.debug?.(e);
+				}
+				C = typeof AbortController < "u" ? new AbortController() : null;
+				try {
+					let i = await s(t, C ? { signal: C.signal } : {});
+					if (e !== x) return;
+					if (!i?.ok) throw Error(i?.error || O("toast.failedSetWorkflowRoots", "Failed to set workflow roots"));
+					let a = String(i?.data?.workflow_roots_text || t).trim();
+					n.paths.workflowRoots = a, y = a, G(n), r("paths.workflowRoots"), E(O("toast.workflowRootsSaved", "Workflow roots saved"), "success", 1800);
+				} catch (t) {
+					if (e !== x || String(t?.name || "") === "AbortError" || String(t?.code || "") === "ABORTED") return;
+					n.paths.workflowRoots = y, G(n), r("paths.workflowRoots"), E(t?.message || O("toast.failedSetWorkflowRoots", "Failed to set workflow roots"), "error");
+				}
+			}, 700);
+		}
+	});
+	try {
+		xe().then((e) => {
+			if (!e?.ok) return;
+			let t = String(e?.data?.workflow_roots_text || "").trim();
+			n.paths = n.paths || {}, n.paths.workflowRoots !== t && (n.paths.workflowRoots = t, y = t, G(n), r("paths.workflowRoots"));
+		}).catch(() => {});
+	} catch (e) {
+		console.debug?.(e);
+	}
+	let te = Fe().map((e) => e.code), T = ["auto", ...te];
 	e({
 		id: `${J}.Language`,
-		category: l(O("cat.advanced"), O("setting.language.name", "Language")),
+		category: a(O("cat.advanced"), O("setting.language.name", "Language")),
 		name: O("setting.language.name", "Majoor: Language"),
 		tooltip: "Use auto to detect and follow ComfyUI language. Or choose a fixed language for Majoor only.",
 		type: "combo",
-		defaultValue: a.i18n?.followComfyLanguage ? "auto" : ke(),
-		options: ne,
+		defaultValue: n.i18n?.followComfyLanguage ? "auto" : Ae(),
+		options: T,
 		onChange: (e) => {
-			if (a.i18n = a.i18n || {}, e === "auto") {
-				a.i18n.followComfyLanguage = !0, Ae(!0), Re(c), G(a), s("language");
+			if (n.i18n = n.i18n || {}, e === "auto") {
+				n.i18n.followComfyLanguage = !0, je(!0), ze(i), G(n), r("language");
 				return;
 			}
-			E.includes(e) && (a.i18n.followComfyLanguage = !1, Ae(!1), je(e), G(a), s("language"));
+			te.includes(e) && (n.i18n.followComfyLanguage = !1, je(!1), Me(e), G(n), r("language"));
 		}
 	}), e({
 		id: `${J}.ProbeBackend.Mode`,
-		category: l(O("cat.advanced"), O("setting.probe.mode.name").replace("Majoor: ", "")),
+		category: a(O("cat.advanced"), O("setting.probe.mode.name").replace("Majoor: ", "")),
 		name: O("setting.probe.mode.name"),
 		tooltip: O("setting.probe.mode.desc") + " (env: MAJOOR_MEDIA_PROBE_BACKEND)",
 		type: "combo",
-		defaultValue: a.probeBackend?.mode || W.probeBackend.mode,
+		defaultValue: n.probeBackend?.mode || W.probeBackend.mode,
 		options: [
 			"auto",
 			"exiftool",
@@ -1755,213 +1773,213 @@ function Ln(e, a, s, c) {
 			"both"
 		],
 		onChange: (e) => {
-			let t = Pt(e, [
+			let i = Ft(e, [
 				"auto",
 				"exiftool",
 				"ffprobe",
 				"both"
 			], W.probeBackend.mode);
-			a.probeBackend = a.probeBackend || {}, a.probeBackend.mode = t, G(a), K(a), s("probeBackend.mode"), pe(t).catch(() => {});
+			n.probeBackend = n.probeBackend || {}, n.probeBackend.mode = i, G(n), K(n), r("probeBackend.mode"), t(i).catch(() => {});
 		}
 	}), e({
 		id: `${J}.MetadataFallback.Image`,
-		category: l(O("cat.advanced"), "Metadata"),
+		category: a(O("cat.advanced"), "Metadata"),
 		name: "Majoor: Metadata Fallback (Images)",
 		tooltip: "Enable Pillow fallback when ExifTool is missing or fails.",
 		type: "boolean",
-		defaultValue: a.metadataFallback?.image ?? W.metadataFallback.image,
+		defaultValue: n.metadataFallback?.image ?? W.metadataFallback.image,
 		onChange: async (e) => {
-			let t = !!e, n = !!(a.metadataFallback?.image ?? W.metadataFallback.image);
-			a.metadataFallback = a.metadataFallback || {}, a.metadataFallback.image = t, G(a), s("metadataFallback.image");
+			let t = !!e, i = !!(n.metadataFallback?.image ?? W.metadataFallback.image);
+			n.metadataFallback = n.metadataFallback || {}, n.metadataFallback.image = t, G(n), r("metadataFallback.image");
 			try {
-				let e = await i({
+				let e = await p({
 					image: t,
-					media: a.metadataFallback?.media ?? W.metadataFallback.media
+					media: n.metadataFallback?.media ?? W.metadataFallback.media
 				});
 				if (!e?.ok) throw Error(e?.error || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"));
 			} catch (e) {
-				a.metadataFallback.image = n, G(a), s("metadataFallback.image"), T(e?.message || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"), "error");
+				n.metadataFallback.image = i, G(n), r("metadataFallback.image"), E(e?.message || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"), "error");
 			}
 		}
 	}), e({
 		id: `${J}.MetadataFallback.Media`,
-		category: l(O("cat.advanced"), "Metadata"),
+		category: a(O("cat.advanced"), "Metadata"),
 		name: "Majoor: Metadata Fallback (Audio/Video)",
 		tooltip: "Enable hachoir fallback when ffprobe is missing or fails.",
 		type: "boolean",
-		defaultValue: a.metadataFallback?.media ?? W.metadataFallback.media,
+		defaultValue: n.metadataFallback?.media ?? W.metadataFallback.media,
 		onChange: async (e) => {
-			let t = !!e, n = !!(a.metadataFallback?.media ?? W.metadataFallback.media);
-			a.metadataFallback = a.metadataFallback || {}, a.metadataFallback.media = t, G(a), s("metadataFallback.media");
+			let t = !!e, i = !!(n.metadataFallback?.media ?? W.metadataFallback.media);
+			n.metadataFallback = n.metadataFallback || {}, n.metadataFallback.media = t, G(n), r("metadataFallback.media");
 			try {
-				let e = await i({
-					image: a.metadataFallback?.image ?? W.metadataFallback.image,
+				let e = await p({
+					image: n.metadataFallback?.image ?? W.metadataFallback.image,
 					media: t
 				});
 				if (!e?.ok) throw Error(e?.error || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"));
 			} catch (e) {
-				a.metadataFallback.media = n, G(a), s("metadataFallback.media"), T(e?.message || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"), "error");
+				n.metadataFallback.media = i, G(n), r("metadataFallback.media"), E(e?.message || O("toast.failedUpdateMetadataFallback", "Failed to update metadata fallback settings"), "error");
 			}
 		}
 	});
 	try {
-		se().then((e) => {
+		ce().then((e) => {
 			if (!e?.ok || !e?.data?.prefs) return;
-			let t = e.data.prefs || {}, n = !!(t.image ?? W.metadataFallback.image), r = !!(t.media ?? W.metadataFallback.media);
-			a.metadataFallback = a.metadataFallback || {};
-			let i = !1;
-			a.metadataFallback.image !== n && (a.metadataFallback.image = n, i = !0), a.metadataFallback.media !== r && (a.metadataFallback.media = r, i = !0), i && (G(a), s("metadataFallback"));
+			let t = e.data.prefs || {}, i = !!(t.image ?? W.metadataFallback.image), a = !!(t.media ?? W.metadataFallback.media);
+			n.metadataFallback = n.metadataFallback || {};
+			let o = !1;
+			n.metadataFallback.image !== i && (n.metadataFallback.image = i, o = !0), n.metadataFallback.media !== a && (n.metadataFallback.media = a, o = !0), o && (G(n), r("metadataFallback"));
 		}).catch(() => {});
 	} catch (e) {
 		console.debug?.(e);
 	}
 	e({
 		id: `${J}.Db.Timeout`,
-		category: l(O("cat.advanced"), "Database"),
+		category: a(O("cat.advanced"), "Database"),
 		name: "DB Timeout (ms)",
 		tooltip: "Client-side DB timeout preference (stored locally).",
 		type: "number",
-		defaultValue: Number(a.db?.timeoutMs || 5e3),
+		defaultValue: Number(n.db?.timeoutMs || 5e3),
 		attrs: {
 			min: 1e3,
 			max: 3e4,
 			step: 1e3
 		},
 		onChange: (e) => {
-			a.db = a.db || {}, a.db.timeoutMs = Math.max(1e3, Math.min(3e4, Math.round(U(e, 5e3)))), G(a), K(a), s("db.timeoutMs");
+			n.db = n.db || {}, n.db.timeoutMs = Math.max(1e3, Math.min(3e4, Math.round(U(e, 5e3)))), G(n), K(n), r("db.timeoutMs");
 		}
 	}), e({
 		id: `${J}.Db.MaxConnections`,
-		category: l(O("cat.advanced"), "Database"),
+		category: a(O("cat.advanced"), "Database"),
 		name: "DB Max Connections",
 		tooltip: "Client-side DB max connections preference (stored locally).",
 		type: "number",
-		defaultValue: Number(a.db?.maxConnections || 10),
+		defaultValue: Number(n.db?.maxConnections || 10),
 		attrs: {
 			min: 1,
 			max: 100,
 			step: 1
 		},
 		onChange: (e) => {
-			a.db = a.db || {}, a.db.maxConnections = Math.max(1, Math.min(100, Math.round(U(e, 10)))), G(a), K(a), s("db.maxConnections");
+			n.db = n.db || {}, n.db.maxConnections = Math.max(1, Math.min(100, Math.round(U(e, 10)))), G(n), K(n), r("db.maxConnections");
 		}
 	}), e({
 		id: `${J}.Db.QueryTimeout`,
-		category: l(O("cat.advanced"), "Database"),
+		category: a(O("cat.advanced"), "Database"),
 		name: "DB Query Timeout (ms)",
 		tooltip: "Client-side DB query timeout preference (stored locally).",
 		type: "number",
-		defaultValue: Number(a.db?.queryTimeoutMs || 1e3),
+		defaultValue: Number(n.db?.queryTimeoutMs || 1e3),
 		attrs: {
 			min: 500,
 			max: 1e4,
 			step: 500
 		},
 		onChange: (e) => {
-			a.db = a.db || {}, a.db.queryTimeoutMs = Math.max(500, Math.min(1e4, Math.round(U(e, 1e3)))), G(a), K(a), s("db.queryTimeoutMs");
+			n.db = n.db || {}, n.db.queryTimeoutMs = Math.max(500, Math.min(1e4, Math.round(U(e, 1e3)))), G(n), K(n), r("db.queryTimeoutMs");
 		}
 	}), e({
 		id: `${J}.Observability.Enabled`,
-		category: l(O("cat.advanced"), O("setting.obs.enabled.name").replace("Majoor: ", "")),
+		category: a(O("cat.advanced"), O("setting.obs.enabled.name").replace("Majoor: ", "")),
 		name: O("setting.obs.enabled.name"),
 		tooltip: O("setting.obs.enabled.desc"),
 		type: "boolean",
-		defaultValue: !!a.observability?.enabled,
+		defaultValue: !!n.observability?.enabled,
 		onChange: (e) => {
-			a.observability = a.observability || {}, a.observability.enabled = !!e, G(a), K(a), s("observability.enabled");
+			n.observability = n.observability || {}, n.observability.enabled = !!e, G(n), K(n), r("observability.enabled");
 		}
 	}), e({
 		id: `${J}.Observability.RuntimeDashboardMode`,
-		category: l(O("cat.advanced"), "Runtime metrics badge"),
+		category: a(O("cat.advanced"), "Runtime metrics badge"),
 		name: "Majoor: Runtime metrics badge",
 		tooltip: "Controls the small DB/enrichment/watcher metrics badge in the Assets Manager panel.",
 		type: "combo",
-		defaultValue: a.observability?.runtimeDashboardMode || W.observability.runtimeDashboardMode,
+		defaultValue: n.observability?.runtimeDashboardMode || W.observability.runtimeDashboardMode,
 		options: [
 			"autoHide30",
 			"always",
 			"hidden"
 		],
 		onChange: (e) => {
-			let t = Pt(e, [
+			let t = Ft(e, [
 				"autoHide30",
 				"always",
 				"hidden"
 			], W.observability.runtimeDashboardMode);
-			a.observability = a.observability || {}, a.observability.runtimeDashboardMode = t, G(a), s("observability.runtimeDashboardMode");
+			n.observability = n.observability || {}, n.observability.runtimeDashboardMode = t, G(n), r("observability.runtimeDashboardMode");
 		}
 	}), e({
 		id: `${J}.Observability.VerboseErrors`,
-		category: l(O("cat.advanced"), "Verbose error logging"),
+		category: a(O("cat.advanced"), "Verbose error logging"),
 		name: "Verbose error logging",
 		tooltip: "Show detailed error messages in toasts and console. Useful for debugging.",
 		type: "boolean",
-		defaultValue: !!a.observability?.verboseErrors,
+		defaultValue: !!n.observability?.verboseErrors,
 		onChange: (e) => {
-			a.observability = a.observability || {}, a.observability.verboseErrors = !!e, G(a), K(a), s("observability.verboseErrors");
+			n.observability = n.observability || {}, n.observability.verboseErrors = !!e, G(n), K(n), r("observability.verboseErrors");
 		}
 	}), e({
 		id: `${J}.Observability.VerboseRouteRegistrationLogs`,
-		category: l(O("cat.advanced"), "Logs"),
+		category: a(O("cat.advanced"), "Logs"),
 		name: "Majoor: Verbose route registration logs",
 		tooltip: "When disabled, Majoor prints a compact startup summary instead of listing every registered API route. Takes effect on the next backend restart.",
 		type: "boolean",
-		defaultValue: !!(a.observability?.verboseRouteRegistrationLogs ?? W.observability?.verboseRouteRegistrationLogs ?? !1),
+		defaultValue: !!(n.observability?.verboseRouteRegistrationLogs ?? W.observability?.verboseRouteRegistrationLogs ?? !1),
 		onChange: async (e) => {
-			let n = !!e, r = !!(a.observability?.verboseRouteRegistrationLogs ?? W.observability?.verboseRouteRegistrationLogs ?? !1);
-			a.observability = a.observability || {}, a.observability.verboseRouteRegistrationLogs = n, G(a), s("observability.verboseRouteRegistrationLogs");
+			let t = !!e, i = !!(n.observability?.verboseRouteRegistrationLogs ?? W.observability?.verboseRouteRegistrationLogs ?? !1);
+			n.observability = n.observability || {}, n.observability.verboseRouteRegistrationLogs = t, G(n), r("observability.verboseRouteRegistrationLogs");
 			try {
-				let e = await t(n);
+				let e = await de(t);
 				if (!e?.ok) throw Error(e?.error || "Failed to update route logging settings");
 			} catch (e) {
-				a.observability.verboseRouteRegistrationLogs = r, G(a), s("observability.verboseRouteRegistrationLogs"), T(e?.message || "Failed to update route logging settings", "error");
+				n.observability.verboseRouteRegistrationLogs = i, G(n), r("observability.verboseRouteRegistrationLogs"), E(e?.message || "Failed to update route logging settings", "error");
 			}
 		}
 	}), (async () => {
 		try {
-			let e = !!(await he())?.data?.prefs?.enabled;
-			a.observability = a.observability || {}, a.observability.verboseRouteRegistrationLogs !== e && (a.observability.verboseRouteRegistrationLogs = e, G(a), s("observability.verboseRouteRegistrationLogs"));
+			let e = !!(await me())?.data?.prefs?.enabled;
+			n.observability = n.observability || {}, n.observability.verboseRouteRegistrationLogs !== e && (n.observability.verboseRouteRegistrationLogs = e, G(n), r("observability.verboseRouteRegistrationLogs"));
 		} catch (e) {
 			console.debug?.(e);
 		}
 	})(), e({
 		id: `${J}.Observability.VerboseStartupLogs`,
-		category: l(O("cat.advanced"), "Logs"),
+		category: a(O("cat.advanced"), "Logs"),
 		name: "Majoor: Verbose startup logs",
 		tooltip: "When disabled, Majoor suppresses most informational bootstrap logs during backend startup while keeping warnings and errors. Takes effect on the next backend restart.",
 		type: "boolean",
-		defaultValue: !!(a.observability?.verboseStartupLogs ?? W.observability?.verboseStartupLogs ?? !1),
+		defaultValue: !!(n.observability?.verboseStartupLogs ?? W.observability?.verboseStartupLogs ?? !1),
 		onChange: async (e) => {
-			let t = !!e, n = !!(a.observability?.verboseStartupLogs ?? W.observability?.verboseStartupLogs ?? !1);
-			a.observability = a.observability || {}, a.observability.verboseStartupLogs = t, G(a), s("observability.verboseStartupLogs");
+			let t = !!e, i = !!(n.observability?.verboseStartupLogs ?? W.observability?.verboseStartupLogs ?? !1);
+			n.observability = n.observability || {}, n.observability.verboseStartupLogs = t, G(n), r("observability.verboseStartupLogs");
 			try {
-				let e = await p(t);
+				let e = await d(t);
 				if (!e?.ok) throw Error(e?.error || "Failed to update startup logging settings");
 			} catch (e) {
-				a.observability.verboseStartupLogs = n, G(a), s("observability.verboseStartupLogs"), T(e?.message || "Failed to update startup logging settings", "error");
+				n.observability.verboseStartupLogs = i, G(n), r("observability.verboseStartupLogs"), E(e?.message || "Failed to update startup logging settings", "error");
 			}
 		}
 	}), (async () => {
 		try {
-			let e = !!(await ae())?.data?.prefs?.enabled;
-			a.observability = a.observability || {}, a.observability.verboseStartupLogs !== e && (a.observability.verboseStartupLogs = e, G(a), s("observability.verboseStartupLogs"));
+			let e = !!(await oe())?.data?.prefs?.enabled;
+			n.observability = n.observability || {}, n.observability.verboseStartupLogs !== e && (n.observability.verboseStartupLogs = e, G(n), r("observability.verboseStartupLogs"));
 		} catch (e) {
 			console.debug?.(e);
 		}
 	})();
 	{
-		let t = "HuggingFace Token", n = "", i = null, o = 0, c = !!a.ai?.huggingFaceTokenVisible, d = () => {
+		let t = "HuggingFace Token", i = "", o = null, s = 0, l = !!n.ai?.huggingFaceTokenVisible, u = () => {
 			try {
 				let e = Array.from(document.querySelectorAll("input[data-mjr-hf-token=\"1\"]"));
 				for (let t of e) try {
-					t.type = c ? "text" : "password";
+					t.type = l ? "text" : "password";
 				} catch (e) {
 					console.debug?.(e);
 				}
 			} catch (e) {
 				console.debug?.(e);
 			}
-		}, f = (e) => {
+		}, d = (e) => {
 			try {
 				let t = String(e || "").trim();
 				if (!t) return;
@@ -1977,18 +1995,18 @@ function Ln(e, a, s, c) {
 		};
 		e({
 			id: `${J}.AI.HuggingFaceTokenVisible`,
-			category: l(O("cat.advanced"), t),
+			category: a(O("cat.advanced"), t),
 			name: "Show HuggingFace token",
 			tooltip: "Show or hide the HuggingFace token while editing.",
 			type: "boolean",
-			defaultValue: c,
+			defaultValue: l,
 			onChange: (e) => {
 				let t = !!e;
-				c = t, a.ai = a.ai || {}, a.ai.huggingFaceTokenVisible = t, G(a), s("ai.huggingFaceTokenVisible"), setTimeout(d, 0);
+				l = t, n.ai = n.ai || {}, n.ai.huggingFaceTokenVisible = t, G(n), r("ai.huggingFaceTokenVisible"), setTimeout(u, 0);
 			}
 		}), e({
 			id: `${J}.AI.HuggingFaceToken`,
-			category: l(O("cat.advanced"), t),
+			category: a(O("cat.advanced"), t),
 			name: "HuggingFace Token",
 			tooltip: [
 				"Optional token for HuggingFace Hub downloads (higher rate limits).",
@@ -1999,62 +2017,62 @@ function Ln(e, a, s, c) {
 			defaultValue: "",
 			attrs: {
 				placeholder: "Paste HuggingFace token (hf_...)",
-				type: c ? "text" : "password",
+				type: l ? "text" : "password",
 				autocomplete: "new-password",
 				name: "mjr_huggingface_token",
 				"data-mjr-hf-token": "1"
 			},
 			onChange: (e) => {
 				let t = String(e || "").trim();
-				if (t !== n) {
+				if (t !== i) {
 					try {
-						i &&= (clearTimeout(i), null);
+						o &&= (clearTimeout(o), null);
 					} catch (e) {
 						console.debug?.(e);
 					}
-					i = setTimeout(async () => {
-						i = null;
-						let e = ++o;
+					o = setTimeout(async () => {
+						o = null;
+						let e = ++s;
 						try {
-							let i = await r(t);
-							if (e !== o) return;
-							if (!i?.ok) throw Error(i?.error || "Failed to update HuggingFace token");
-							n = t, s("ai.huggingFaceToken"), t ? T("HuggingFace token saved", "success") : T("HuggingFace token cleared", "success", void 0, { noHistory: !0 });
+							let n = await Ce(t);
+							if (e !== s) return;
+							if (!n?.ok) throw Error(n?.error || "Failed to update HuggingFace token");
+							i = t, r("ai.huggingFaceToken"), t ? E("HuggingFace token saved", "success") : E("HuggingFace token cleared", "success", void 0, { noHistory: !0 });
 						} catch (t) {
-							if (e !== o) return;
-							T(t?.message || "Failed to update HuggingFace token", "error");
+							if (e !== s) return;
+							E(t?.message || "Failed to update HuggingFace token", "error");
 						}
 					}, 900);
 				}
 			}
-		}), setTimeout(d, 0), (async () => {
+		}), setTimeout(u, 0), (async () => {
 			try {
 				let e = (await w())?.data?.prefs || {}, t = !!e?.has_token, n = String(e?.token_hint || "").trim();
-				f(t ? `Configured ${n || "(saved)"}` : "Paste HuggingFace token (hf_...)");
+				d(t ? `Configured ${n || "(saved)"}` : "Paste HuggingFace token (hf_...)");
 			} catch (e) {
 				console.debug?.(e);
 			}
 		})(), e({
 			id: `${J}.AI.VerboseLogs`,
-			category: l(O("cat.advanced"), t),
+			category: a(O("cat.advanced"), t),
 			name: "Majoor: Verbose AI logs",
 			tooltip: "Enable detailed HuggingFace/SigLIP2/X-CLIP logs and progress bars during model download/loading.",
 			type: "boolean",
-			defaultValue: !!(a.ai?.verboseAiLogs ?? W.ai?.verboseAiLogs ?? !1),
+			defaultValue: !!(n.ai?.verboseAiLogs ?? W.ai?.verboseAiLogs ?? !1),
 			onChange: async (e) => {
-				let t = !!e, n = !!(a.ai?.verboseAiLogs ?? W.ai?.verboseAiLogs ?? !1);
-				a.ai = a.ai || {}, a.ai.verboseAiLogs = t, G(a), s("ai.verboseAiLogs");
+				let t = !!e, i = !!(n.ai?.verboseAiLogs ?? W.ai?.verboseAiLogs ?? !1);
+				n.ai = n.ai || {}, n.ai.verboseAiLogs = t, G(n), r("ai.verboseAiLogs");
 				try {
-					let e = await Ce(t);
+					let e = await we(t);
 					if (!e?.ok) throw Error(e?.error || "Failed to update AI logging settings");
 				} catch (e) {
-					a.ai.verboseAiLogs = n, G(a), s("ai.verboseAiLogs"), T(e?.message || "Failed to update AI logging settings", "error");
+					n.ai.verboseAiLogs = i, G(n), r("ai.verboseAiLogs"), E(e?.message || "Failed to update AI logging settings", "error");
 				}
 			}
 		}), (async () => {
 			try {
-				let e = !!(await u())?.data?.prefs?.enabled;
-				a.ai = a.ai || {}, a.ai.verboseAiLogs !== e && (a.ai.verboseAiLogs = e, G(a), s("ai.verboseAiLogs"));
+				let e = !!(await c())?.data?.prefs?.enabled;
+				n.ai = n.ai || {}, n.ai.verboseAiLogs !== e && (n.ai.verboseAiLogs = e, G(n), r("ai.verboseAiLogs"));
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -2062,21 +2080,21 @@ function Ln(e, a, s, c) {
 	}
 	e({
 		id: `${J}.AI.VectorStats`,
-		category: l(O("cat.advanced"), "AI / Vector Search"),
+		category: a(O("cat.advanced"), "AI / Vector Search"),
 		name: "Vector Index Status",
 		tooltip: "Current status of the SigLIP2/X-CLIP vector index used for semantic search",
 		type: "text",
 		defaultValue: "Loading vector status..."
 	}), (async () => {
 		try {
-			let e = await d();
+			let e = await _e();
 			e?.ok ? console.debug?.("[Majoor] Vector status:", `${e.data?.total || 0} assets indexed | Model: ${e.data?.model || "N/A"}`) : console.debug?.("[Majoor] Vector status unavailable");
 		} catch (e) {
 			console.debug?.("[Majoor] Vector status fetch failed", e);
 		}
 	})(), e({
 		id: `${J}.AI.VectorBackfillAction`,
-		category: l(O("cat.advanced"), "AI / Vector Search"),
+		category: a(O("cat.advanced"), "AI / Vector Search"),
 		name: "Vector Index Action",
 		tooltip: [
 			"Compute CLIP embeddings for all assets that don't have them yet.",
@@ -2100,14 +2118,14 @@ function Ln(e, a, s, c) {
 				forceStore: !0
 			} };
 			try {
-				T(O("toast.vectorBackfillStarting", "Starting vector backfill... This may take a while."), "info", void 0, { history: {
+				E(O("toast.vectorBackfillStarting", "Starting vector backfill... This may take a while."), "info", void 0, { history: {
 					...t.history,
 					status: "started",
 					detail: "Starting vector backfill... This may take a while."
 				} });
-				let e = await n(64, { onProgress: (e) => {
+				let e = await ee(64, { onProgress: (e) => {
 					let n = String(e?.status || "running").toLowerCase() || "running", r = e?.progress || e?.result || {}, i = Number(r?.candidates ?? r?.processed ?? 0), a = Number(r?.indexed ?? 0), o = Number(r?.skipped ?? 0), s = Number(r?.errors ?? 0), c = Math.max(i, a + o + s), l = c > 0 ? Math.round((a + o + s) / c * 100) : null, u = n === "queued" ? "Vector backfill queued" : `Candidates ${i}, indexed ${a}, skipped ${o}, errors ${s}`;
-					D({
+					g({
 						summary: "Vector Backfill",
 						detail: u
 					}, n === "failed" ? "error" : n === "succeeded" ? "success" : "info", 0, { history: {
@@ -2133,7 +2151,7 @@ function Ln(e, a, s, c) {
 					].includes(r), a = n?.progress || {}, o = Number(n?.processed ?? a?.candidates ?? 0), s = Number(n?.indexed ?? a?.indexed ?? 0), c = Number(n?.skipped ?? a?.skipped ?? 0);
 					if (i) {
 						let e = String(n?.job_id || "").trim();
-						T(O("toast.vectorBackfillRunning", "Vector backfill still running in background{job}.", { job: e ? ` (job ${e.slice(0, 8)})` : "" }), "info", void 0, { history: {
+						E(O("toast.vectorBackfillRunning", "Vector backfill still running in background{job}.", { job: e ? ` (job ${e.slice(0, 8)})` : "" }), "info", void 0, { history: {
 							...t.history,
 							status: "running",
 							detail: `Vector backfill still running in background${e ? ` (${e.slice(0, 8)})` : ""}.`,
@@ -2146,7 +2164,7 @@ function Ln(e, a, s, c) {
 								label: "running"
 							}
 						} });
-					} else T(O("toast.vectorBackfillComplete", "Vector backfill complete! Processed: {processed}, Indexed: {indexed}, Skipped: {skipped}", {
+					} else E(O("toast.vectorBackfillComplete", "Vector backfill complete! Processed: {processed}, Indexed: {indexed}, Skipped: {skipped}", {
 						processed: o,
 						indexed: s,
 						skipped: c
@@ -2164,7 +2182,7 @@ function Ln(e, a, s, c) {
 						}
 					} });
 					try {
-						let e = await d();
+						let e = await _e();
 						e?.ok && console.debug?.("[Majoor] Vector stats after backfill:", e.data);
 					} catch (e) {
 						console.debug?.("[Majoor] Failed to refresh vector stats:", e);
@@ -2172,7 +2190,7 @@ function Ln(e, a, s, c) {
 				} else throw Error(e?.error || O("toast.vectorBackfillFailedGeneric", "Backfill failed"));
 			} catch (e) {
 				let n = e?.message || String(e || O("status.unknown", "unknown"));
-				T(O("toast.vectorBackfillFailedDetail", "Vector backfill failed: {error}", { error: n }), "error", void 0, { history: {
+				E(O("toast.vectorBackfillFailedDetail", "Vector backfill failed: {error}", { error: n }), "error", void 0, { history: {
 					...t.history,
 					status: "failed",
 					detail: n
@@ -2183,15 +2201,15 @@ function Ln(e, a, s, c) {
 }
 //#endregion
 //#region ui/app/settings/settingsSearch.ts
-var Rn = "Majoor", zn = "Majoor Assets Manager";
-function Bn(e, t, n) {
+var zn = "Majoor", Bn = "Majoor Assets Manager";
+function Vn(e, t, n) {
 	let r = (e, t) => [
-		zn,
+		Bn,
 		e,
 		t
 	];
 	e({
-		id: `${Rn}.AI.VectorSearchEnabled`,
+		id: `${zn}.AI.VectorSearchEnabled`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.enabled.name", "Enable AI semantic search"),
 		tooltip: O("setting.ai.vector.enabled.desc", "Enable/disable AI vector search features (SigLIP2/X-CLIP: description search, prompt alignment, AI tag suggestions, smart collections)."),
@@ -2202,18 +2220,18 @@ function Bn(e, t, n) {
 			let r = !!(t.ai.vectorSearchEnabled ?? !0), i = !!e;
 			t.ai.vectorSearchEnabled = i, G(t), K(t), n("ai.vectorSearchEnabled");
 			try {
-				let e = await h(i);
+				let e = await m(i);
 				if (!e?.ok) {
-					t.ai.vectorSearchEnabled = r, G(t), K(t), n("ai.vectorSearchEnabled"), T(e?.error || "Failed to update AI vector search setting", "error");
+					t.ai.vectorSearchEnabled = r, G(t), K(t), n("ai.vectorSearchEnabled"), E(e?.error || "Failed to update AI vector search setting", "error");
 					return;
 				}
-				T(i ? "AI semantic search enabled" : "AI semantic search disabled", "info", 2200);
+				E(i ? "AI semantic search enabled" : "AI semantic search disabled", "info", 2200);
 			} catch (e) {
-				t.ai.vectorSearchEnabled = r, G(t), K(t), n("ai.vectorSearchEnabled"), T(e?.message || "Failed to update AI vector search setting", "error");
+				t.ai.vectorSearchEnabled = r, G(t), K(t), n("ai.vectorSearchEnabled"), E(e?.message || "Failed to update AI vector search setting", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.AI.VectorCaptionOnIndex`,
+		id: `${zn}.AI.VectorCaptionOnIndex`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.captionOnIndex.name", "Generate AI captions during indexing"),
 		tooltip: O("setting.ai.vector.captionOnIndex.desc", "Allow automatic vector indexing and backfill to run Florence-2 captions for image assets. This is slower and can use significant VRAM/CPU; leave it off for faster grid startup."),
@@ -2224,18 +2242,18 @@ function Bn(e, t, n) {
 			let r = !!(t.ai.vectorCaptionOnIndex ?? !1), i = !!e;
 			t.ai.vectorCaptionOnIndex = i, G(t), K(t), n("ai.vectorCaptionOnIndex");
 			try {
-				let e = await h({ caption_on_index: i });
+				let e = await m({ caption_on_index: i });
 				if (!e?.ok) {
-					t.ai.vectorCaptionOnIndex = r, G(t), K(t), n("ai.vectorCaptionOnIndex"), T(e?.error || "Failed to update AI caption indexing setting", "error");
+					t.ai.vectorCaptionOnIndex = r, G(t), K(t), n("ai.vectorCaptionOnIndex"), E(e?.error || "Failed to update AI caption indexing setting", "error");
 					return;
 				}
-				i && T("AI captions during indexing enabled", "info", 2600);
+				i && E("AI captions during indexing enabled", "info", 2600);
 			} catch (e) {
-				t.ai.vectorCaptionOnIndex = r, G(t), K(t), n("ai.vectorCaptionOnIndex"), T(e?.message || "Failed to update AI caption indexing setting", "error");
+				t.ai.vectorCaptionOnIndex = r, G(t), K(t), n("ai.vectorCaptionOnIndex"), E(e?.message || "Failed to update AI caption indexing setting", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.AI.VectorIndexOnScan`,
+		id: `${zn}.AI.VectorIndexOnScan`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.indexOnScan.name", "Index vectors during scans"),
 		tooltip: O("setting.ai.vector.indexOnScan.desc", "Compute SigLIP/X-CLIP embeddings while assets are scanned. Disable to avoid surprise VRAM use; run vector backfill manually when needed."),
@@ -2246,18 +2264,18 @@ function Bn(e, t, n) {
 			let r = !!(t.ai.vectorIndexOnScan ?? !1), i = !!e;
 			t.ai.vectorIndexOnScan = i, G(t), K(t), n("ai.vectorIndexOnScan");
 			try {
-				let e = await h({ index_on_scan: i });
+				let e = await m({ index_on_scan: i });
 				if (!e?.ok) {
-					t.ai.vectorIndexOnScan = r, G(t), K(t), n("ai.vectorIndexOnScan"), T(e?.error || "Failed to update vector scan indexing", "error");
+					t.ai.vectorIndexOnScan = r, G(t), K(t), n("ai.vectorIndexOnScan"), E(e?.error || "Failed to update vector scan indexing", "error");
 					return;
 				}
-				T(i ? "Vector indexing during scans enabled" : "Vector indexing during scans disabled", "info", 2400);
+				E(i ? "Vector indexing during scans enabled" : "Vector indexing during scans disabled", "info", 2400);
 			} catch (e) {
-				t.ai.vectorIndexOnScan = r, G(t), K(t), n("ai.vectorIndexOnScan"), T(e?.message || "Failed to update vector scan indexing", "error");
+				t.ai.vectorIndexOnScan = r, G(t), K(t), n("ai.vectorIndexOnScan"), E(e?.message || "Failed to update vector scan indexing", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.AI.VectorConcurrency`,
+		id: `${zn}.AI.VectorConcurrency`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.concurrency.name", "Vector indexing concurrency"),
 		tooltip: O("setting.ai.vector.concurrency.desc", "Maximum concurrent vector embedding workers. Use 1 to minimize transient VRAM spikes."),
@@ -2273,14 +2291,14 @@ function Bn(e, t, n) {
 			let r = Number(t.ai.vectorConcurrency || 1), i = Math.max(1, Math.min(16, Math.floor(Number(e) || 1)));
 			t.ai.vectorConcurrency = i, G(t), K(t), n("ai.vectorConcurrency");
 			try {
-				let e = await h({ concurrency: i });
-				e?.ok || (t.ai.vectorConcurrency = r, G(t), K(t), n("ai.vectorConcurrency"), T(e?.error || "Failed to update vector concurrency", "error"));
+				let e = await m({ concurrency: i });
+				e?.ok || (t.ai.vectorConcurrency = r, G(t), K(t), n("ai.vectorConcurrency"), E(e?.error || "Failed to update vector concurrency", "error"));
 			} catch (e) {
-				t.ai.vectorConcurrency = r, G(t), K(t), n("ai.vectorConcurrency"), T(e?.message || "Failed to update vector concurrency", "error");
+				t.ai.vectorConcurrency = r, G(t), K(t), n("ai.vectorConcurrency"), E(e?.message || "Failed to update vector concurrency", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.AI.VectorUnloadAfterUse`,
+		id: `${zn}.AI.VectorUnloadAfterUse`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.unloadAfterUse.name", "Unload AI models after use"),
 		tooltip: O("setting.ai.vector.unloadAfterUse.desc", "Unload Majoor SigLIP/X-CLIP/Florence models after heavy AI actions and call torch CUDA cache cleanup. This frees VRAM but makes the next AI action slower."),
@@ -2291,18 +2309,18 @@ function Bn(e, t, n) {
 			let r = !!(t.ai.vectorUnloadAfterUse ?? !1), i = !!e;
 			t.ai.vectorUnloadAfterUse = i, G(t), K(t), n("ai.vectorUnloadAfterUse");
 			try {
-				let e = await h({ unload_after_use: i });
+				let e = await m({ unload_after_use: i });
 				if (!e?.ok) {
-					t.ai.vectorUnloadAfterUse = r, G(t), K(t), n("ai.vectorUnloadAfterUse"), T(e?.error || "Failed to update model unload setting", "error");
+					t.ai.vectorUnloadAfterUse = r, G(t), K(t), n("ai.vectorUnloadAfterUse"), E(e?.error || "Failed to update model unload setting", "error");
 					return;
 				}
-				T(i ? "AI model unload after use enabled" : "AI model unload after use disabled", "info", 2400);
+				E(i ? "AI model unload after use enabled" : "AI model unload after use disabled", "info", 2400);
 			} catch (e) {
-				t.ai.vectorUnloadAfterUse = r, G(t), K(t), n("ai.vectorUnloadAfterUse"), T(e?.message || "Failed to update model unload setting", "error");
+				t.ai.vectorUnloadAfterUse = r, G(t), K(t), n("ai.vectorUnloadAfterUse"), E(e?.message || "Failed to update model unload setting", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.AI.VectorUnloadNow`,
+		id: `${zn}.AI.VectorUnloadNow`,
 		category: r(O("cat.search", "Search"), "AI"),
 		name: O("setting.ai.vector.unloadNow.name", "Memory purge now"),
 		tooltip: O("setting.ai.vector.unloadNow.desc", "Immediately unload Majoor AI vector/caption models, ask ComfyUI to unload loaded models, and clear torch CUDA cache when idle."),
@@ -2311,14 +2329,14 @@ function Bn(e, t, n) {
 		defaultValue: "Idle",
 		onChange: async (e) => {
 			if (String(e || "") === "Unload now") try {
-				let e = await b();
-				T(e?.ok ? "Majoor AI model cache unloaded" : e?.error || "Failed to unload Majoor AI model cache", e?.ok ? "info" : "error", 2600);
+				let e = await Te();
+				E(e?.ok ? "Majoor AI model cache unloaded" : e?.error || "Failed to unload Majoor AI model cache", e?.ok ? "info" : "error", 2600);
 			} catch (e) {
-				T(e?.message || "Failed to unload Majoor AI model cache", "error");
+				E(e?.message || "Failed to unload Majoor AI model cache", "error");
 			}
 		}
 	}), e({
-		id: `${Rn}.Search.MaxResults`,
+		id: `${zn}.Search.MaxResults`,
 		category: r(O("cat.search", "Search")),
 		name: O("setting.search.maxResults.name", "Max search results (client)"),
 		tooltip: O("setting.search.maxResults.desc", "Maximum number of results requested per search. The backend still enforces MAJOOR_SEARCH_MAX_LIMIT; increase that env var if you need a higher hard cap."),
@@ -2333,7 +2351,7 @@ function Bn(e, t, n) {
 			t.search = t.search || {}, t.search.maxResults = Math.max(10, Math.min(A.MAX_PAGE_SIZE || 2e3, Number(e) || A.SEARCH_DEFAULT_LIMIT)), G(t), K(t), n("search.maxResults");
 		}
 	}), e({
-		id: `${Rn}.EnvVars.Reference`,
+		id: `${zn}.EnvVars.Reference`,
 		category: r(O("cat.advanced"), "Environment variables"),
 		name: "Environment variables reference",
 		tooltip: [
@@ -2369,7 +2387,7 @@ function Bn(e, t, n) {
 }
 //#endregion
 //#region ui/app/settings/SettingsPanel.ts
-var Vn = "Majoor Assets Manager", Hn = /^\s*Majoor:\s*/i, Un = Object.freeze({
+var Hn = "Majoor Assets Manager", Un = /^\s*Majoor:\s*/i, Wn = Object.freeze({
 	ASSETS_PANEL: "Assets Panel",
 	GENERATED_FEED: "Generated Feed",
 	VIEWER: "Viewer & Floating Viewer",
@@ -2378,7 +2396,7 @@ var Vn = "Majoor Assets Manager", Hn = /^\s*Majoor:\s*/i, Un = Object.freeze({
 	GENERAL: "General",
 	ADVANCED: "Advanced",
 	SECURITY: "Security"
-}), Wn = new Set([
+}), Gn = new Set([
 	"grid.starColor",
 	"grid.badgeImageColor",
 	"grid.badgeVideoColor",
@@ -2389,70 +2407,70 @@ var Vn = "Majoor Assets Manager", Hn = /^\s*Majoor:\s*/i, Un = Object.freeze({
 	"ui.cardSelectionColor",
 	"ui.ratingColor",
 	"ui.tagColor"
-]), Gn = "Majoor.General.ResetAllSettings", Kn = "mjr-settings-reset-btn", qn = null, Jn = null;
-function Yn(e) {
-	let t = String(e || "").trim();
-	return !t || t === Gn || t === "Majoor.Language" ? Un.GENERAL : /^Majoor\.(Safety|Security)\./.test(t) ? Un.SECURITY : /^Majoor\.(Paths|Db|ProbeBackend|MetadataFallback|Observability)\./.test(t) || t === "Majoor.EnvVars.Reference" ? Un.ADVANCED : /^Majoor\.(Viewer|WorkflowMinimap)\./.test(t) ? Un.VIEWER : /^Majoor\.Feed\./.test(t) ? Un.GENERATED_FEED : /^Majoor\.(AutoScan|Scan|Watcher|ExecutionGrouping|RatingTagsSync)\./.test(t) || t === "Majoor.RtHydrate.Concurrency" ? Un.INDEXING : /^Majoor\.AI\.(HuggingFaceTokenVisible|HuggingFaceToken|VerboseLogs|VectorStats|VectorBackfillAction|VectorSearchEnabled|VectorCaptionOnIndex|VectorIndexOnScan|VectorConcurrency|VectorUnloadAfterUse|VectorUnloadNow)$/.test(t) || /^Majoor\.Search\./.test(t) ? Un.SEARCH_AI : /^Majoor\.(Grid|Cards|Badges|Sidebar|InfiniteScroll|General)\./.test(t) ? Un.ASSETS_PANEL : Un.GENERAL;
-}
+]), Kn = "Majoor.General.ResetAllSettings", qn = "mjr-settings-reset-btn", Jn = null, Yn = null;
 function Xn(e) {
-	let t = Array.isArray(e?.category) ? e.category.filter(Boolean) : [], n = Yn(e?.id), r = String(t[1] || t[0] || "").trim(), i = String(t[2] || "").trim(), a = String(e?.name || "").replace(Hn, "").trim();
+	let t = String(e || "").trim();
+	return !t || t === Kn || t === "Majoor.Language" ? Wn.GENERAL : /^Majoor\.(Safety|Security)\./.test(t) ? Wn.SECURITY : /^Majoor\.(Paths|Db|ProbeBackend|MetadataFallback|Observability)\./.test(t) || t === "Majoor.EnvVars.Reference" ? Wn.ADVANCED : /^Majoor\.(Viewer|WorkflowMinimap)\./.test(t) ? Wn.VIEWER : /^Majoor\.Feed\./.test(t) ? Wn.GENERATED_FEED : /^Majoor\.(AutoScan|Scan|Watcher|ExecutionGrouping|RatingTagsSync)\./.test(t) || t === "Majoor.RtHydrate.Concurrency" ? Wn.INDEXING : /^Majoor\.AI\.(HuggingFaceTokenVisible|HuggingFaceToken|VerboseLogs|VectorStats|VectorBackfillAction|VectorSearchEnabled|VectorCaptionOnIndex|VectorIndexOnScan|VectorConcurrency|VectorUnloadAfterUse|VectorUnloadNow)$/.test(t) || /^Majoor\.Search\./.test(t) ? Wn.SEARCH_AI : /^Majoor\.(Grid|Cards|Badges|Sidebar|InfiniteScroll|General)\./.test(t) ? Wn.ASSETS_PANEL : Wn.GENERAL;
+}
+function Zn(e) {
+	let t = Array.isArray(e?.category) ? e.category.filter(Boolean) : [], n = Xn(e?.id), r = String(t[1] || t[0] || "").trim(), i = String(t[2] || "").trim(), a = String(e?.name || "").replace(Un, "").trim();
 	return [
-		Vn,
+		Hn,
 		n,
 		i || r || a || n
 	];
 }
-var Zn = !1, Qn = null, $n = null, er = !1, tr = /* @__PURE__ */ new Set();
-function nr(e) {
+var Qn = !1, $n = null, er = null, tr = !1, nr = /* @__PURE__ */ new Set();
+function rr(e) {
 	if (!e || typeof e != "object") return null;
 	let t = { ...e };
 	try {
-		typeof t.name == "string" && (t.name = t.name.replace(Hn, "").trim());
+		typeof t.name == "string" && (t.name = t.name.replace(Un, "").trim());
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		t.category = Xn(t);
+		t.category = Zn(t);
 	} catch {
-		t.category = [Vn, Un.GENERAL];
+		t.category = [Hn, Wn.GENERAL];
 	}
 	return !t.tooltip && typeof t.name == "string" && t.name.trim() && (t.tooltip = t.name.trim()), t;
 }
-function rr(e, t, n) {
+function ir(e, t, n) {
 	let r = String(t?.id || "").trim();
-	if (!r || tr.has(r)) return !1;
-	tr.add(r);
+	if (!r || nr.has(r)) return !1;
+	nr.add(r);
 	try {
-		return Ee(e, r, n);
+		return De(e, r, n);
 	} finally {
-		tr.delete(r);
+		nr.delete(r);
 	}
 }
-function ir(e, t) {
+function ar(e, t) {
 	if (!t || typeof t != "object") return t;
 	let n = { ...t };
-	rr(e, n, n.defaultValue);
+	ir(e, n, n.defaultValue);
 	let r = n.onChange;
 	return n.onChange = (t, ...i) => {
-		if (rr(e, n, t), typeof r == "function") return r(t, ...i);
+		if (ir(e, n, t), typeof r == "function") return r(t, ...i);
 		n.defaultValue = t;
 	}, n;
 }
-function ar(e) {
+function or(e) {
 	try {
 		return JSON.parse(JSON.stringify(e || {}));
 	} catch {
 		return { ...W };
 	}
 }
-function or(e, t, n, { wrapForComfy: r = !0 } = {}) {
+function sr(e, t, n, { wrapForComfy: r = !0 } = {}) {
 	let i = [], a = (e) => {
-		let n = nr(e);
-		n && i.push(r ? ir(t, n) : n);
+		let n = rr(e);
+		n && i.push(r ? ar(t, n) : n);
 	};
-	return sn(a, e, n), gn(a, e, n), un(a, e, n), pn(a, e, n), Fn(a, e, n), Ln(a, e, n, t), Bn(a, e, n), i;
+	return cn(a, e, n), _n(a, e, n), dn(a, e, n), mn(a, e, n), In(a, e, n), Rn(a, e, n, t), Vn(a, e, n), i;
 }
-function sr(e, t) {
+function cr(e, t) {
 	if (e === t) return !0;
 	try {
 		return JSON.stringify(e) === JSON.stringify(t);
@@ -2460,97 +2478,97 @@ function sr(e, t) {
 		return !1;
 	}
 }
-function cr(e) {
+function lr(e) {
 	return e ? e.querySelector(".form-input") || e.querySelector(".p-inputgroup") || e.querySelector(".setting-input") || e.querySelector("[class*='input']") : null;
 }
-function lr(e, t) {
+function ur(e, t) {
 	let n = document.createElement("button");
-	return n.type = "button", n.className = Kn, n.textContent = e, n.title = t, n.style.marginLeft = "8px", n.style.minWidth = e.length > 2 ? "auto" : "24px", n.style.height = "24px", n.style.padding = e.length > 2 ? "0 10px" : "0", n.style.borderRadius = "6px", n.style.border = "1px solid var(--border-color, #555)", n.style.background = "var(--comfy-input-bg, #2b2b2b)", n.style.color = "var(--input-text, inherit)", n.style.cursor = "pointer", n.style.fontSize = "12px", n.style.lineHeight = "22px", n.style.flexShrink = "0", n;
+	return n.type = "button", n.className = qn, n.textContent = e, n.title = t, n.style.marginLeft = "8px", n.style.minWidth = e.length > 2 ? "auto" : "24px", n.style.height = "24px", n.style.padding = e.length > 2 ? "0 10px" : "0", n.style.borderRadius = "6px", n.style.border = "1px solid var(--border-color, #555)", n.style.background = "var(--comfy-input-bg, #2b2b2b)", n.style.color = "var(--input-text, inherit)", n.style.cursor = "pointer", n.style.fontSize = "12px", n.style.lineHeight = "22px", n.style.flexShrink = "0", n;
 }
-function ur(e, t, n) {
-	String(e?.id || "").trim() && (rr(n, e, t), typeof e?.onChange == "function" && e.onChange(t));
+function dr(e, t, n) {
+	String(e?.id || "").trim() && (ir(n, e, t), typeof e?.onChange == "function" && e.onChange(t));
 }
-function dr(e, t, n, r) {
-	let i = !sr(De(r, t.id, t.defaultValue), n);
+function fr(e, t, n, r) {
+	let i = !cr(Oe(r, t.id, t.defaultValue), n);
 	e.disabled = !i, e.style.opacity = i ? "1" : "0.45";
 }
-function fr() {
-	if (typeof document > "u" || !Jn) return;
-	let { app: e, definitions: t, defaultValues: n } = Jn, r = document.querySelector(`[data-setting-id="${Gn}"]`), i = cr(r);
+function pr() {
+	if (typeof document > "u" || !Yn) return;
+	let { app: e, definitions: t, defaultValues: n } = Yn, r = document.querySelector(`[data-setting-id="${Kn}"]`), i = lr(r);
 	if (r && i && !r.getAttribute("data-mjr-reset-injected")) {
 		r.setAttribute("data-mjr-reset-injected", "true"), i.innerHTML = "";
-		let a = lr("Reset all settings", "Reset all Majoor settings to defaults");
+		let a = ur("Reset all settings", "Reset all Majoor settings to defaults");
 		a.onclick = (r) => {
 			r.preventDefault(), r.stopPropagation();
-			for (let r of t) r.id !== Gn && n.has(r.id) && ur(r, n.get(r.id), e);
-			fr();
+			for (let r of t) r.id !== Kn && n.has(r.id) && dr(r, n.get(r.id), e);
+			pr();
 		}, i.appendChild(a);
 	}
 	for (let r of t) {
-		if (!r?.id || r.id === Gn || !n.has(r.id)) continue;
+		if (!r?.id || r.id === Kn || !n.has(r.id)) continue;
 		let t = document.querySelector(`[data-setting-id="${r.id}"]`);
 		if (!t || t.getAttribute("data-mjr-reset-injected")) continue;
-		let i = cr(t);
+		let i = lr(t);
 		if (!i) continue;
 		t.setAttribute("data-mjr-reset-injected", "true");
-		let a = lr("Reset", "Reset this setting to default");
-		dr(a, r, n.get(r.id), e), a.onclick = (t) => {
+		let a = ur("Reset", "Reset this setting to default");
+		fr(a, r, n.get(r.id), e), a.onclick = (t) => {
 			t.preventDefault(), t.stopPropagation();
 			let i = n.get(r.id);
-			ur(r, i, e), dr(a, r, i, e);
+			dr(r, i, e), fr(a, r, i, e);
 		}, i.appendChild(a);
 	}
 }
-function pr(e, t, n) {
-	typeof document > "u" || typeof MutationObserver > "u" || (Jn = {
+function mr(e, t, n) {
+	typeof document > "u" || typeof MutationObserver > "u" || (Yn = {
 		app: e,
 		definitions: t,
-		defaultValues: new Map(n.filter((e) => e?.id && e.id !== Gn).map((e) => [e.id, e.defaultValue]))
-	}, fr(), !qn && (qn = new MutationObserver(() => fr()), qn.observe(document.body, {
+		defaultValues: new Map(n.filter((e) => e?.id && e.id !== Kn).map((e) => [e.id, e.defaultValue]))
+	}, pr(), !Jn && (Jn = new MutationObserver(() => pr()), Jn.observe(document.body, {
 		childList: !0,
 		subtree: !0
 	})));
 }
-function mr(e, t, { initRuntime: n = !1 } = {}) {
-	if ($n) typeof t == "function" && $n.onAppliedListeners.add(t), e && !$n.app && ($n.app = e);
+function hr(e, t, { initRuntime: n = !1 } = {}) {
+	if (er) typeof t == "function" && er.onAppliedListeners.add(t), e && !er.app && (er.app = e);
 	else {
-		let n = Ut();
-		n.i18n = n.i18n || {}, typeof n.i18n.followComfyLanguage == "boolean" ? Ae(!!n.i18n.followComfyLanguage) : (n.i18n.followComfyLanguage = !0, Ae(!0), G(n));
+		let n = Wt();
+		n.i18n = n.i18n || {}, typeof n.i18n.followComfyLanguage == "boolean" ? je(!!n.i18n.followComfyLanguage) : (n.i18n.followComfyLanguage = !0, je(!0), G(n));
 		let r = /* @__PURE__ */ new Set();
 		typeof t == "function" && r.add(t);
 		let i = /* @__PURE__ */ new Set(), a = /* @__PURE__ */ new Set(), o = () => {
 			if (!i.size) return;
 			let e = Array.from(i);
 			i.clear();
-			for (let t of e) We("mjr-settings-changed", { key: t }, { warnPrefix: "[Majoor]" });
+			for (let t of e) Ge("mjr-settings-changed", { key: t }, { warnPrefix: "[Majoor]" });
 		}, s = () => {
 			if (!a.size) return;
 			let e = Array.from(a);
 			a.clear();
-			for (let t of e) We("mjr-settings-changed", { key: t }, { warnPrefix: "[Majoor]" });
-		}, c = an(o, 120), l = an(s, 450), u = (e) => {
+			for (let t of e) Ge("mjr-settings-changed", { key: t }, { warnPrefix: "[Majoor]" });
+		}, c = on(o, 120), l = on(s, 450), u = (e) => {
 			typeof e == "string" && i.add(e), c();
 		}, d = (e) => {
 			typeof e == "string" && a.add(e), l();
 		}, f = () => {
-			let e = Ut();
+			let e = Wt();
 			Object.assign(n, e), K(n), u("storage");
 		}, p = (e) => {
 			!e || e.key !== "mjrSettings" || e.newValue !== e.oldValue && f();
 		};
-		if (!Zn) {
-			if (Qn && typeof window < "u") try {
-				window.removeEventListener("storage", Qn);
+		if (!Qn) {
+			if ($n && typeof window < "u") try {
+				window.removeEventListener("storage", $n);
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				window.addEventListener("storage", p), Zn = !0, Qn = p;
+				window.addEventListener("storage", p), Qn = !0, $n = p;
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		$n = {
+		er = {
 			app: e,
 			notifyApplied: (e) => {
 				for (let t of r) try {
@@ -2558,48 +2576,48 @@ function mr(e, t, { initRuntime: n = !1 } = {}) {
 				} catch (e) {
 					console.debug?.(e);
 				}
-				Wn.has(String(e || "")) ? d(e) : u(e);
+				Gn.has(String(e || "")) ? d(e) : u(e);
 			},
 			onAppliedListeners: r,
 			refreshFromStorage: f,
 			settings: n
 		};
 	}
-	if (n && !er) {
-		let t = e || $n.app, n = $n.settings;
-		Re(t), K(n), Fe(t), Wt(), Gt(), Kt(), n?.watcher && typeof n.watcher.enabled == "boolean" && f(!!n.watcher.enabled).catch(() => {}), nn(), er = !0;
+	if (n && !tr) {
+		let t = e || er.app, n = er.settings;
+		ze(t), K(n), Ie(t), Gt(), Kt(), qt(), n?.watcher && typeof n.watcher.enabled == "boolean" && v(!!n.watcher.enabled).catch(() => {}), rn(), tr = !0;
 	}
-	return $n;
+	return er;
 }
-var hr = (e, t) => mr(e, t, { initRuntime: !0 }).settings, gr = (e, t) => {
-	let n = mr(e, t, { initRuntime: !1 });
-	Object.assign(n.settings, Ut());
-	let r = e || n.app, i = or(n.settings, r, n.notifyApplied), a = or(ar(W), r, () => {}, { wrapForComfy: !1 });
-	return i.unshift(ir(r, {
-		id: Gn,
+var gr = (e, t) => hr(e, t, { initRuntime: !0 }).settings, _r = (e, t) => {
+	let n = hr(e, t, { initRuntime: !1 });
+	Object.assign(n.settings, Wt());
+	let r = e || n.app, i = sr(n.settings, r, n.notifyApplied), a = sr(or(W), r, () => {}, { wrapForComfy: !1 });
+	return i.unshift(ar(r, {
+		id: Kn,
 		category: [
-			Vn,
-			Un.GENERAL,
+			Hn,
+			Wn.GENERAL,
 			"Reset"
 		],
 		name: "Reset all settings to defaults",
 		tooltip: "Reset every Majoor Assets Manager setting to its default value.",
 		type: "text",
 		defaultValue: ""
-	})), pr(r, i, a), i;
+	})), mr(r, i, a), i;
 };
 try {
-	let e = Ut();
-	e?.watcher && typeof e.watcher.enabled == "boolean" && me().then((e) => {
-		let t = !!e?.ok && !!e?.data?.enabled, n = Ut();
-		n.watcher = n.watcher || {}, typeof t == "boolean" && t !== !!n.watcher.enabled && (n.watcher.enabled = t, G(n), We("mjr-settings-changed", { key: "watcher.enabled" }, { warnPrefix: "[Majoor]" }));
+	let e = Wt();
+	e?.watcher && typeof e.watcher.enabled == "boolean" && pe().then((e) => {
+		let t = !!e?.ok && !!e?.data?.enabled, n = Wt();
+		n.watcher = n.watcher || {}, typeof t == "boolean" && t !== !!n.watcher.enabled && (n.watcher.enabled = t, G(n), Ge("mjr-settings-changed", { key: "watcher.enabled" }, { warnPrefix: "[Majoor]" }));
 	}).catch(() => {});
 } catch (e) {
 	console.debug?.(e);
 }
 //#endregion
 //#region ui/features/contextmenu/gridContextMenuState.ts
-function _r() {
+function vr() {
 	return {
 		open: !1,
 		x: 0,
@@ -2608,11 +2626,11 @@ function _r() {
 		title: ""
 	};
 }
-var Y = Ct({
+var Y = wt({
 	portalOwnerId: "",
 	mountedPortalIds: [],
-	main: _r(),
-	submenu: _r(),
+	main: vr(),
+	submenu: vr(),
 	tags: {
 		open: !1,
 		x: 0,
@@ -2620,52 +2638,52 @@ var Y = Ct({
 		asset: null,
 		onChanged: null
 	}
-}), vr = 1;
-function yr(e) {
+}), yr = 1;
+function br(e) {
 	e && (e.open = !1, e.x = 0, e.y = 0, e.items = [], e.title = "");
 }
-function br(e = "") {
+function xr(e = "") {
 	try {
 		window.dispatchEvent(new CustomEvent("mjr-close-all-menus", { detail: { source: String(e || "") } }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function xr() {
-	let e = `mjr-grid-context-menu-portal-${vr++}`;
+function Sr() {
+	let e = `mjr-grid-context-menu-portal-${yr++}`;
 	return Y.mountedPortalIds.push(e), Y.portalOwnerId ||= e, e;
 }
-function Sr(e) {
+function Cr(e) {
 	let t = Y.mountedPortalIds.filter((t) => t !== e);
 	Y.mountedPortalIds.splice(0, Y.mountedPortalIds.length, ...t), Y.portalOwnerId === e && (Y.portalOwnerId = Y.mountedPortalIds[0] || "");
 }
-function Cr(e) {
+function wr(e) {
 	return String(Y.portalOwnerId || "") === String(e || "");
 }
-function wr({ x: e = 0, y: t = 0, items: n = [], title: r = "" } = {}) {
-	br("grid"), kr(), Dr(), Y.main.open = !0, Y.main.x = Number(e) || 0, Y.main.y = Number(t) || 0, Y.main.items = Array.isArray(n) ? n.filter(Boolean) : [], Y.main.title = String(r || "");
+function Tr({ x: e = 0, y: t = 0, items: n = [], title: r = "" } = {}) {
+	xr("grid"), Ar(), Or(), Y.main.open = !0, Y.main.x = Number(e) || 0, Y.main.y = Number(t) || 0, Y.main.items = Array.isArray(n) ? n.filter(Boolean) : [], Y.main.title = String(r || "");
 }
-function Tr() {
-	yr(Y.main), Dr();
+function Er() {
+	br(Y.main), Or();
 }
-function Er({ x: e = 0, y: t = 0, items: n = [], title: r = "" } = {}) {
+function Dr({ x: e = 0, y: t = 0, items: n = [], title: r = "" } = {}) {
 	Y.submenu.open = !0, Y.submenu.x = Number(e) || 0, Y.submenu.y = Number(t) || 0, Y.submenu.items = Array.isArray(n) ? n.filter(Boolean) : [], Y.submenu.title = String(r || "");
 }
-function Dr() {
-	yr(Y.submenu);
+function Or() {
+	br(Y.submenu);
 }
-function Or({ x: e = 0, y: t = 0, asset: n = null, onChanged: r = null } = {}) {
-	Tr(), Y.tags.open = !!n, Y.tags.x = Number(e) || 0, Y.tags.y = Number(t) || 0, Y.tags.asset = n || null, Y.tags.onChanged = typeof r == "function" ? r : null;
-}
-function kr() {
-	Y.tags.open = !1, Y.tags.x = 0, Y.tags.y = 0, Y.tags.asset = null, Y.tags.onChanged = null;
+function kr({ x: e = 0, y: t = 0, asset: n = null, onChanged: r = null } = {}) {
+	Er(), Y.tags.open = !!n, Y.tags.x = Number(e) || 0, Y.tags.y = Number(t) || 0, Y.tags.asset = n || null, Y.tags.onChanged = typeof r == "function" ? r : null;
 }
 function Ar() {
-	Tr(), kr();
+	Y.tags.open = !1, Y.tags.x = 0, Y.tags.y = 0, Y.tags.asset = null, Y.tags.onChanged = null;
+}
+function jr() {
+	Er(), Ar();
 }
 //#endregion
 //#region ui/features/dnd/utils/constants.ts
-var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "application/x-comfy-asset-info", Pr = new Set([
+var Mr = "application/x-mjr-asset", Nr = "application/x-mjr-assets", Pr = "application/x-comfy-asset-info", Fr = new Set([
 	".png",
 	".jpg",
 	".jpeg",
@@ -2674,13 +2692,13 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	".bmp",
 	".avif",
 	".jxl"
-]), Fr = new Set([
+]), Ir = new Set([
 	".mp4",
 	".mov",
 	".mkv",
 	".webm",
 	".avi"
-]), Ir = new Set([
+]), Lr = new Set([
 	".wav",
 	".mp3",
 	".flac",
@@ -2688,7 +2706,7 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	".m4a",
 	".aac",
 	".opus"
-]), Lr = new Set([
+]), Rr = new Set([
 	".obj",
 	".fbx",
 	".glb",
@@ -2698,23 +2716,23 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	".splat",
 	".ksplat",
 	".spz"
-]), Rr = (e) => {
-	if (!e) return !1;
-	let t = e.lastIndexOf(".");
-	return t === -1 ? !1 : Pr.has(e.slice(t).toLowerCase());
-}, zr = (e) => e ? String(e.kind || "").toLowerCase() === "image" ? !0 : Rr(e.filename) : !1, Br = (e) => {
+]), zr = (e) => {
 	if (!e) return !1;
 	let t = e.lastIndexOf(".");
 	return t === -1 ? !1 : Fr.has(e.slice(t).toLowerCase());
-}, Vr = (e) => e ? String(e.kind || "").toLowerCase() === "video" ? !0 : Br(e.filename) : !1, Hr = (e) => {
+}, Br = (e) => e ? String(e.kind || "").toLowerCase() === "image" ? !0 : zr(e.filename) : !1, Vr = (e) => {
 	if (!e) return !1;
 	let t = e.lastIndexOf(".");
 	return t === -1 ? !1 : Ir.has(e.slice(t).toLowerCase());
-}, Ur = (e) => e ? String(e.kind || "").toLowerCase() === "audio" ? !0 : Hr(e.filename) : !1, Wr = (e) => {
+}, Hr = (e) => e ? String(e.kind || "").toLowerCase() === "video" ? !0 : Vr(e.filename) : !1, Ur = (e) => {
 	if (!e) return !1;
 	let t = e.lastIndexOf(".");
 	return t === -1 ? !1 : Lr.has(e.slice(t).toLowerCase());
-}, Gr = (e) => e ? String(e.kind || "").toLowerCase() === "model3d" ? !0 : Wr(e.filename) : !1, Kr = (e) => zr(e) || Vr(e) || Ur(e) || Gr(e) || String(e?.kind || "").toLowerCase() === "workflow", qr = {
+}, Wr = (e) => e ? String(e.kind || "").toLowerCase() === "audio" ? !0 : Ur(e.filename) : !1, Gr = (e) => {
+	if (!e) return !1;
+	let t = e.lastIndexOf(".");
+	return t === -1 ? !1 : Rr.has(e.slice(t).toLowerCase());
+}, Kr = (e) => e ? String(e.kind || "").toLowerCase() === "model3d" ? !0 : Gr(e.filename) : !1, qr = (e) => Br(e) || Hr(e) || Wr(e) || Kr(e) || String(e?.kind || "").toLowerCase() === "workflow", Jr = {
 	mp4: "video/mp4",
 	mov: "video/quicktime",
 	webm: "video/webm",
@@ -2724,45 +2742,45 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	obj: "model/obj",
 	stl: "model/stl",
 	ply: "application/ply"
-}, Jr = (e) => qr[String(e || "").split(".").pop()?.toLowerCase()] ?? "application/octet-stream", Yr = (e, t) => {
-	if (typeof e != "string") return !1;
-	let n = e.trim().toLowerCase();
-	if (!n) return !1;
-	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
-	return r ? t && r === String(t).toLowerCase() ? !0 : Fr.has(`.${r}`) : !1;
-}, Xr = (e, t, n) => {
-	if (!e || e.type !== "combo" || !e.options) return !1;
-	let r = Array.isArray(e.options.values) && e.options.values || e.options.values && Array.isArray(e.options.values.values) && e.options.values.values || null;
-	return Array.isArray(r) ? r.some((e) => n(typeof e == "string" ? e : e?.content ?? e?.value ?? e?.text, t)) : !1;
-}, Zr = (e, t) => Xr(e, t, Yr), Qr = (e, t) => {
-	if (typeof e != "string") return !1;
-	let n = e.trim().toLowerCase();
-	if (!n) return !1;
-	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
-	return r ? t && r === String(t).toLowerCase() ? !0 : Pr.has(`.${r}`) : !1;
-}, $r = (e, t) => Xr(e, t, Qr), ei = (e, t) => {
+}, Yr = (e) => Jr[String(e || "").split(".").pop()?.toLowerCase()] ?? "application/octet-stream", Xr = (e, t) => {
 	if (typeof e != "string") return !1;
 	let n = e.trim().toLowerCase();
 	if (!n) return !1;
 	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
 	return r ? t && r === String(t).toLowerCase() ? !0 : Ir.has(`.${r}`) : !1;
-}, ti = (e, t) => Xr(e, t, ei), ni = (e, t) => {
+}, Zr = (e, t, n) => {
+	if (!e || e.type !== "combo" || !e.options) return !1;
+	let r = Array.isArray(e.options.values) && e.options.values || e.options.values && Array.isArray(e.options.values.values) && e.options.values.values || null;
+	return Array.isArray(r) ? r.some((e) => n(typeof e == "string" ? e : e?.content ?? e?.value ?? e?.text, t)) : !1;
+}, Qr = (e, t) => Zr(e, t, Xr), $r = (e, t) => {
+	if (typeof e != "string") return !1;
+	let n = e.trim().toLowerCase();
+	if (!n) return !1;
+	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
+	return r ? t && r === String(t).toLowerCase() ? !0 : Fr.has(`.${r}`) : !1;
+}, ei = (e, t) => Zr(e, t, $r), ti = (e, t) => {
 	if (typeof e != "string") return !1;
 	let n = e.trim().toLowerCase();
 	if (!n) return !1;
 	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
 	return r ? t && r === String(t).toLowerCase() ? !0 : Lr.has(`.${r}`) : !1;
-}, ri = (e, t) => Xr(e, t, ni), ii = /* @__PURE__ */ new WeakMap(), ai = (e) => {
+}, ni = (e, t) => Zr(e, t, ti), ri = (e, t) => {
+	if (typeof e != "string") return !1;
+	let n = e.trim().toLowerCase();
+	if (!n) return !1;
+	let r = (n.split(/[?#]/)[0].split(".").pop() || "").toLowerCase();
+	return r ? t && r === String(t).toLowerCase() ? !0 : Rr.has(`.${r}`) : !1;
+}, ii = (e, t) => Zr(e, t, ri), ai = /* @__PURE__ */ new WeakMap(), oi = (e) => {
 	if (!e || typeof e != "object") return {
 		node: null,
 		prev: null
 	};
-	let t = ii.get(e);
+	let t = ai.get(e);
 	return t || (t = {
 		node: null,
 		prev: null
-	}, ii.set(e, t)), t;
-}, oi = (e, t, n) => {
+	}, ai.set(e, t)), t;
+}, si = (e, t, n) => {
 	let r = e?.canvas?.canvas || document.querySelector("canvas"), i = e?.canvas?.graph, a = e?.canvas?.ds;
 	if (!r || !i || !a) return null;
 	let o = r.getBoundingClientRect();
@@ -2777,14 +2795,14 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		if (t.flags && t.flags.collapsed && (r = 30), d >= t.pos[0] && f >= t.pos[1] && d <= t.pos[0] + n && f <= t.pos[1] + r) return t;
 	}
 	return null;
-}, si = (e, t, n) => {
-	let r = ai(e);
-	!t || r.node === t || (ci(e, n), r.node = t, r.prev = {
+}, ci = (e, t, n) => {
+	let r = oi(e);
+	!t || r.node === t || (li(e, n), r.node = t, r.prev = {
 		color: t.color,
 		bgcolor: t.bgcolor
 	}, t.bgcolor = "#3355ff", t.color = "#a9c4ff", n(e));
-}, ci = (e, t) => {
-	let n = ai(e);
+}, li = (e, t) => {
+	let n = oi(e);
 	if (n.node) {
 		try {
 			n.prev && (n.node.color = n.prev.color, n.node.bgcolor = n.prev.bgcolor);
@@ -2793,7 +2811,7 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		}
 		n.node = null, n.prev = null, t(e);
 	}
-}, li = (e, t) => {
+}, ui = (e, t) => {
 	if (!e || e.type !== "combo" || !e.options) return;
 	let n = e.options.values, r = e.options;
 	if (typeof n != "function") {
@@ -2805,7 +2823,7 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 			value: t
 		}), r.values = n);
 	}
-}, ui = new Set([
+}, di = new Set([
 	"number",
 	"int",
 	"float",
@@ -2814,34 +2832,34 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	"checkbox",
 	"button",
 	"hidden"
-]), di = [
+]), fi = [
 	"output",
 	"save",
 	"export",
 	"folder",
 	"dir"
-], fi = ["file", "path"], pi = [
+], pi = ["file", "path"], mi = [
 	"path",
 	"file",
 	"input",
 	"src",
 	"source"
-], mi = (e, t, n) => {
+], hi = (e, t, n) => {
 	let r = e?.widgets;
 	if (!Array.isArray(r) || !r.length) return null;
 	let i = String(t || "").toLowerCase().replace(/^\./, ""), a = String(e?.type || "").toLowerCase(), o = n.knownNodeIncludes.some((e) => a.includes(e)), s = [];
 	for (let e of r) {
 		if (!e) continue;
 		let t = String(e?.type || "").toLowerCase(), r = e?.value;
-		if (ui.has(t) || typeof r == "number" || typeof r == "boolean") continue;
+		if (di.has(t) || typeof r == "number" || typeof r == "boolean") continue;
 		let a = t === "text" || t === "string" || t === "combo", c = typeof e?.callback == "function" && typeof r == "string";
 		if (!a && !c) continue;
 		let l = String(e?.name || e?.label || "").toLowerCase().trim(), u = 0;
 		n.exactNames.has(l) && (u += 100), l === "file" && o && t === "combo" && n.comboChecker(e, i) && (u += 100);
-		let d = n.mediaTerms.some((e) => l.includes(e)), f = pi.some((e) => l.includes(e));
-		d && f && (u += 80), fi.some((e) => l.includes(e)) && (u += 35);
+		let d = n.mediaTerms.some((e) => l.includes(e)), f = mi.some((e) => l.includes(e));
+		d && f && (u += 80), pi.some((e) => l.includes(e)) && (u += 35);
 		for (let { terms: e, score: t } of n.extraTerms) e.some((e) => l.includes(e)) && (u += t);
-		di.some((e) => l.includes(e)) && (u -= 90), n.exactSingleNames.has(l) && (typeof r == "string" && r.trim() === "" || n.looksLikeFn(r, i) ? u += 25 : u -= 10), o && (u += 15);
+		fi.some((e) => l.includes(e)) && (u -= 90), n.exactSingleNames.has(l) && (typeof r == "string" && r.trim() === "" || n.looksLikeFn(r, i) ? u += 25 : u -= 10), o && (u += 15);
 		let p = typeof r == "string" && r.trim() === "";
 		p && (u += 3), t === "combo" && n.comboChecker(e, i) && (u += 12), s.push({
 			w: e,
@@ -2860,7 +2878,7 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		console.debug?.(e);
 	}
 	return c.w;
-}, hi = {
+}, gi = {
 	exactNames: new Set([
 		"video_path",
 		"input_video",
@@ -2903,10 +2921,10 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		score: 45
 	}],
 	exactSingleNames: new Set(["video"]),
-	looksLikeFn: Yr,
-	comboChecker: Zr,
+	looksLikeFn: Xr,
+	comboChecker: Qr,
 	scoreKey: "__mjrVideoPickScore"
-}, gi = {
+}, _i = {
 	exactNames: new Set([
 		"image",
 		"image_path",
@@ -2961,10 +2979,10 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		score: 35
 	}],
 	exactSingleNames: new Set(["image", "face"]),
-	looksLikeFn: Qr,
-	comboChecker: $r,
+	looksLikeFn: $r,
+	comboChecker: ei,
 	scoreKey: "__mjrImagePickScore"
-}, _i = {
+}, vi = {
 	exactNames: new Set([
 		"audio_path",
 		"input_audio",
@@ -3012,10 +3030,10 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		score: 45
 	}],
 	exactSingleNames: new Set(["audio", "voice"]),
-	looksLikeFn: ei,
-	comboChecker: ti,
+	looksLikeFn: ti,
+	comboChecker: ni,
 	scoreKey: "__mjrAudioPickScore"
-}, vi = {
+}, yi = {
 	exactNames: new Set([
 		"model_path",
 		"input_model",
@@ -3074,13 +3092,13 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		"mesh",
 		"geometry"
 	]),
-	looksLikeFn: ni,
-	comboChecker: ri,
+	looksLikeFn: ri,
+	comboChecker: ii,
 	scoreKey: "__mjrModel3DPickScore"
-}, yi = (e, t, n) => {
+}, bi = (e, t, n) => {
 	let r = String(t?.kind || "").toLowerCase();
-	return mi(e, n, r === "model3d" ? vi : r === "audio" ? _i : r === "image" ? gi : hi);
-}, bi = (e, t, n, r) => {
+	return hi(e, n, r === "model3d" ? yi : r === "audio" ? vi : r === "image" ? _i : gi);
+}, xi = (e, t, n, r) => {
 	if (!t || !t.inputs || !t.inputs.length) return null;
 	let i = e?.canvas?.canvas || document.querySelector("canvas"), a = e?.canvas?.ds;
 	if (!i || !a) return null;
@@ -3093,15 +3111,15 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		};
 	}
 	return null;
-}, xi = (e) => {
+}, Si = (e) => {
 	let t = e?.canvas?.canvas || document.querySelector("canvas");
 	return t ? t.getBoundingClientRect() : null;
-}, Si = (e, t) => {
-	let n = xi(e);
+}, Ci = (e, t) => {
+	let n = Si(e);
 	if (!n) return !1;
 	let r = t.clientX, i = t.clientY;
 	return r >= n.left && r <= n.right && i >= n.top && i <= n.bottom;
-}, Ci = (e) => {
+}, wi = (e) => {
 	try {
 		e?.graph?.setDirtyCanvas?.(!0, !0);
 	} catch (e) {
@@ -3112,21 +3130,21 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 	} catch (e) {
 		console.debug?.(e);
 	}
-}, wi = (e) => {
+}, Ti = (e) => {
 	let t = String(e?.filename || ""), n = t.lastIndexOf(".");
 	return n >= 0 ? t.slice(n).toLowerCase() : "";
-}, Ti = (e) => {
-	let t = String(e?.kind || "").toLowerCase(), n = wi(e);
-	return t === "image" || Pr.has(n) ? ["LoadImage"] : t === "video" || Fr.has(n) ? [
+}, Ei = (e) => {
+	let t = String(e?.kind || "").toLowerCase(), n = Ti(e);
+	return t === "image" || Fr.has(n) ? ["LoadImage"] : t === "video" || Ir.has(n) ? [
 		"LoadVideo",
 		"VHS_LoadVideo",
 		"VideoLoader"
-	] : t === "audio" || Ir.has(n) ? [
+	] : t === "audio" || Lr.has(n) ? [
 		"LoadAudio",
 		"VHS_LoadAudioUpload",
 		"VHS_LoadAudio",
 		"AudioLoader"
-	] : t === "model3d" || Lr.has(n) ? [
+	] : t === "model3d" || Rr.has(n) ? [
 		"Load3D",
 		"LoadModel",
 		"LoadMesh",
@@ -3135,9 +3153,9 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		"LoadSTL",
 		"LoadPLY"
 	] : [];
-}, Ei = (e, t) => {
+}, Di = (e, t) => {
 	if (e) {
-		e.type === "combo" && li(e, t), e.value = t;
+		e.type === "combo" && ui(e, t), e.value = t;
 		try {
 			e.callback?.(e.value);
 		} catch (e) {
@@ -3149,41 +3167,41 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 			console.debug?.(e);
 		}
 	}
-}, Di = (e) => {
+}, Oi = (e) => {
 	let t = e?.canvas?.canvas || document.querySelector("canvas"), n = t?.getBoundingClientRect?.(), r = n ? Number(n.width || n.right - n.left) : 0, i = n ? Number(n.height || n.bottom - n.top) : 0, a = Number(r || t?.width || 800), o = Number(i || t?.height || 600);
 	if (!n) return [Math.max(0, a / 2), Math.max(0, o / 2)];
 	let s = n && Number(n.left) || 0, c = n && Number(n.top) || 0;
-	return Oi(e, s + Math.max(0, a / 2), c + Math.max(0, o / 2));
-}, Oi = (e, t, n) => {
+	return ki(e, s + Math.max(0, a / 2), c + Math.max(0, o / 2));
+}, ki = (e, t, n) => {
 	let r = (e?.canvas?.canvas || document.querySelector("canvas"))?.getBoundingClientRect?.(), i = e?.canvas?.ds || {}, a = Number(i.scale) || 1, o = i.offset || [0, 0], s = Array.isArray(o) ? Number(o[0]) || 0 : Number(o?.x) || 0, c = Array.isArray(o) ? Number(o[1]) || 0 : Number(o?.y) || 0;
-	return !r || !Number.isFinite(Number(t)) || !Number.isFinite(Number(n)) ? Di(e) : [(Number(t) - r.left) / a - s, (Number(n) - r.top) / a - c];
-}, ki = (e, t = null) => {
-	if (Number.isFinite(Number(t?.clientX)) && Number.isFinite(Number(t?.clientY))) return Oi(e, t.clientX, t.clientY);
+	return !r || !Number.isFinite(Number(t)) || !Number.isFinite(Number(n)) ? Oi(e) : [(Number(t) - r.left) / a - s, (Number(n) - r.top) / a - c];
+}, Ai = (e, t = null) => {
+	if (Number.isFinite(Number(t?.clientX)) && Number.isFinite(Number(t?.clientY))) return ki(e, t.clientX, t.clientY);
 	try {
 		let n = e?.canvas?.convertEventToCanvasOffset?.(t);
 		if (Array.isArray(n)) return [Number(n[0]) || 0, Number(n[1]) || 0];
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return Oi(e, t?.clientX, t?.clientY);
-}, Ai = ({ app: e, payload: t, relativePath: n, event: r = null, droppedExt: i = "", position: a = null }) => {
+	return ki(e, t?.clientX, t?.clientY);
+}, ji = ({ app: e, payload: t, relativePath: n, event: r = null, droppedExt: i = "", position: a = null }) => {
 	let o = e?.graph ?? e?.canvas?.graph ?? null;
 	if (!o || typeof o.add != "function") return !1;
 	let s = null;
-	for (let n of Ti(t)) try {
-		if (s = ze(n, e), s) break;
+	for (let n of Ei(t)) try {
+		if (s = Be(n, e), s) break;
 	} catch (e) {
 		console.debug?.(e);
 	}
 	if (!s) return !1;
-	s.pos = Array.isArray(a) ? [Number(a[0]) || 0, Number(a[1]) || 0] : ki(e, r), o.add(s);
-	let c = yi(s, t, i);
-	return c && Ei(c, n), Ci(e), !0;
-}, ji = ({ app: e, items: t = [], event: n = null, gap: r = 90 }) => {
+	s.pos = Array.isArray(a) ? [Number(a[0]) || 0, Number(a[1]) || 0] : Ai(e, r), o.add(s);
+	let c = bi(s, t, i);
+	return c && Di(c, n), wi(e), !0;
+}, Mi = ({ app: e, items: t = [], event: n = null, gap: r = 90 }) => {
 	let i = Array.isArray(t) ? t.filter(Boolean) : [];
 	if (!i.length) return 0;
-	let a = ki(e, n), o = 0;
-	for (let t of i) Ai({
+	let a = Ai(e, n), o = 0;
+	for (let t of i) ji({
 		app: e,
 		payload: t.payload,
 		relativePath: t.relativePath,
@@ -3192,27 +3210,27 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		position: [a[0] + o * Number(r || 90), a[1]]
 	}) && (o += 1);
 	return o;
-}, Mi = Ei, Ni = ({ app: e, payload: t, relativePath: n, targetNode: r, inputSlotIndex: i, event: a = null }) => {
+}, Ni = Di, Pi = ({ app: e, payload: t, relativePath: n, targetNode: r, inputSlotIndex: i, event: a = null }) => {
 	let o = e?.graph ?? e?.canvas?.graph ?? null;
 	if (!o || typeof o.add != "function" || !r) return !1;
 	let s = null;
-	for (let n of Ti(t)) try {
-		if (s = ze(n, e), s) break;
+	for (let n of Ei(t)) try {
+		if (s = Be(n, e), s) break;
 	} catch (e) {
 		console.debug?.(e);
 	}
 	if (!s) return !1;
 	let c = Number(r.pos[0]) || 0, l = Number(r.pos[1]) || 0, u = Array.isArray(s.size) && Number(s.size[0]) || 220;
 	s.pos = [c - u - 60, l + Number(i) * 20], o.add(s);
-	let d = wi(t), f = yi(s, t, d);
-	f && Ei(f, n);
+	let d = Ti(t), f = bi(s, t, d);
+	f && Di(f, n);
 	try {
 		s.connect(0, r, i);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return Ci(e), !0;
-}, Pi = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => {
+	return wi(e), !0;
+}, Fi = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => {
 	let a = {
 		index: !!r,
 		files: [{
@@ -3220,12 +3238,12 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 			subfolder: n.subfolder || "",
 			dest_subfolder: "",
 			type: n.type || "output",
-			root_id: Te(n) || void 0
+			root_id: Ee(n) || void 0
 		}]
 	};
 	return i && (a.purpose = i), e(t, a);
-}, Fi = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => {
-	let a = await Pi({
+}, Ii = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => {
+	let a = await Fi({
 		post: e,
 		endpoint: t,
 		payload: n,
@@ -3240,41 +3258,41 @@ var jr = "application/x-mjr-asset", Mr = "application/x-mjr-assets", Nr = "appli
 		name: o?.name || null,
 		subfolder: o?.subfolder || ""
 	} : null;
-}, Ii = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => (await Fi({
+}, Li = async ({ post: e, endpoint: t, payload: n, index: r = !0, purpose: i = null }) => (await Ii({
 	post: e,
 	endpoint: t,
 	payload: n,
 	index: r,
 	purpose: i
-}))?.relativePath || null, Li = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, Ri = /^[0-9a-f]{20,}$/i;
-function zi(...e) {
+}))?.relativePath || null, Ri = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, zi = /^[0-9a-f]{20,}$/i;
+function Bi(...e) {
 	for (let t of e) {
 		let e = String(t || "").trim();
 		if (e) return e;
 	}
 	return "";
 }
-function Bi(e) {
-	let t = String(e || "").trim();
-	return !!t && (Li.test(t) || Ri.test(t));
-}
 function Vi(e) {
-	return String(e?.type || e?.class_type || e?.comfyClass || e?.classType || "").trim();
+	let t = String(e || "").trim();
+	return !!t && (Ri.test(t) || zi.test(t));
 }
 function Hi(e) {
-	return zi(e?.properties?.subgraph_name, e?.title, e?.properties?.title, e?.properties?.name, e?.properties?.label, e?.name, e?.subgraph?.name, e?.subgraph_instance?.name);
+	return String(e?.type || e?.class_type || e?.comfyClass || e?.classType || "").trim();
 }
 function Ui(e) {
-	let t = Vi(e), n = Hi(e);
-	return n && (!t || Bi(t) || n !== t) ? n : t && !Bi(t) ? t : n || (t ? "Subgraph" : String(e?.id || "Node").trim() || "Node");
+	return Bi(e?.properties?.subgraph_name, e?.title, e?.properties?.title, e?.properties?.name, e?.properties?.label, e?.name, e?.subgraph?.name, e?.subgraph_instance?.name);
 }
 function Wi(e) {
-	let t = Vi(e);
-	return t && !Bi(t) ? t : t ? "Subgraph" : "Node";
+	let t = Hi(e), n = Ui(e);
+	return n && (!t || Vi(t) || n !== t) ? n : t && !Vi(t) ? t : n || (t ? "Subgraph" : String(e?.id || "Node").trim() || "Node");
+}
+function Gi(e) {
+	let t = Hi(e);
+	return t && !Vi(t) ? t : t ? "Subgraph" : "Node";
 }
 //#endregion
 //#region ui/components/sidebar/utils/minimap.ts
-var Gi = 6, Ki = 1, qi = 64, Ji = 74, Yi = 42, Xi = [
+var Ki = 6, qi = 1, Ji = 64, Yi = 74, Xi = 42, Zi = [
 	["sampler", "#8e5cff"],
 	["ksampler", "#8e5cff"],
 	["loader", "#4f8cff"],
@@ -3291,20 +3309,20 @@ var Gi = 6, Ki = 1, qi = 64, Ji = 74, Yi = 42, Xi = [
 	["save", "#4aa37c"],
 	["preview", "#4aa37c"],
 	["api", "#3aa6a6"]
-], Zi = (e, t, n) => {
+], Qi = (e, t, n) => {
 	let r = Number(e);
 	return Number.isFinite(r) ? Math.max(t, Math.min(n, r)) : t;
-}, Qi = (e, t = !1) => {
+}, $i = (e, t = !1) => {
 	let n = String(e || "").toUpperCase();
 	return n.includes("IMAGE") ? "rgba(145,198,99,0.9)" : n.includes("LATENT") ? "rgba(89,178,118,0.9)" : n.includes("MODEL") ? "rgba(112,155,255,0.9)" : n.includes("CONDITIONING") ? "rgba(191,123,226,0.9)" : n.includes("CLIP") ? "rgba(220,178,77,0.9)" : n.includes("VAE") ? "rgba(72,184,214,0.9)" : n.includes("MASK") ? "rgba(190,190,190,0.88)" : n.includes("STRING") || n.includes("TEXT") ? "rgba(230,230,230,0.86)" : n.includes("INT") || n.includes("FLOAT") || n.includes("NUMBER") ? "rgba(130,210,220,0.88)" : t ? "rgba(170,220,255,0.82)" : "rgba(255,255,255,0.72)";
-}, $i = (e, t, n) => {
+}, ea = (e, t, n) => {
 	let r = String(t || "").replace(/\s+/g, " ").trim(), i = Math.max(1, Number(n) || 1);
 	if (!r || e.measureText(r).width <= i) return r;
 	let a = r;
 	for (; a.length > 3 && e.measureText(`${a}...`).width > i;) a = a.slice(0, -1);
 	return a.length > 3 ? `${a}...` : r.slice(0, 3);
 };
-function ea(e, t, n = null) {
+function ta(e, t, n = null) {
 	if (!e) return;
 	let r = e.getContext?.("2d");
 	if (!r) return;
@@ -3318,7 +3336,7 @@ function ea(e, t, n = null) {
 		showNodeLabels: !1,
 		expandSubgraphs: !0,
 		...n && typeof n == "object" ? n : {}
-	}, a = i.expandSubgraphs === !1 ? t : ta(t), o = Array.isArray(a?.nodes) ? a.nodes : [], s = Array.isArray(a?.groups) && a.groups || Array.isArray(a?.extra?.groups) && a.extra.groups || Array.isArray(a?.extra?.groupNodes) && a.extra.groupNodes || Array.isArray(a?.extra?.group_nodes) && a.extra.group_nodes || [], c = Array.isArray(a?.links) && a.links || Array.isArray(a?.extra?.links) && a.extra.links || [], l = Math.max(1, e.clientWidth || e.width || 1), u = Math.max(1, e.clientHeight || e.height || 1);
+	}, a = i.expandSubgraphs === !1 ? t : na(t), o = Array.isArray(a?.nodes) ? a.nodes : [], s = Array.isArray(a?.groups) && a.groups || Array.isArray(a?.extra?.groups) && a.extra.groups || Array.isArray(a?.extra?.groupNodes) && a.extra.groupNodes || Array.isArray(a?.extra?.group_nodes) && a.extra.group_nodes || [], c = Array.isArray(a?.links) && a.links || Array.isArray(a?.extra?.links) && a.extra.links || [], l = Math.max(1, e.clientWidth || e.width || 1), u = Math.max(1, e.clientHeight || e.height || 1);
 	if ((!o || o.length === 0) && (!s || s.length === 0)) return r.clearRect(0, 0, l, u), null;
 	let d = (e, t) => {
 		if (!e || typeof e != "string") return `rgba(255,255,255,${t})`;
@@ -3355,7 +3373,7 @@ function ea(e, t, n = null) {
 		let t = e?.bgcolor || e?.color || null;
 		if (t) return t;
 		let n = String(e?.category || e?.type || e?.comfyClass || e?.class_type || e?.title || "").toLowerCase();
-		for (let [e, t] of Xi) if (n.includes(e)) return t;
+		for (let [e, t] of Zi) if (n.includes(e)) return t;
 		let r = 0;
 		for (let e = 0; e < n.length; e += 1) r = r * 31 + n.charCodeAt(e) | 0;
 		return `hsl(${Math.abs(r) % 360} 42% 42%)`;
@@ -3364,7 +3382,7 @@ function ea(e, t, n = null) {
 		if (n) {
 			for (let [e, r] of Object.entries(n)) if (!(Array.isArray(r) || r && typeof r == "object") && (t.push([e, r]), t.length >= 3)) return t;
 		}
-		let r = Array.isArray(e?.widgets_values) ? e.widgets_values : [], i = Array.isArray(e?.widgets) ? e.widgets : [], a = Array.isArray(e?.inputs) ? e.inputs : [], o = a.filter((e) => e?.widget === !0 || e?.widget && typeof e.widget == "object" || typeof e?.widget == "string" && e.widget.trim()), s = a.filter((e) => e?.link == null && la(e?.type)), c = (o.length ? o : s.length ? s : a).map((e) => String(e?.label || e?.localized_name || e?.name || e?.widget?.name || e?.widget?.label || "").trim());
+		let r = Array.isArray(e?.widgets_values) ? e.widgets_values : [], i = Array.isArray(e?.widgets) ? e.widgets : [], a = Array.isArray(e?.inputs) ? e.inputs : [], o = a.filter((e) => e?.widget === !0 || e?.widget && typeof e.widget == "object" || typeof e?.widget == "string" && e.widget.trim()), s = a.filter((e) => e?.link == null && ua(e?.type)), c = (o.length ? o : s.length ? s : a).map((e) => String(e?.label || e?.localized_name || e?.name || e?.widget?.name || e?.widget?.label || "").trim());
 		return r.forEach((e, n) => {
 			let r = i[n]?.name || i[n]?.label || c[n] || `p${n + 1}`;
 			t.push([r, e]);
@@ -3407,7 +3425,7 @@ function ea(e, t, n = null) {
 			outputs: C,
 			inputCount: S.length || (e?.inputs && typeof e.inputs == "object" ? Object.keys(e.inputs).length : 0),
 			outputCount: C.length,
-			label: Ui(e).replace(/\s+/g, " ").trim()
+			label: Wi(e).replace(/\s+/g, " ").trim()
 		}), n && h.set(n, m[m.length - 1]);
 	}
 	if (i.showGroups) for (let e of s || []) {
@@ -3427,21 +3445,21 @@ function ea(e, t, n = null) {
 	if (!m.length) return r.clearRect(0, 0, l, u), null;
 	let v = m[0].x, y = m[0].y, b = m[0].x + m[0].w, x = m[0].y + m[0].h;
 	for (let e of m) v = Math.min(v, e.x), y = Math.min(y, e.y), b = Math.max(b, e.x + e.w), x = Math.max(x, e.y + e.h);
-	let S = Math.max(1, b - v), C = Math.max(1, x - y), ee = v + S / 2, te = y + C / 2, w = i.view && typeof i.view == "object" ? i.view : Object.create(null), T = Zi(w.zoom ?? 1, Ki, qi), E = Math.max(1, S / T), ne = Math.max(1, C / T), re = E / 2, D = ne / 2, ie = E >= S ? ee : Zi(w.centerX ?? ee, v + re, b - re), ae = ne >= C ? te : Zi(w.centerY ?? te, y + D, x - D), oe = ie - re, se = ae - D, ce = Gi, le = Math.min((l - ce * 2) / E, (u - ce * 2) / ne), ue = w.hoveredNodeId !== null && w.hoveredNodeId !== void 0 ? String(w.hoveredNodeId) : null;
+	let S = Math.max(1, b - v), C = Math.max(1, x - y), ee = v + S / 2, te = y + C / 2, w = i.view && typeof i.view == "object" ? i.view : Object.create(null), T = Qi(w.zoom ?? 1, qi, Ji), ne = Math.max(1, S / T), re = Math.max(1, C / T), ie = ne / 2, E = re / 2, ae = ne >= S ? ee : Qi(w.centerX ?? ee, v + ie, b - ie), oe = re >= C ? te : Qi(w.centerY ?? te, y + E, x - E), se = ae - ie, ce = oe - E, le = Ki, ue = Math.min((l - le * 2) / ne, (u - le * 2) / re), de = w.hoveredNodeId !== null && w.hoveredNodeId !== void 0 ? String(w.hoveredNodeId) : null;
 	r.clearRect(0, 0, l, u), r.fillStyle = "rgba(0,0,0,0.22)", r.fillRect(0, 0, l, u);
-	let de = (e, t) => ({
-		x: ce + (e - oe) * le,
-		y: ce + (t - se) * le
+	let D = (e, t) => ({
+		x: le + (e - se) * ue,
+		y: le + (t - ce) * ue
 	}), fe = (e, t) => ({
-		x: Zi(oe + (Number(e) - ce) / le, v, b),
-		y: Zi(se + (Number(t) - ce) / le, y, x)
+		x: Qi(se + (Number(e) - le) / ue, v, b),
+		y: Qi(ce + (Number(t) - le) / ue, y, x)
 	}), pe = (e) => ({
-		x: ce + (e.x - oe) * le,
-		y: ce + (e.y - se) * le,
-		w: Math.max(1, e.w * le),
-		h: Math.max(1, e.h * le)
+		x: le + (e.x - se) * ue,
+		y: le + (e.y - ce) * ue,
+		w: Math.max(1, e.w * ue),
+		h: Math.max(1, e.h * ue)
 	}), me = (e) => Math.max(10, Math.min(24, Math.floor(Number(e) * .2))), he = (e, t, n) => {
-		let r = pe(e), i = me(r.h), a = n === "output" ? e.outputs : e.inputs, o = Math.max(1, Array.isArray(a) ? a.length : Number(e[`${n}Count`]) || 0), s = Zi(t, 0, Math.max(0, o - 1));
+		let r = pe(e), i = me(r.h), a = n === "output" ? e.outputs : e.inputs, o = Math.max(1, Array.isArray(a) ? a.length : Number(e[`${n}Count`]) || 0), s = Qi(t, 0, Math.max(0, o - 1));
 		return r.y + i + (r.h - i) * (s + 1) / (o + 1);
 	}, ge = (e) => Array.isArray(e) && e.length >= 5 ? {
 		originId: e[1],
@@ -3478,7 +3496,7 @@ function ea(e, t, n = null) {
 			r.restore();
 		}
 	}, ye = (e) => {
-		let { x: t, y: n, w: a, h: o } = pe(e), s = e.kind === "node", c = e.kind === "group", l = !!e.bypassed, u = !!e.errored, f = c ? .18 : l && i.renderBypassState ? .14 : .62, p = c ? .55 : l && i.renderBypassState ? .32 : .8, m = d(e.fill, f), h = d(e.stroke, p), g = s && i.showNodeLabels && a >= Ji && o >= Yi, _ = Math.max(2, Math.min(g ? 7 : 8, Math.floor(Math.min(a, o) * .08))), v = s ? me(o) : 0;
+		let { x: t, y: n, w: a, h: o } = pe(e), s = e.kind === "node", c = e.kind === "group", l = !!e.bypassed, u = !!e.errored, f = c ? .18 : l && i.renderBypassState ? .14 : .62, p = c ? .55 : l && i.renderBypassState ? .32 : .8, m = d(e.fill, f), h = d(e.stroke, p), g = s && i.showNodeLabels && a >= Yi && o >= Xi, _ = Math.max(2, Math.min(g ? 7 : 8, Math.floor(Math.min(a, o) * .08))), v = s ? me(o) : 0;
 		if (r.save(), r.globalAlpha = 1, typeof m == "string" && (m.startsWith("#") || m.startsWith("rgb") || m.startsWith("hsl")) ? (r.fillStyle = m, r.globalAlpha = f) : (r.fillStyle = typeof m == "string" ? m : "rgba(82,88,96,0.72)", r.globalAlpha = f), typeof r.roundRect == "function" ? (r.beginPath(), r.roundRect(t, n, a, o, _), r.fill()) : r.fillRect(t, n, a, o), r.restore(), s && (r.save(), r.fillStyle = d(e.stroke || e.fill, l ? .34 : .9), typeof r.roundRect == "function" ? (r.beginPath(), r.roundRect(t, n, a, v, [
 			_,
 			_,
@@ -3499,11 +3517,11 @@ function ea(e, t, n = null) {
 			r.save(), r.strokeStyle = "rgba(0,0,0,0.48)", r.lineWidth = 1;
 			for (let i = 0; i < n; i += 1) {
 				let n = he(e, i, "input");
-				r.fillStyle = Qi(e.inputs?.[i]?.type, !1), r.beginPath(), r.arc(t, n, g ? 3 : 2.2, 0, Math.PI * 2), r.fill(), r.stroke();
+				r.fillStyle = $i(e.inputs?.[i]?.type, !1), r.beginPath(), r.arc(t, n, g ? 3 : 2.2, 0, Math.PI * 2), r.fill(), r.stroke();
 			}
 			for (let n = 0; n < i; n += 1) {
 				let i = he(e, n, "output");
-				r.fillStyle = Qi(e.outputs?.[n]?.type, !0), r.beginPath(), r.arc(t + a, i, g ? 3 : 2.2, 0, Math.PI * 2), r.fill(), r.stroke();
+				r.fillStyle = $i(e.outputs?.[n]?.type, !0), r.beginPath(), r.arc(t + a, i, g ? 3 : 2.2, 0, Math.PI * 2), r.fill(), r.stroke();
 			}
 			r.restore();
 		}
@@ -3515,7 +3533,7 @@ function ea(e, t, n = null) {
 			}
 			r.strokeStyle = "rgba(244,67,54,0.95)", r.lineWidth = 1.5, r.strokeRect(t - .5, n - .5, a + 1, o + 1);
 		}
-		if (s && ue && String(e.id || "") === ue) {
+		if (s && de && String(e.id || "") === de) {
 			try {
 				r.setLineDash([]);
 			} catch (e) {
@@ -3546,12 +3564,12 @@ function ea(e, t, n = null) {
 			let i = Math.max(24, a * .34);
 			for (let a = 0; a < Math.min(8, e.inputs?.length || 0); a += 1) {
 				let o = e.inputs[a], s = String(o?.label || o?.localized_name || o?.name || "").trim();
-				s && r.fillText($i(r, s, i), t + 7, he(e, a, "input") + n * .35, i);
+				s && r.fillText(ea(r, s, i), t + 7, he(e, a, "input") + n * .35, i);
 			}
 			for (let o = 0; o < Math.min(8, e.outputs?.length || 0); o += 1) {
 				let s = e.outputs[o], c = String(s?.label || s?.localized_name || s?.name || "").trim();
 				if (!c) continue;
-				let l = $i(r, c, i);
+				let l = ea(r, c, i);
 				r.fillText(l, t + a - 7 - Math.min(i, r.measureText(l).width), he(e, o, "output") + n * .35, i);
 			}
 			r.restore();
@@ -3561,9 +3579,9 @@ function ea(e, t, n = null) {
 	ve();
 	for (let e of m.filter((e) => e.kind === "node")) ye(e);
 	if (i.showViewport) try {
-		let e = Oe();
+		let e = ke();
 		if (e) {
-			let t = de(e.x0, e.y0), n = de(e.x1, e.y1), i = Math.min(t.x, n.x), a = Math.min(t.y, n.y), o = Math.abs(n.x - t.x), s = Math.abs(n.y - t.y);
+			let t = D(e.x0, e.y0), n = D(e.x1, e.y1), i = Math.min(t.x, n.x), a = Math.min(t.y, n.y), o = Math.abs(n.x - t.x), s = Math.abs(n.y - t.y);
 			r.save(), r.globalAlpha = 1, r.strokeStyle = "rgba(255,255,255,0.9)", r.lineWidth = 1, r.strokeRect(i, a, o, s), r.restore();
 		}
 	} catch (e) {
@@ -3580,17 +3598,17 @@ function ea(e, t, n = null) {
 		},
 		resolvedView: {
 			zoom: T,
-			centerX: ie,
-			centerY: ae,
-			visibleW: E,
-			visibleH: ne,
-			viewMinX: oe,
-			viewMinY: se,
-			pad: ce,
-			renderScale: le
+			centerX: ae,
+			centerY: oe,
+			visibleW: ne,
+			visibleH: re,
+			viewMinX: se,
+			viewMinY: ce,
+			pad: le,
+			renderScale: ue
 		},
 		canvasToWorld: fe,
-		worldToCanvas: de,
+		worldToCanvas: D,
 		hitTestNode: (e, t) => {
 			let n = fe(e, t);
 			for (let e = m.length - 1; e >= 0; --e) {
@@ -3601,16 +3619,16 @@ function ea(e, t, n = null) {
 		}
 	};
 }
-function ta(e, t = null) {
+function na(e, t = null) {
 	if (!e || typeof e != "object") return e;
-	let n = Array.isArray(e.nodes) ? e.nodes.filter(Boolean) : [], r = na(e, t);
+	let n = Array.isArray(e.nodes) ? e.nodes.filter(Boolean) : [], r = ra(e, t);
 	if (!n.length) return e;
 	let i = [], a = Array.isArray(e.links) ? [...e.links] : [], o = [...Array.isArray(e.groups) ? e.groups : [], ...Array.isArray(e.extra?.groups) ? e.extra.groups : []];
 	for (let e of n) {
 		i.push(e);
-		let t = ra(e, r);
+		let t = ia(e, r);
 		if (!t || !Array.isArray(t.nodes) || !t.nodes.length) continue;
-		let n = aa(e, ta(t, r));
+		let n = oa(e, na(t, r));
 		i.push(...n.nodes), a.push(...n.links), n.group && o.push(n.group);
 	}
 	return {
@@ -3624,16 +3642,16 @@ function ta(e, t = null) {
 		}
 	};
 }
-function na(e, t = null) {
+function ra(e, t = null) {
 	let n = [
 		...Array.isArray(e?.definitions?.subgraphs) ? e.definitions.subgraphs : [],
 		...Array.isArray(e?.subgraphs) ? e.subgraphs : [],
 		...Array.isArray(e?.rootGraph?.subgraphs) ? e.rootGraph.subgraphs : []
 	], r = new Map(t || []);
-	for (let e of n) for (let t of ia(e)) t != null && r.set(String(t), e);
+	for (let e of n) for (let t of aa(e)) t != null && r.set(String(t), e);
 	return r;
 }
-function ra(e, t) {
+function ia(e, t) {
 	let n = [
 		e?.type,
 		e?.comfyClass,
@@ -3661,7 +3679,7 @@ function ra(e, t) {
 		e?.subgraph_graph
 	].find((e) => e && typeof e == "object" && Array.isArray(e.nodes)) || null;
 }
-function ia(e) {
+function aa(e) {
 	return [
 		e?.id,
 		e?.name,
@@ -3673,9 +3691,9 @@ function ia(e) {
 		e?.properties?.subgraphId
 	].filter((e) => e != null && String(e).trim());
 }
-function aa(e, t) {
-	let n = String(e?.id ?? e?.ID ?? ""), r = sa(e?.pos) || [0, 0], i = ca(e?.size) || [260, 180], a = t.nodes.filter(Boolean), o = oa(a), s = Math.min(22, Math.max(8, i[0] * .08)), c = Math.min(34, Math.max(18, i[1] * .18)), l = Math.min(18, Math.max(8, i[1] * .08)), u = Math.max(40, i[0] - s * 2), d = Math.max(34, i[1] - c - l), f = Math.min(1, u / o.width, d / o.height), p = r[0] + s + (u - o.width * f) / 2, m = r[1] + c + (d - o.height * f) / 2, h = a.map((r) => {
-		let i = sa(r?.pos) || [o.minX, o.minY], a = ca(r?.size) || [140, 60];
+function oa(e, t) {
+	let n = String(e?.id ?? e?.ID ?? ""), r = ca(e?.pos) || [0, 0], i = la(e?.size) || [260, 180], a = t.nodes.filter(Boolean), o = sa(a), s = Math.min(22, Math.max(8, i[0] * .08)), c = Math.min(34, Math.max(18, i[1] * .18)), l = Math.min(18, Math.max(8, i[1] * .08)), u = Math.max(40, i[0] - s * 2), d = Math.max(34, i[1] - c - l), f = Math.min(1, u / o.width, d / o.height), p = r[0] + s + (u - o.width * f) / 2, m = r[1] + c + (d - o.height * f) / 2, h = a.map((r) => {
+		let i = ca(r?.pos) || [o.minX, o.minY], a = la(r?.size) || [140, 60];
 		return {
 			...r,
 			id: `${n}::${r?.id ?? r?.ID ?? ""}`,
@@ -3715,12 +3733,12 @@ function aa(e, t) {
 		}
 	};
 }
-function oa(e) {
+function sa(e) {
 	let t = Infinity, n = Infinity, r = -Infinity, i = -Infinity;
 	for (let a of e) {
-		let e = sa(a?.pos);
+		let e = ca(a?.pos);
 		if (!e) continue;
-		let o = ca(a?.size) || [140, 60];
+		let o = la(a?.size) || [140, 60];
 		t = Math.min(t, e[0]), n = Math.min(n, e[1]), r = Math.max(r, e[0] + o[0]), i = Math.max(i, e[1] + o[1]);
 	}
 	return Number.isFinite(t) ? {
@@ -3735,7 +3753,7 @@ function oa(e) {
 		height: 1
 	};
 }
-function sa(e) {
+function ca(e) {
 	if (Array.isArray(e) && e.length >= 2) return [Number(e[0]), Number(e[1])];
 	if (e && typeof e == "object") {
 		let t = e[0] ?? e[0] ?? e.x ?? e.left ?? null, n = e[1] ?? e[1] ?? e.y ?? e.top ?? null;
@@ -3743,7 +3761,7 @@ function sa(e) {
 	}
 	return null;
 }
-function ca(e) {
+function la(e) {
 	if (Array.isArray(e) && e.length >= 2) return [Number(e[0]), Number(e[1])];
 	if (e && typeof e == "object") {
 		let t = e[0] ?? e[0] ?? e.w ?? e.width ?? null, n = e[1] ?? e[1] ?? e.h ?? e.height ?? null;
@@ -3751,12 +3769,12 @@ function ca(e) {
 	}
 	return null;
 }
-function la(e) {
+function ua(e) {
 	if (Array.isArray(e)) return !0;
 	let t = String(e || "").trim().toUpperCase();
 	return t === "INT" || t === "FLOAT" || t === "STRING" || t === "BOOLEAN" || t === "BOOL" || t === "COMBO" || t === "ENUM";
 }
-function ua(e, t = null) {
+function da(e, t = null) {
 	if (!e || typeof e != "object") return null;
 	let n = {
 		maxNodes: 220,
@@ -3827,7 +3845,7 @@ function ua(e, t = null) {
 }
 //#endregion
 //#region ui/features/workflows/workflowPickerState.ts
-var X = Ct({
+var X = wt({
 	open: !1,
 	mode: "workflow",
 	title: "",
@@ -3836,17 +3854,17 @@ var X = Ct({
 	items: [],
 	resolve: null
 });
-function da({ title: e = "Select workflow", sourceAsset: t = null } = {}) {
-	return pa(null), X.open = !0, X.mode = "workflow", X.title = String(e || "Select workflow"), X.sourceAsset = t || null, X.workflow = null, X.items = [], new Promise((e) => {
+function fa({ title: e = "Select workflow", sourceAsset: t = null } = {}) {
+	return ma(null), X.open = !0, X.mode = "workflow", X.title = String(e || "Select workflow"), X.sourceAsset = t || null, X.workflow = null, X.items = [], new Promise((e) => {
 		X.resolve = e;
 	});
 }
-function fa({ title: e = "Select asset", workflow: t = null, items: n = [] } = {}) {
-	return pa(null), X.open = !0, X.mode = "asset", X.title = String(e || "Select asset"), X.sourceAsset = null, X.workflow = t || null, X.items = Array.isArray(n) ? n.filter(Boolean) : [], new Promise((e) => {
+function pa({ title: e = "Select asset", workflow: t = null, items: n = [] } = {}) {
+	return ma(null), X.open = !0, X.mode = "asset", X.title = String(e || "Select asset"), X.sourceAsset = null, X.workflow = t || null, X.items = Array.isArray(n) ? n.filter(Boolean) : [], new Promise((e) => {
 		X.resolve = e;
 	});
 }
-function pa(e = null) {
+function ma(e = null) {
 	let t = X.resolve;
 	if (X.open = !1, X.mode = "workflow", X.title = "", X.sourceAsset = null, X.workflow = null, X.items = [], X.resolve = null, typeof t == "function") try {
 		t(e || null);
@@ -3856,41 +3874,41 @@ function pa(e = null) {
 }
 //#endregion
 //#region ui/vue/majoorPrimeVue.ts
-var ma = {
-	Button: ct,
-	Checkbox: st,
-	InputText: wt,
-	Textarea: pt,
-	Select: xt,
-	ToggleButton: _t,
-	Badge: vt,
-	Tag: it,
-	Dialog: dt,
-	Menu: bt,
-	Listbox: gt,
-	Tree: St,
-	VirtualScroller: ot
+var ha = {
+	Button: lt,
+	Checkbox: ct,
+	InputText: Tt,
+	Textarea: mt,
+	Select: St,
+	ToggleButton: vt,
+	Badge: yt,
+	Tag: at,
+	Dialog: ft,
+	Menu: xt,
+	Listbox: _t,
+	Tree: Ct,
+	VirtualScroller: st
 };
-function ha(e) {
-	return e.use(lt, {
+function ga(e) {
+	return e.use(ut, {
 		ripple: !1,
 		unstyled: !0,
 		zIndex: { overlay: 10100 }
-	}), e.use(ut), e.use(ht), Object.entries(ma).forEach(([t, n]) => {
+	}), e.use(dt), e.use(gt), Object.entries(ha).forEach(([t, n]) => {
 		e.component(`M${t}`, n);
 	}), e;
 }
 //#endregion
 //#region ui/vue/createVueApp.ts
-function ga(e, t = void 0) {
-	let n = Et(), r = rt(e, t);
-	return r.use(n), ha(r), {
+function _a(e, t = void 0) {
+	let n = Dt(), r = it(e, t);
+	return r.use(n), ga(r), {
 		app: r,
 		pinia: n
 	};
 }
-var _a = /* @__PURE__ */ new Map();
-function va(e, t, n) {
+var va = /* @__PURE__ */ new Map();
+function ya(e, t, n) {
 	try {
 		window.dispatchEvent(new CustomEvent("mjr:keepalive-attached", { detail: {
 			mountKey: String(e || "_mjrVueApp"),
@@ -3899,28 +3917,28 @@ function va(e, t, n) {
 		} }));
 	} catch {}
 }
-function ya(e) {
+function ba(e) {
 	let t = document.createElement("div");
 	return t.dataset.mjrKeepAliveHost = String(e || "_mjrVueApp"), t.style.height = "100%", t.style.width = "100%", t.style.minHeight = "0", t.style.display = "flex", t.style.flexDirection = "column", t.style.overflow = "hidden", t;
 }
-function ba(e, t) {
-	!e || !t || (e.style.height = "100%", e.style.minHeight = "0", e.style.display = "flex", e.style.flexDirection = "column", e.style.overflow = "hidden", !(e.firstChild === t && e.childNodes.length === 1) && (e.replaceChildren(t), va(t?.dataset?.mjrKeepAliveHost, t, e)));
+function xa(e, t) {
+	!e || !t || (e.style.height = "100%", e.style.minHeight = "0", e.style.display = "flex", e.style.flexDirection = "column", e.style.overflow = "hidden", !(e.firstChild === t && e.childNodes.length === 1) && (e.replaceChildren(t), ya(t?.dataset?.mjrKeepAliveHost, t, e)));
 }
-function xa(e, t, n = "_mjrVueApp") {
+function Sa(e, t, n = "_mjrVueApp") {
 	if (!e) return !1;
-	let r = _a.get(n), i = !1;
+	let r = va.get(n), i = !1;
 	if (!r) {
-		let e = ya(n), { app: a } = ga(t);
+		let e = ba(n), { app: a } = _a(t);
 		a.mount(e), r = {
 			app: a,
 			host: e,
 			container: null
-		}, _a.set(n, r), i = !0;
+		}, va.set(n, r), i = !0;
 	}
-	return ba(e, r.host), r.container = e, i;
+	return xa(e, r.host), r.container = e, i;
 }
-function Sa(e, t = "_mjrVueApp") {
-	let n = _a.get(t);
+function Ca(e, t = "_mjrVueApp") {
+	let n = va.get(t);
 	if (n?.app) {
 		try {
 			n.app.unmount();
@@ -3928,30 +3946,30 @@ function Sa(e, t = "_mjrVueApp") {
 		try {
 			n.host?.remove?.();
 		} catch {}
-		_a.delete(t);
+		va.delete(t);
 	}
 }
 //#endregion
 //#region ui/utils/format.ts
-function Ca(e) {
+function wa(e) {
 	if (!e) return null;
 	let t = Number(e);
 	if (!isNaN(t)) return /* @__PURE__ */ new Date(t * 1e3);
 	let n = new Date(e);
 	return isNaN(n.getTime()) ? null : n;
 }
-function wa(e) {
-	let t = Ca(e);
+function Ta(e) {
+	let t = wa(e);
 	return t ? `${t.getDate().toString().padStart(2, "0")}/${(t.getMonth() + 1).toString().padStart(2, "0")}` : "";
 }
-function Ta(e) {
-	let t = Ca(e);
+function Ea(e) {
+	let t = wa(e);
 	return t ? `${t.getHours().toString().padStart(2, "0")}:${t.getMinutes().toString().padStart(2, "0")}` : "";
 }
-function Ea(e) {
+function Da(e) {
 	return e ? e < 60 ? `${Math.round(e)}s` : `${Math.floor(e / 60)}m ${Math.round(e % 60)}s` : "";
 }
-var Da = {
+var Oa = {
 	version: 1,
 	parser_family_version: "geninfo-catalog-v1",
 	sections: [
@@ -4044,25 +4062,25 @@ var Da = {
 		}
 	]
 };
-function Oa() {
+function ka() {
 	let e = {};
-	for (let t of Da.sections) {
+	for (let t of Oa.sections) {
 		e[t.key] = t.searchField, e[t.searchField] = t.searchField;
 		for (let n of t.aliases || []) e[String(n).toLowerCase()] = t.searchField;
 	}
 	return e;
 }
-function ka(e) {
-	let t = String(e || "").trim().toLowerCase();
-	return Oa()[t] || "";
-}
 function Aa(e) {
 	let t = String(e || "").trim().toLowerCase();
-	return t && Da.sections.find((e) => e.key === t) || null;
+	return ka()[t] || "";
+}
+function ja(e) {
+	let t = String(e || "").trim().toLowerCase();
+	return t && Oa.sections.find((e) => e.key === t) || null;
 }
 //#endregion
 //#region ui/vue/components/panel/sidebar/SidebarFileInfoSection.vue
-var ja = {
+var Ma = {
 	key: 0,
 	class: "mjr-sidebar-section",
 	style: {
@@ -4071,11 +4089,11 @@ var ja = {
 		"border-radius": "8px",
 		padding: "10px"
 	}
-}, Ma = { style: {
+}, Na = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "6px"
-} }, Na = ["title"], Pa = ["title"], Fa = {
+} }, Pa = ["title"], Fa = ["title"], Ia = {
 	__name: "SidebarFileInfoSection",
 	props: { asset: {
 		type: Object,
@@ -4126,16 +4144,16 @@ var ja = {
 				tooltip: "Image/video resolution in pixels"
 			}), e.duration && e.duration > 0 && d.push({
 				label: "Duration",
-				value: Ea(e.duration),
+				value: Da(e.duration),
 				tooltip: "Video duration"
 			});
-			let f = qe(e);
+			let f = Je(e);
 			f != null && d.push({
 				label: "FPS",
-				value: Ge(f),
+				value: Ke(f),
 				tooltip: "Native frame rate"
 			});
-			let p = Ke(e, f);
+			let p = qe(e, f);
 			d.push({
 				label: "Frames",
 				value: p == null ? "N/A" : String(Math.max(0, Math.floor(p))),
@@ -4169,16 +4187,16 @@ var ja = {
 				value: String(i(l.color_space, s.color_space, s.colorspace) || "N/A"),
 				tooltip: "Encoded color space"
 			});
-			let m = Ve(e.generation_time_ms ?? e.metadata?.generation_time_ms ?? 0);
+			let m = He(e.generation_time_ms ?? e.metadata?.generation_time_ms ?? 0);
 			m > 0 && d.push({
 				label: "Generation Time",
 				value: `${(Number(m) / 1e3).toFixed(1)}s`,
 				tooltip: "Time taken to generate this asset (workflow execution time)",
-				valueStyle: `color: ${Ue(m)}; font-weight: 600;`
+				valueStyle: `color: ${We(m)}; font-weight: 600;`
 			});
 			let h = e.generation_time || e.file_creation_time || e.mtime || e.created_at;
 			if (h) {
-				let e = wa(h), t = Ta(h);
+				let e = Ta(h), t = Ea(h);
 				e && d.push({
 					label: "Date",
 					value: e,
@@ -4223,14 +4241,14 @@ var ja = {
 				tooltip: "ComfyUI workflow identifier (from workflow.id in extra_data)"
 			}), d;
 		});
-		return (e, t) => s.value.length ? (j(), z("div", ja, [t[0] ||= N("div", { style: {
+		return (e, t) => s.value.length ? (j(), z("div", Ma, [t[0] ||= N("div", { style: {
 			"font-size": "12px",
 			"font-weight": "700",
 			color: "#607d8b",
 			"margin-bottom": "8px",
 			"text-transform": "uppercase",
 			"letter-spacing": "0.4px"
-		} }, " File Info ", -1), N("div", Ma, [(j(!0), z(M, null, P(s.value, (e) => (j(), z("div", {
+		} }, " File Info ", -1), N("div", Na, [(j(!0), z(M, null, P(s.value, (e) => (j(), z("div", {
 			key: e.label,
 			style: {
 				display: "flex",
@@ -4245,12 +4263,12 @@ var ja = {
 				opacity: "0.68",
 				"min-width": "92px"
 			}
-		}, R(e.label), 9, Na), N("div", {
+		}, R(e.label), 9, Pa), N("div", {
 			style: V(e.valueStyle || "font-size: 12px; text-align: right; word-break: break-word"),
 			title: String(e.value || "")
-		}, R(e.value), 13, Pa)]))), 128))])])) : F("", !0);
+		}, R(e.value), 13, Fa)]))), 128))])])) : F("", !0);
 	}
-}, Ia = new Set([
+}, La = new Set([
 	"png",
 	"jpg",
 	"jpeg",
@@ -4267,31 +4285,31 @@ var ja = {
 	"hdr",
 	"svg"
 ]);
-function La(e) {
+function Ra(e) {
 	let t = String(e?.filename || e?.name || e?.filepath || e?.path || "").trim().toLowerCase();
 	return !t || !t.includes(".") ? "" : t.split(".").pop() || "";
 }
-function Ra(e) {
-	return String(e?.kind || "").trim().toLowerCase() === "image" || String(e?.mime || e?.mimetype || "").trim().toLowerCase().startsWith("image/") ? !0 : Ia.has(La(e));
-}
 function za(e) {
-	let t = La(e);
+	return String(e?.kind || "").trim().toLowerCase() === "image" || String(e?.mime || e?.mimetype || "").trim().toLowerCase().startsWith("image/") ? !0 : La.has(Ra(e));
+}
+function Ba(e) {
+	let t = Ra(e);
 	return t === "jpg" || t === "jpeg";
 }
-function Ba() {
+function Va() {
 	try {
-		return !!(Ut()?.ai?.vectorSearchEnabled ?? !0);
+		return !!(Wt()?.ai?.vectorSearchEnabled ?? !0);
 	} catch {
 		return !0;
 	}
 }
-function Va(e) {
+function Ha(e) {
 	return e >= .75 ? "#4CAF50" : e >= .5 ? "#8BC34A" : e >= .3 ? "#FF9800" : "#F44336";
 }
-function Ha(e) {
+function Ua(e) {
 	return e >= .85 ? "Excellent" : e >= .7 ? "Good" : e >= .5 ? "Fair" : e >= .3 ? "Low" : "Very Low";
 }
-function Ua(e) {
+function Wa(e) {
 	let t = String(e || "").trim();
 	if (!t) return "";
 	let n = [];
@@ -4301,21 +4319,21 @@ function Ua(e) {
 	}
 	return (n.length ? n.join(" ") : t).replace(/\s+/g, " ").replace(/:{2,}\s*$/, "").trim();
 }
-function Wa(e) {
+function Ga(e) {
 	let t = String(e?.filename || "").trim();
 	if (!t) return [];
 	let n = String(e?.subfolder || "").trim(), r = String(e?.folder_type || "input").trim().toLowerCase(), i = [], a = (e) => {
 		if (!e) return;
-		let r = Ie(t, n, e);
+		let r = Le(t, n, e);
 		r && !i.includes(r) && i.push(r);
 	};
 	return (r === "input" || r === "output") && a(r), a("input"), a("output"), i;
 }
-function Ga(e) {
+function Ka(e) {
 	let t = String(e?.filepath || "").trim(), n = String(e?.filename || "").trim();
 	return !t || t === n ? "" : t;
 }
-function Ka(e) {
+function qa(e) {
 	let t = String(e || "").trim();
 	if (!t) return !1;
 	if (t.startsWith("/")) return !0;
@@ -4329,7 +4347,7 @@ function Ka(e) {
 function Z(e) {
 	return e == null || e === "" ? "-" : String(e);
 }
-function qa(e, t) {
+function Ja(e, t) {
 	let n = String(e?.pass_stage || e?.stage || e?.kind || "").trim().toLowerCase();
 	if (n === "txt2img" || n === "text_to_image" || n === "text-to-image") return O("sidebar.generation.stageTextToImage", "Text-to-Image");
 	if (n === "img2img" || n === "image_to_image" || n === "image-to-image") return O("sidebar.generation.stageImageToImage", "Image-to-Image");
@@ -4341,34 +4359,34 @@ function qa(e, t) {
 	let i = Number(e?.denoise);
 	return t === 0 || i === 1 ? O("sidebar.generation.stageBase", "Base") : Number.isFinite(i) && i < 1 ? O("sidebar.generation.stageRefineUpscale", "Refine / Upscale") : O("sidebar.generation.stagePassN", "Pass {n}", { n: t + 1 });
 }
-function Ja(e) {
+function Ya(e) {
 	let t = [];
 	return e?.metadata_raw && t.push(e.metadata_raw), e?.workflow && t.push(e.workflow), e?.metadata_raw?.workflow && t.push(e.metadata_raw.workflow), e?.metadata_raw?.raw_ffprobe?.format?.tags && t.push(e.metadata_raw.raw_ffprobe.format.tags), e?.metadata_raw?.ffprobe?.format?.tags && t.push(e.metadata_raw.ffprobe.format.tags), e?.geninfo && typeof e.geninfo == "object" && t.push({ geninfo: e.geninfo }), e?.metadata && (typeof e.metadata == "object" || typeof e.metadata == "string") && t.push(e.metadata), e?.prompt && (typeof e.prompt == "object" || typeof e.prompt == "string") && t.push(e.prompt), e?.exif && t.push(e.exif), e && typeof e == "object" && t.push(e), t;
 }
-function Ya(e, t) {
+function Xa(e, t) {
 	for (let [n, r] of Object.entries(t)) r == null || r === "" || (e[n] === void 0 || e[n] === null || e[n] === "") && (e[n] = r);
 }
-function Xa(e) {
-	let t = Ja(e), n = {};
+function Za(e) {
+	let t = Ya(e), n = {};
 	for (let e of t) {
-		let t = kt(e);
-		!t || typeof t != "object" || Ya(n, t);
+		let t = At(e);
+		!t || typeof t != "object" || Xa(n, t);
 	}
 	return Object.keys(n).length ? n : null;
 }
-function Za(e) {
+function Qa(e) {
 	try {
 		if (!e || typeof e != "object") return !1;
-		if (e.is_override || typeof e.workflow_notes == "string" && e.workflow_notes.trim() || typeof e.notes == "string" && e.notes.trim() || Array.isArray(e.custom_info) && e.custom_info.length > 0 || e.engine && typeof e.engine == "object" && e.engine.type || jt(e.prompt) || typeof (e.negative_prompt || e.negativePrompt) == "string" && jt(e.negative_prompt || e.negativePrompt) || e.models || e.model || e.checkpoint || e.loras || e.ltx_director && typeof e.ltx_director == "object" || e.ideogram && typeof e.ideogram == "object" || e.sampler || e.sampler_name || e.steps || e.cfg || e.cfg_scale || e.cfg_high_noise || e.cfg_low_noise || e.scheduler || Array.isArray(e.chained_passes) && e.chained_passes.length > 0 || Array.isArray(e.all_samplers) && e.all_samplers.length > 0 || e.seed || e.denoise || e.denoising || e.clip_skip || e.voice || e.language || e.temperature || e.top_k || e.top_p || e.repetition_penalty || e.max_new_tokens || e.device || e.voice_preset || e.instruct || e.dtype || e.attn_implementation || e.enable_chunking !== void 0 || e.max_chars_per_chunk || e.chunk_combination_method || e.silence_between_chunks_ms || e.enable_audio_cache !== void 0 || e.batch_size !== void 0 || e.use_torch_compile !== void 0 || e.use_cuda_graphs !== void 0 || e.compile_mode || typeof e.lyrics == "string" && e.lyrics.trim()) return !0;
+		if (e.is_override || typeof e.workflow_notes == "string" && e.workflow_notes.trim() || typeof e.notes == "string" && e.notes.trim() || Array.isArray(e.custom_info) && e.custom_info.length > 0 || e.engine && typeof e.engine == "object" && e.engine.type || Mt(e.prompt) || typeof (e.negative_prompt || e.negativePrompt) == "string" && Mt(e.negative_prompt || e.negativePrompt) || e.models || e.model || e.checkpoint || e.loras || e.ltx_director && typeof e.ltx_director == "object" || e.ideogram && typeof e.ideogram == "object" || e.sampler || e.sampler_name || e.steps || e.cfg || e.cfg_scale || e.cfg_high_noise || e.cfg_low_noise || e.scheduler || Array.isArray(e.chained_passes) && e.chained_passes.length > 0 || Array.isArray(e.all_samplers) && e.all_samplers.length > 0 || e.seed || e.denoise || e.denoising || e.clip_skip || e.voice || e.language || e.temperature || e.top_k || e.top_p || e.repetition_penalty || e.max_new_tokens || e.device || e.voice_preset || e.instruct || e.dtype || e.attn_implementation || e.enable_chunking !== void 0 || e.max_chars_per_chunk || e.chunk_combination_method || e.silence_between_chunks_ms || e.enable_audio_cache !== void 0 || e.batch_size !== void 0 || e.use_torch_compile !== void 0 || e.use_cuda_graphs !== void 0 || e.compile_mode || typeof e.lyrics == "string" && e.lyrics.trim()) return !0;
 	} catch {
 		return !1;
 	}
 	return !1;
 }
 function Q(e) {
-	return e ? typeof e == "string" ? Mt(e) : typeof e == "object" ? Mt(e.name || e.value || "") : "" : "";
+	return e ? typeof e == "string" ? Nt(e) : typeof e == "object" ? Nt(e.name || e.value || "") : "" : "";
 }
-function Qa(e, t, n, r) {
+function $a(e, t, n, r) {
 	let i = String(r || "").trim();
 	if (!i) return;
 	let a = `${n}::${i}`;
@@ -4377,15 +4395,15 @@ function Qa(e, t, n, r) {
 		value: i
 	}));
 }
-function $a(e) {
+function eo(e) {
 	let t = `${String(e?.source || "").toLowerCase()} ${String(e?.name || e?.lora_name || "").toLowerCase()}`;
 	return t.includes("high_noise") || t.includes("high noise") ? "high_noise" : t.includes("low_noise") || t.includes("low noise") ? "low_noise" : "";
 }
-function eo(e) {
+function to(e) {
 	let t = [], n = Array.isArray(e.model_groups) ? e.model_groups : [];
 	if (n.length) return n.forEach((e) => {
 		if (!e || typeof e != "object") return;
-		let n = Q(e.model), r = Array.isArray(e.loras) ? e.loras.map((e) => At(e)).filter(Boolean) : [];
+		let n = Q(e.model), r = Array.isArray(e.loras) ? e.loras.map((e) => jt(e)).filter(Boolean) : [];
 		!n && !r.length || t.push({
 			key: String(e.key || "").trim() || `group-${t.length + 1}`,
 			label: String(e.label || "").trim() || `Group ${t.length + 1}`,
@@ -4403,14 +4421,14 @@ function eo(e) {
 		label: O("sidebar.generation.lowNoise", "Low Noise"),
 		model: Q(r.unet_low_noise)
 	}].forEach((e) => {
-		let n = i.filter((t) => $a(t) === e.key).map((e) => At(e)).filter(Boolean);
+		let n = i.filter((t) => eo(t) === e.key).map((e) => jt(e)).filter(Boolean);
 		!e.model && !n.length || t.push({
 			...e,
 			loras: n
 		});
 	}), t;
 }
-function to(e, t) {
+function no(e, t) {
 	return t == null ? null : {
 		label: e,
 		value: t ? O("state.on", "on") : O("state.off", "off")
@@ -4419,74 +4437,74 @@ function to(e, t) {
 function $(e) {
 	return e != null && String(e).trim() !== "";
 }
-function no(e) {
+function ro(e) {
 	let t = String(e || "").toLowerCase();
 	return t.includes("high") ? "#52ffe8" : t.includes("low") ? "#42A5F5" : t.includes("refine") ? "#AB47BC" : t.includes("upscale") ? "#66BB6A" : t.includes("interpolation") || t.includes("video") ? "#dace26" : "#9C27B0";
 }
-function ro(e) {
+function io(e) {
 	return String(e || "").trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
 }
-function io(e, t) {
+function ao(e, t) {
 	let n = String(t || e || "").trim(), r = String(e || n).toLowerCase(), i = r.match(/^pass_(\d+)$/);
 	return i ? O("sidebar.generation.stagePassN", "Pass {n}", { n: Number(i[1]) }) : r.includes("high") ? "High" : r.includes("low") ? "Low" : r.includes("refine") ? "Refiner" : r.includes("upscale") ? "Upscale" : r.includes("text_to_image") || r.includes("image_to_image") || r === "base" ? "Base" : n || "Branch";
 }
-function ao(e, t) {
+function oo(e, t) {
 	let n = new Set(t.map((e) => String(e).toLowerCase()));
 	return e.find((e) => n.has(String(e.label || "").toLowerCase())) || null;
 }
-function oo(e, t) {
+function so(e, t) {
 	return $(t) ? {
 		label: e,
 		value: t
 	} : null;
 }
-function so(e) {
+function co(e) {
 	let t = String(e || "").toLowerCase();
 	return t.includes("high_noise") || t.includes("high-noise") || t.includes("high noise") ? "high" : t.includes("low_noise") || t.includes("low-noise") || t.includes("low noise") ? "low" : "";
 }
-function co(e) {
+function lo(e) {
 	return Array.isArray(e) || e && typeof e == "object" ? !1 : $(e) && String(e).trim() !== "-";
 }
-function lo(e) {
+function uo(e) {
 	return typeof e == "number" ? Math.abs(e - Math.round(e)) < 1e-9 ? String(Math.round(e)) : e.toFixed(2).replace(/0+$/g, "").replace(/\.$/, "") : String(e ?? "").trim();
 }
-function uo(e) {
+function fo(e) {
 	if (!$(e)) return null;
 	let t = Number(e);
 	return !Number.isFinite(t) || t <= 0 ? null : e;
 }
-function fo(e, t) {
-	let n = uo(e.seed);
+function po(e, t) {
+	let n = fo(e.seed);
 	if (n !== null) return n;
 	let r = [Array.isArray(e.chained_passes) ? e.chained_passes : [], Array.isArray(e.all_samplers) ? e.all_samplers : []];
 	for (let e of r) for (let t of e) {
-		let e = uo(t?.seed_val ?? t?.seed);
+		let e = fo(t?.seed_val ?? t?.seed);
 		if (e !== null) return e;
 	}
 	for (let e of t || []) {
-		let t = uo(ao(e.fields || [], ["Seed"])?.value);
+		let t = fo(oo(e.fields || [], ["Seed"])?.value);
 		if (t !== null) return t;
 	}
 	return null;
 }
-function po(e, t) {
-	if (!t || !co(t.value)) return;
-	let n = `${String(t.label || "").toLowerCase()}::${lo(t.value)}`;
-	e.some((e) => `${String(e.label || "").toLowerCase()}::${lo(e.value)}` === n) || e.push({
+function mo(e, t) {
+	if (!t || !lo(t.value)) return;
+	let n = `${String(t.label || "").toLowerCase()}::${uo(t.value)}`;
+	e.some((e) => `${String(e.label || "").toLowerCase()}::${uo(e.value)}` === n) || e.push({
 		...t,
-		value: lo(t.value)
+		value: uo(t.value)
 	});
 }
-function mo(e, t, n, r) {
+function ho(e, t, n, r) {
 	let i = /* @__PURE__ */ new Map(), a = (e, t) => {
-		let n = ro(e || t || "branch") || "branch";
+		let n = io(e || t || "branch") || "branch";
 		n.includes("high") && (n = "high"), n.includes("low") && (n = "low");
 		let r = i.get(n);
 		if (r) return r;
 		let a = {
 			key: n,
-			label: io(n, t),
-			accent: no(n),
+			label: ao(n, t),
+			accent: ro(n),
 			modelFields: [],
 			samplingFields: [],
 			loras: []
@@ -4494,7 +4512,7 @@ function mo(e, t, n, r) {
 		return i.set(n, a), a;
 	}, o = (e, t, n) => {
 		let r = String(n || "").trim();
-		r && (e.modelFields.some((e) => String(e.label || "").toLowerCase() === String(t || "").toLowerCase() && Mt(e.value) === Mt(r)) || e.modelFields.push({
+		r && (e.modelFields.some((e) => String(e.label || "").toLowerCase() === String(t || "").toLowerCase() && Nt(e.value) === Nt(r)) || e.modelFields.push({
 			label: t,
 			value: r
 		}));
@@ -4509,7 +4527,7 @@ function mo(e, t, n, r) {
 	}
 	let c = e.models && typeof e.models == "object" ? e.models : null;
 	if (c) {
-		let t = Q(c.unet), n = so(t), r = Q(c.checkpoint || (n ? null : c.unet) || e.model || e.checkpoint), i = Q(c.unet_high_noise) || (n === "high" ? t : ""), l = Q(c.unet_low_noise) || (n === "low" ? t : ""), u = Q(c.clip), d = Q(c.vae), f = Array.isArray(e.loras) ? e.loras.map((e) => At(e)).filter(Boolean) : [], p = !!(i || l), m = !p && (r || u || d || f.length) ? a("base", "Base") : null, h = p && (u || d) ? a("shared", "Shared") : null, g = i ? a("high", "High") : null, _ = l ? a("low", "Low") : null;
+		let t = Q(c.unet), n = co(t), r = Q(c.checkpoint || (n ? null : c.unet) || e.model || e.checkpoint), i = Q(c.unet_high_noise) || (n === "high" ? t : ""), l = Q(c.unet_low_noise) || (n === "low" ? t : ""), u = Q(c.clip), d = Q(c.vae), f = Array.isArray(e.loras) ? e.loras.map((e) => jt(e)).filter(Boolean) : [], p = !!(i || l), m = !p && (r || u || d || f.length) ? a("base", "Base") : null, h = p && (u || d) ? a("shared", "Shared") : null, g = i ? a("high", "High") : null, _ = l ? a("low", "Low") : null;
 		if (m) {
 			r && o(m, e.model || e.checkpoint || c.checkpoint ? "Model" : "UNet", r), u && o(m, "CLIP", u), d && o(m, "VAE", d);
 			for (let e of f) s(m, e);
@@ -4517,22 +4535,22 @@ function mo(e, t, n, r) {
 		h && (u && o(h, "CLIP", u), d && o(h, "VAE", d)), g && o(g, "UNet", i), _ && o(_, "UNet", l);
 	}
 	let l = i.get("high") || i.get("high_noise"), u = i.get("low") || i.get("low_noise"), d = [
-		ao(n, ["Sampler"]),
-		ao(n, ["Scheduler"]),
-		ao(n, ["Steps"]),
-		ao(n, ["Seed"])
-	].filter(Boolean), f = oo("CFG", e.cfg_high_noise), p = oo("CFG", e.cfg_low_noise);
-	l && [...d, ...f ? [f] : []].forEach((e) => po(l.samplingFields, e)), u && [...d, ...p ? [p] : []].forEach((e) => po(u.samplingFields, e));
-	let m = (r || []).some((e) => ro(e.label).includes("upscale")), h = (r || []).length === 2 && (r || []).every((e) => ["base", "pass_2"].includes(ro(e.label)));
+		oo(n, ["Sampler"]),
+		oo(n, ["Scheduler"]),
+		oo(n, ["Steps"]),
+		oo(n, ["Seed"])
+	].filter(Boolean), f = so("CFG", e.cfg_high_noise), p = so("CFG", e.cfg_low_noise);
+	l && [...d, ...f ? [f] : []].forEach((e) => mo(l.samplingFields, e)), u && [...d, ...p ? [p] : []].forEach((e) => mo(u.samplingFields, e));
+	let m = (r || []).some((e) => io(e.label).includes("upscale")), h = (r || []).length === 2 && (r || []).every((e) => ["base", "pass_2"].includes(io(e.label)));
 	for (let [e, t] of (r || []).entries()) {
-		let n = ro(t.label);
+		let n = io(t.label);
 		if (!n) continue;
-		let i = (r || []).filter((e) => ro(e.label) === ro(t.label)).length, o = ro(t.stage), s = o ? (r || []).filter((e) => ro(e.stage) === o).length : 0, c = ao(t.fields || [], ["Model"]), d = so(c?.value);
+		let i = (r || []).filter((e) => io(e.label) === io(t.label)).length, o = io(t.stage), s = o ? (r || []).filter((e) => io(e.stage) === o).length : 0, c = oo(t.fields || [], ["Model"]), d = co(c?.value);
 		["high", "low"].includes(n) || (d ? n = d : s > 1 || i > 1 ? n = `pass_${e + 1}` : h ? n = e === 0 ? "high" : "low" : n === "base" && l && u ? n = "high" : ["text_to_image", "image_to_image"].includes(n) && (n = m ? "low" : "base")), n.includes("upscale") && m && (n = "high");
 		let f = a(n, t.label);
 		if (!/^pass_\d+$/i.test(n) && c && String(c.value || "") !== "-") {
-			let e = Mt(c.value);
-			f.modelFields.some((t) => Mt(t.value) === e) || f.modelFields.push(c);
+			let e = Nt(c.value);
+			f.modelFields.some((t) => Nt(t.value) === e) || f.modelFields.push(c);
 		}
 		for (let e of t.fields || []) [
 			"Sampler",
@@ -4543,11 +4561,11 @@ function mo(e, t, n, r) {
 			"Seed",
 			"Start",
 			"End"
-		].includes(String(e.label || "")) && po(f.samplingFields, e);
+		].includes(String(e.label || "")) && mo(f.samplingFields, e);
 	}
 	return Array.from(i.values()).filter((e) => e.modelFields.length || e.samplingFields.length || e.loras.length);
 }
-function ho(e, t, n, r) {
+function go(e, t, n, r) {
 	let i = [], a = (e, t, n, r) => {
 		let a = r.filter((e) => e && $(e.value) && String(e.value) !== "-");
 		a.length && i.push({
@@ -4558,24 +4576,24 @@ function ho(e, t, n, r) {
 		});
 	};
 	for (let n of t || []) {
-		let t = ro(n.label), r = (n.fields || []).some((e) => {
+		let t = io(n.label), r = (n.fields || []).some((e) => {
 			let t = String(e?.label || "").toLowerCase(), n = String(e?.value || "").toLowerCase();
 			return t.includes("upscaler") || n.includes("upscale") || n.includes("upscaler") || /(?:^|[_\s-])to[_\s-]?\d{3,5}(?:[_\s.-]|$)/i.test(n);
 		});
 		t.includes("upscale") && (e.upscaler || r) && a("upscale", "Upscale", "#66BB6A", n.fields || []), (t.includes("interpolation") || t.includes("rife") || t.includes("film")) && a("interpolation", "Interpolation", "#26C6DA", n.fields || []);
 	}
 	a("audio", "MMAudio", "#26A69A", [
-		oo("Voice", e.voice),
-		oo("Language", e.language),
-		oo("Temperature", e.temperature),
-		oo("Lyrics Strength", e.lyrics_strength)
+		so("Voice", e.voice),
+		so("Language", e.language),
+		so("Temperature", e.temperature),
+		so("Lyrics Strength", e.lyrics_strength)
 	].filter(Boolean)), a("interpolation", "Interpolation", "#26C6DA", [
-		oo("Engine", e.interpolation_engine || e.frame_interpolation || e.interpolator),
-		oo("Source FPS", e.source_fps || e.input_fps),
-		oo("Final FPS", e.final_fps || e.output_fps || e.fps)
+		so("Engine", e.interpolation_engine || e.frame_interpolation || e.interpolator),
+		so("Source FPS", e.source_fps || e.input_fps),
+		so("Final FPS", e.final_fps || e.output_fps || e.fps)
 	].filter(Boolean));
 	for (let e of n || []) i.push({
-		key: ro(e.title) || `module_${i.length}`,
+		key: io(e.title) || `module_${i.length}`,
 		title: e.title,
 		accent: e.color || "#2196F3",
 		fields: [{
@@ -4583,32 +4601,32 @@ function ho(e, t, n, r) {
 			value: e.content
 		}]
 	});
-	r && !i.some((e) => String(e.title).toLowerCase() === String(r).toLowerCase()) && a("workflow_engine", r, "#2196F3", [oo("Engine", r)].filter(Boolean));
+	r && !i.some((e) => String(e.title).toLowerCase() === String(r).toLowerCase()) && a("workflow_engine", r, "#2196F3", [so("Engine", r)].filter(Boolean));
 	let o = /* @__PURE__ */ new Set();
 	return i.filter((e) => {
 		let t = `${e.key}:${e.title}:${JSON.stringify(e.fields)}`;
 		return o.has(t) ? !1 : (o.add(t), !0);
 	});
 }
-function go(e) {
+function _o(e) {
 	return new Set(Array.isArray(e.override_fields) ? e.override_fields.map((e) => String(e || "").trim()).filter(Boolean) : []);
 }
-function _o(e, ...t) {
+function vo(e, ...t) {
 	return t.some((t) => e.has(t));
 }
-function vo(e) {
+function yo(e) {
 	return Array.isArray(e) ? e.filter((e) => e && typeof e == "object").map((e, t) => ({
 		title: String(e.title || O("sidebar.generation.customInfoN", "Custom Info {n}", { n: t + 1 })).trim(),
 		content: String(e.content ?? e.value ?? "").trim(),
 		color: /^#[0-9a-fA-F]{6}$/.test(String(e.color || "").trim()) ? String(e.color).trim() : "#2196F3"
 	})).filter((e) => e.content) : [];
 }
-function yo(e) {
+function bo(e) {
 	if (!e || typeof e != "object") return null;
 	let t = [], n = (e, n) => {
 		$(n) && t.push({
 			label: e,
-			value: lo(n)
+			value: uo(n)
 		});
 	};
 	n("FPS", e.frame_rate), n("Frames", e.duration_frames), n("Duration", e.duration_seconds), ($(e.width) || $(e.height)) && t.push({
@@ -4617,7 +4635,7 @@ function yo(e) {
 	});
 	let r = Array.isArray(e.segments) ? e.segments.map((e, t) => {
 		if (!e || typeof e != "object") return null;
-		let n = jt(e.prompt || e.text || ""), r = String(e.filename || e.imageFile || e.videoFile || e.audioFile || "").trim(), i = String(e.filepath || e.path || r).trim(), a = String(e.in || e.in_label || e.start || e.start_frame || "").trim(), o = String(e.out || e.out_label || e.end || e.end_frame || "").trim();
+		let n = Mt(e.prompt || e.text || ""), r = String(e.filename || e.imageFile || e.videoFile || e.audioFile || "").trim(), i = String(e.filepath || e.path || r).trim(), a = String(e.in || e.in_label || e.start || e.start_frame || "").trim(), o = String(e.out || e.out_label || e.end || e.end_frame || "").trim();
 		if (!n && !r && !a && !o) return null;
 		let s = String(e.type || "").trim().toLowerCase(), c = s === "video" || /\.(mp4|mov|webm|mkv|avi|m4v)$/i.test(r), l = s === "audio" || /\.(mp3|wav|flac|ogg|m4a|aac|opus)$/i.test(r);
 		return {
@@ -4631,14 +4649,14 @@ function yo(e) {
 			type: String(e.type || "").trim(),
 			isVideo: c,
 			isAudio: l,
-			previewCandidates: r ? Wa({
+			previewCandidates: r ? Ga({
 				filename: r,
 				filepath: i,
 				folder_type: String(e.folder_type || e.folderType || "input").trim(),
 				subfolder: String(e.subfolder || "").trim()
 			}) : []
 		};
-	}).filter(Boolean) : [], i = jt(e.global_prompt || e.globalPrompt || "");
+	}).filter(Boolean) : [], i = Mt(e.global_prompt || e.globalPrompt || "");
 	return !i && !r.length && !t.length ? null : {
 		title: String(e.title || "LTX Director").trim(),
 		globalPrompt: i,
@@ -4646,12 +4664,12 @@ function yo(e) {
 		segments: r
 	};
 }
-function bo(e) {
+function xo(e) {
 	if (!e || typeof e != "object") return null;
-	let t = e.payload && typeof e.payload == "object" ? e.payload : e, n = typeof e.json == "string" && e.json.trim() ? e.json.trim() : JSON.stringify(t, null, 2), r = jt(e.high_level_description || e.highLevelDescription || t.high_level_description || ""), i = jt(e.background || t.background || ""), a = [], o = (e, t) => {
+	let t = e.payload && typeof e.payload == "object" ? e.payload : e, n = typeof e.json == "string" && e.json.trim() ? e.json.trim() : JSON.stringify(t, null, 2), r = Mt(e.high_level_description || e.highLevelDescription || t.high_level_description || ""), i = Mt(e.background || t.background || ""), a = [], o = (e, t) => {
 		$(t) && a.push({
 			label: e,
-			value: lo(t)
+			value: uo(t)
 		});
 	};
 	o("Style", t.style), o("Photo Style", t.photo_style || t["style.photo"]), o("Medium", t.medium), o("Lighting", t.lighting), o("Aesthetics", t.aesthetics), o("BG Brightness", t.bg_brightness), ($(t.width) || $(t.height)) && a.push({
@@ -4685,8 +4703,8 @@ function bo(e) {
 		colorPalette: c.map((e) => String(e || "").trim()).filter(Boolean)
 	};
 }
-function xo(e) {
-	let t = Xa(e), n = {
+function So(e) {
+	let t = Za(e), n = {
 		kind: "empty",
 		title: O("sidebar.generation.title", "Generation"),
 		workflowType: "",
@@ -4702,7 +4720,7 @@ function xo(e) {
 		showAlignment: !1,
 		captionLabel: O("sidebar.generation.imageDescription", "Image Description"),
 		emptyCaptionText: O("sidebar.generation.noImageDescription", "No image description yet."),
-		isImageAsset: Ra(e),
+		isImageAsset: za(e),
 		lyrics: "",
 		modelFields: [],
 		modelGroups: [],
@@ -4725,26 +4743,26 @@ function xo(e) {
 		ltxDirector: null,
 		ideogram: null
 	};
-	if (!t || typeof t == "object" && Object.keys(t).length === 0 || !Za(t)) {
+	if (!t || typeof t == "object" && Object.keys(t).length === 0 || !Qa(t)) {
 		let t = e?.metadata_raw?.geninfo_status || e?.geninfo_status;
 		return t && typeof t == "object" && t.kind === "media_pipeline" ? {
 			...n,
 			kind: "media-only",
 			mediaOnlyMessage: O("sidebar.generation.mediaOnlyPipeline", "This file looks like a media-only pipeline (e.g. LoadVideo/VideoCombine) and does not contain generation parameters.")
-		} : Ra(e) || za(e) ? {
+		} : za(e) || Ba(e) ? {
 			...n,
 			kind: "caption-only",
 			showAlignment: !1
 		} : n;
 	}
-	let r = t, i = yo(r.ltx_director), a = bo(r.ideogram), o = go(r), s = r.engine && typeof r.engine == "object" ? r.engine : null, c = !!(r.is_override || s?.mode === "override" || s?.parser_version === "geninfo-override-v1" || s?.source === "majoor_geninfo"), l = Nt(r), u = Ot(typeof r.prompt == "string" ? r.prompt : null, typeof (r.negative_prompt || r.negativePrompt) == "string" ? r.negative_prompt || r.negativePrompt : null), d = Array.isArray(r.all_positive_prompts) && r.all_positive_prompts.length > 1 ? r.all_positive_prompts.map((e, t) => {
-		let n = Ot(typeof e == "string" ? e : "", typeof r.all_negative_prompts?.[t] == "string" ? r.all_negative_prompts[t] : "");
+	let r = t, i = bo(r.ltx_director), a = xo(r.ideogram), o = _o(r), s = r.engine && typeof r.engine == "object" ? r.engine : null, c = !!(r.is_override || s?.mode === "override" || s?.parser_version === "geninfo-override-v1" || s?.source === "majoor_geninfo"), l = Pt(r), u = kt(typeof r.prompt == "string" ? r.prompt : null, typeof (r.negative_prompt || r.negativePrompt) == "string" ? r.negative_prompt || r.negativePrompt : null), d = Array.isArray(r.all_positive_prompts) && r.all_positive_prompts.length > 1 ? r.all_positive_prompts.map((e, t) => {
+		let n = kt(typeof e == "string" ? e : "", typeof r.all_negative_prompts?.[t] == "string" ? r.all_negative_prompts[t] : "");
 		return {
 			label: O("sidebar.generation.promptN", "Prompt {n}", { n: t + 1 }),
-			positive: jt(n.positive),
-			negative: jt(n.negative)
+			positive: Mt(n.positive),
+			negative: Mt(n.negative)
 		};
-	}).filter((e) => e.positive) : [], f = [], p = /* @__PURE__ */ new Set(), m = r.models && typeof r.models == "object" ? r.models : null, h = eo(r), g = new Set(h.map((e) => String(e.model || "").trim()).filter(Boolean)), _ = Array.isArray(r.all_checkpoints) && r.all_checkpoints.length > 1 ? r.all_checkpoints : null;
+	}).filter((e) => e.positive) : [], f = [], p = /* @__PURE__ */ new Set(), m = r.models && typeof r.models == "object" ? r.models : null, h = to(r), g = new Set(h.map((e) => String(e.model || "").trim()).filter(Boolean)), _ = Array.isArray(r.all_checkpoints) && r.all_checkpoints.length > 1 ? r.all_checkpoints : null;
 	if (m) {
 		let e = new Set([
 			Q(m.unet_high_noise),
@@ -4753,11 +4771,11 @@ function xo(e) {
 		].filter(Boolean));
 		if (_) _.forEach((e, t) => {
 			let n = Q(e);
-			Qa(f, p, O("sidebar.generation.checkpointN", "Checkpoint {n}", { n: t + 1 }), n);
+			$a(f, p, O("sidebar.generation.checkpointN", "Checkpoint {n}", { n: t + 1 }), n);
 		});
 		else {
 			let t = Q(m.checkpoint);
-			t && !e.has(t) && Qa(f, p, O("sidebar.generation.checkpoint", "Checkpoint"), t);
+			t && !e.has(t) && $a(f, p, O("sidebar.generation.checkpoint", "Checkpoint"), t);
 		}
 		[
 			["UNet", Q(m.unet)],
@@ -4766,37 +4784,37 @@ function xo(e) {
 			["CLIP", Q(m.clip)],
 			["VAE", Q(m.vae)]
 		].forEach(([t, n]) => {
-			e.has(n) || Qa(f, p, t, n);
+			e.has(n) || $a(f, p, t, n);
 		});
-	} else (r.model || r.checkpoint) && Qa(f, p, O("sidebar.generation.model", "Model"), Mt(r.model || r.checkpoint));
+	} else (r.model || r.checkpoint) && $a(f, p, O("sidebar.generation.model", "Model"), Nt(r.model || r.checkpoint));
 	if (Array.isArray(r.loras) && r.loras.length > 0) {
-		let e = r.loras.map((e) => At(e)).filter(Boolean).join("\n");
-		e && Qa(f, p, r.loras.length > 1 ? O("sidebar.generation.loras", "LoRAs") : "LoRA", e);
+		let e = r.loras.map((e) => jt(e)).filter(Boolean).join("\n");
+		e && $a(f, p, r.loras.length > 1 ? O("sidebar.generation.loras", "LoRAs") : "LoRA", e);
 	}
-	!m && r.clip && Qa(f, p, "CLIP", Mt(r.clip)), !m && r.vae && Qa(f, p, "VAE", Mt(r.vae)), !m && r.unet && Qa(f, p, "UNet", Mt(r.unet)), !m && r.diffusion && Qa(f, p, "Diffusion", Mt(r.diffusion)), !m && r.upscaler && Qa(f, p, O("sidebar.generation.upscaler", "Upscaler"), Mt(r.upscaler)), m && r.clip && Qa(f, p, "CLIP", Mt(r.clip)), m && r.vae && Qa(f, p, "VAE", Mt(r.vae));
+	!m && r.clip && $a(f, p, "CLIP", Nt(r.clip)), !m && r.vae && $a(f, p, "VAE", Nt(r.vae)), !m && r.unet && $a(f, p, "UNet", Nt(r.unet)), !m && r.diffusion && $a(f, p, "Diffusion", Nt(r.diffusion)), !m && r.upscaler && $a(f, p, O("sidebar.generation.upscaler", "Upscaler"), Nt(r.upscaler)), m && r.clip && $a(f, p, "CLIP", Nt(r.clip)), m && r.vae && $a(f, p, "VAE", Nt(r.vae));
 	for (let e of f) {
 		let t = String(e.label || "").toLowerCase();
-		(t.includes("checkpoint") || t === "model") && (e.override = _o(o, "checkpoint", "model")), t === "clip" && (e.override = _o(o, "clip")), t === "vae" && (e.override = _o(o, "vae")), t.includes("lora") && (e.override = _o(o, "loras"));
+		(t.includes("checkpoint") || t === "model") && (e.override = vo(o, "checkpoint", "model")), t === "clip" && (e.override = vo(o, "clip")), t === "vae" && (e.override = vo(o, "vae")), t.includes("lora") && (e.override = vo(o, "loras"));
 	}
 	let v = [];
 	$(r.seed) && v.push({
 		label: O("sidebar.generation.seed", "Seed"),
 		value: r.seed,
-		override: _o(o, "seed")
+		override: vo(o, "seed")
 	}), (r.sampler || r.sampler_name) && v.push({
 		label: O("sidebar.generation.sampler", "Sampler"),
 		value: r.sampler || r.sampler_name,
-		override: _o(o, "sampler", "sampler_name")
+		override: vo(o, "sampler", "sampler_name")
 	}), $(r.steps) && v.push({
 		label: O("sidebar.generation.steps", "Steps"),
 		value: r.steps,
-		override: _o(o, "steps")
+		override: vo(o, "steps")
 	});
 	let y = $(r.cfg) ? r.cfg : r.cfg_scale;
 	$(y) && v.push({
 		label: O("sidebar.generation.cfgScale", "CFG Scale"),
 		value: y,
-		override: _o(o, "cfg", "cfg_scale")
+		override: vo(o, "cfg", "cfg_scale")
 	}), r.cfg_high_noise !== void 0 && r.cfg_high_noise !== null && v.push({
 		label: O("sidebar.generation.cfgHighNoise", "CFG High Noise"),
 		value: r.cfg_high_noise
@@ -4806,17 +4824,17 @@ function xo(e) {
 	}), r.scheduler && v.push({
 		label: O("sidebar.generation.scheduler", "Scheduler"),
 		value: r.scheduler,
-		override: _o(o, "scheduler")
+		override: vo(o, "scheduler")
 	});
 	let b = $(r.denoise) ? r.denoise : r.denoising;
 	$(b) && v.push({
 		label: O("sidebar.generation.denoise", "Denoise"),
 		value: b,
-		override: _o(o, "denoise", "denoising")
+		override: vo(o, "denoise", "denoising")
 	});
 	let x = [];
 	Array.isArray(r.chained_passes) && r.chained_passes.length > 1 ? x = r.chained_passes.filter((e) => e && typeof e == "object").map((e, t) => ({
-		label: qa(e, t),
+		label: Ja(e, t),
 		stage: String(e?.pass_stage || "").trim(),
 		fields: [
 			{
@@ -4857,7 +4875,7 @@ function xo(e) {
 			}
 		]
 	})) : Array.isArray(r.all_samplers) && r.all_samplers.length > 1 && (x = r.all_samplers.filter((e) => e && typeof e == "object").map((e, t) => ({
-		label: qa(e, t),
+		label: Ja(e, t),
 		stage: String(e?.pass_stage || "").trim(),
 		fields: [
 			{
@@ -4938,13 +4956,13 @@ function xo(e) {
 		label: O("sidebar.generation.compileMode", "Compile Mode"),
 		value: r.compile_mode
 	}), [
-		to(O("sidebar.generation.torchCompile", "Torch Compile"), r.use_torch_compile),
-		to(O("sidebar.generation.cudaGraphs", "CUDA Graphs"), r.use_cuda_graphs),
-		to(O("sidebar.generation.xVectorOnly", "X-Vector Only"), r.x_vector_only_mode)
+		no(O("sidebar.generation.torchCompile", "Torch Compile"), r.use_torch_compile),
+		no(O("sidebar.generation.cudaGraphs", "CUDA Graphs"), r.use_cuda_graphs),
+		no(O("sidebar.generation.xVectorOnly", "X-Vector Only"), r.x_vector_only_mode)
 	].filter(Boolean).forEach((e) => C.push(e));
 	let ee = [];
 	[
-		to(O("sidebar.generation.chunking", "Chunking"), r.enable_chunking),
+		no(O("sidebar.generation.chunking", "Chunking"), r.enable_chunking),
 		r.max_chars_per_chunk !== void 0 && r.max_chars_per_chunk !== null ? {
 			label: O("sidebar.generation.maxCharsChunk", "Max Chars/Chunk"),
 			value: r.max_chars_per_chunk
@@ -4957,7 +4975,7 @@ function xo(e) {
 			label: O("sidebar.generation.silenceBetweenChunks", "Silence Between Chunks (ms)"),
 			value: r.silence_between_chunks_ms
 		} : null,
-		to(O("sidebar.generation.audioCache", "Audio Cache"), r.enable_audio_cache),
+		no(O("sidebar.generation.audioCache", "Audio Cache"), r.enable_audio_cache),
 		r.batch_size !== void 0 && r.batch_size !== null ? {
 			label: O("sidebar.generation.batchSize", "Batch Size"),
 			value: r.batch_size
@@ -4976,25 +4994,25 @@ function xo(e) {
 		label: O("sidebar.generation.clipSkip", "Clip Skip"),
 		value: r.clip_skip
 	});
-	let T = [], E = String(r.workflow_notes || r.notes || "").trim();
-	E && T.push({
+	let T = [], ne = String(r.workflow_notes || r.notes || "").trim();
+	ne && T.push({
 		label: O("sidebar.generation.workflowNotes", "Workflow Notes"),
-		value: E,
-		override: _o(o, "workflow_notes", "notes")
+		value: ne,
+		override: vo(o, "workflow_notes", "notes")
 	});
-	let ne = vo(r.custom_info), re = mo(r, h, v, x), D = ho(r, x, ne, l.workflowType), ie = fo(r, x), ae = Array.isArray(r.inputs) ? r.inputs.filter((e) => e && typeof e == "object" && e.filename).map((e, t) => ({
+	let re = yo(r.custom_info), ie = ho(r, h, v, x), E = go(r, x, re, l.workflowType), ae = po(r, x), oe = Array.isArray(r.inputs) ? r.inputs.filter((e) => e && typeof e == "object" && e.filename).map((e, t) => ({
 		id: `${e.filename}-${t}`,
 		filename: String(e.filename || "").trim(),
 		subfolder: String(e.subfolder || "").trim(),
 		type: String(e.folder_type || "input").trim().toLowerCase(),
 		root_id: String(e.root_id || e.rootId || "").trim(),
 		kind: String(e.kind || e.media_kind || e.type || "").trim().toLowerCase(),
-		filepath: Ga(e),
+		filepath: Ka(e),
 		role: String(e.role || "").trim(),
 		roleLabel: String(e.role || "").trim().replace(/_/g, " "),
 		isVideo: String(e.type || "").toLowerCase() === "video" || /\.(mp4|mov|webm)$/i.test(String(e.filename || "")),
 		isAudio: String(e.type || "").toLowerCase() === "audio" || /\.(wav|mp3|flac|ogg|m4a|aac|opus)$/i.test(String(e.filename || "")),
-		previewCandidates: Wa(e)
+		previewCandidates: Ga(e)
 	})) : [];
 	return {
 		...n,
@@ -5006,15 +5024,15 @@ function xo(e) {
 		isTruncated: !!(e?.geninfo?._truncated || e?.metadata?._truncated || e?.prompt?._truncated),
 		positivePrompt: d.length || a ? "" : String(u.positive || "").trim(),
 		negativePrompt: d.length ? "" : String(u.negative || "").trim(),
-		positivePromptOverride: _o(o, "prompt", "positive", "positive_prompt"),
-		negativePromptOverride: _o(o, "negative_prompt", "negative", "negativePrompt"),
+		positivePromptOverride: vo(o, "prompt", "positive", "positive_prompt"),
+		negativePromptOverride: vo(o, "negative_prompt", "negative", "negativePrompt"),
 		promptTabs: d,
 		showAlignment: !!e?.id && (!!String(u.positive || "").trim() || d.length > 0),
-		isImageAsset: Ra(e),
+		isImageAsset: za(e),
 		lyrics: String(r.lyrics || "").trim(),
 		modelFields: f,
 		modelGroups: h,
-		branchCards: re,
+		branchCards: ie,
 		pipelineTabs: x,
 		samplingFields: v,
 		ttsFields: S,
@@ -5022,21 +5040,21 @@ function xo(e) {
 		ttsInstruction: String(r.instruct || "").trim(),
 		ttsRuntimeFields: ee,
 		audioFields: te,
-		seed: ie,
+		seed: ae,
 		imageFields: w,
-		inputFiles: ae,
+		inputFiles: oe,
 		isOverride: c,
 		overrideLabel: c ? "Gen Info Override" : "",
 		notesFields: T,
-		customInfoBlocks: ne,
-		moduleBlocks: D,
+		customInfoBlocks: re,
+		moduleBlocks: E,
 		ltxDirector: i,
 		ideogram: a
 	};
 }
 //#endregion
 //#region ui/vue/components/panel/sidebar/GenerationInputThumb.vue
-var So = ["title"], Co = ["src"], wo = {
+var Co = ["title"], wo = ["src"], To = {
 	key: 1,
 	style: {
 		width: "100%",
@@ -5051,14 +5069,14 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "6px",
 		"text-align": "center"
 	}
-}, To = { style: {
+}, Eo = { style: {
 	"font-size": "8px",
 	"font-weight": "700",
 	"max-width": "54px",
 	"white-space": "nowrap",
 	overflow: "hidden",
 	"text-overflow": "ellipsis"
-} }, Eo = ["src"], Do = {
+} }, Do = ["src"], Oo = {
 	key: 3,
 	style: {
 		position: "absolute",
@@ -5074,7 +5092,7 @@ var So = ["title"], Co = ["src"], wo = {
 		overflow: "hidden",
 		"text-overflow": "ellipsis"
 	}
-}, Oo = {
+}, ko = {
 	key: 4,
 	title: "Video file",
 	style: {
@@ -5084,7 +5102,7 @@ var So = ["title"], Co = ["src"], wo = {
 		"font-size": "16px",
 		"pointer-events": "none"
 	}
-}, ko = {
+}, Ao = {
 	__name: "GenerationInputThumb",
 	props: { inputFile: {
 		type: Object,
@@ -5093,7 +5111,7 @@ var So = ["title"], Co = ["src"], wo = {
 	setup(e) {
 		let t = e, n = B(0), r = B(!1), i = null;
 		function a() {
-			return i ||= import("./floatingViewerManager-CGdpmtv-.js").then((e) => e.n), i;
+			return i ||= import("./floatingViewerManager-C0fDYFQu.js").then((e) => e.n), i;
 		}
 		function o() {
 			return (Array.isArray(t.inputFile?.previewCandidates) ? t.inputFile.previewCandidates : [])[n.value] || "";
@@ -5158,15 +5176,15 @@ var So = ["title"], Co = ["src"], wo = {
 			};
 		}
 		function m() {
-			return Ka(o()) || !!t.inputFile?.filename || !!t.inputFile?.filepath;
+			return qa(o()) || !!t.inputFile?.filename || !!t.inputFile?.filepath;
 		}
 		function h() {
-			if (Dt({
+			if (Ot({
 				asset: u(),
 				index: 0
 			})) return;
 			let e = o();
-			if (Ka(e)) try {
+			if (qa(e)) try {
 				window.open(e, "_blank", "noopener,noreferrer");
 			} catch (e) {
 				console.debug?.(e);
@@ -5180,16 +5198,16 @@ var So = ["title"], Co = ["src"], wo = {
 					index: 0
 				});
 			} catch (e) {
-				console.debug?.(e), T(O("toast.viewerOpenFailed", "Failed to open viewer."), "error");
+				console.debug?.(e), E(O("toast.viewerOpenFailed", "Failed to open viewer."), "error");
 			}
 		}
 		async function _() {
-			let e = await ce(u());
+			let e = await le(u());
 			if (!e?.ok) {
-				T(e?.error || O("toast.openFolderFailed", "Failed to open folder."), "error");
+				E(e?.error || O("toast.openFolderFailed", "Failed to open folder."), "error");
 				return;
 			}
-			T(O("toast.openedInFolder", "Opened in folder"), "info", 1600);
+			E(O("toast.openedInFolder", "Opened in folder"), "info", 1600);
 		}
 		async function v() {
 			let e = u(), t = {
@@ -5198,18 +5216,18 @@ var So = ["title"], Co = ["src"], wo = {
 				type: e.type || "input",
 				root_id: e.root_id || void 0,
 				kind: e.kind
-			}, n = await Fi({
-				post: fe,
-				endpoint: Le.STAGE_TO_INPUT,
+			}, n = await Ii({
+				post: D,
+				endpoint: Re.STAGE_TO_INPUT,
 				payload: t,
 				index: !1
 			});
 			if (!n?.relativePath) {
-				T(O("toast.loadAssetFailed", "Failed to load asset."), "error");
+				E(O("toast.loadAssetFailed", "Failed to load asset."), "error");
 				return;
 			}
-			if (!ji({
-				app: Ne(),
+			if (!Mi({
+				app: Pe(),
 				items: [{
 					payload: t,
 					relativePath: n.relativePath,
@@ -5217,15 +5235,15 @@ var So = ["title"], Co = ["src"], wo = {
 				}],
 				event: null
 			})) {
-				T(O("toast.loadAssetFailed", "Failed to load asset."), "error");
+				E(O("toast.loadAssetFailed", "Failed to load asset."), "error");
 				return;
 			}
-			T(O("toast.assetLoadedToCanvas", "{kind} loader added to canvas.", { kind: e.kind ? e.kind.charAt(0).toUpperCase() + e.kind.slice(1) : "Asset" }), "success", 1800);
+			E(O("toast.assetLoadedToCanvas", "{kind} loader added to canvas.", { kind: e.kind ? e.kind.charAt(0).toUpperCase() + e.kind.slice(1) : "Asset" }), "success", 1800);
 		}
 		function y(e) {
 			e?.preventDefault?.(), e?.stopPropagation?.();
 			let n = d(), r = n === "video" ? O("ctx.loadVideo", "Load video") : n === "audio" ? O("ctx.loadAudio", "Load audio") : n === "model3d" ? O("ctx.loadModel3d", "Load 3D model") : O("ctx.loadImage", "Load image");
-			wr({
+			Tr({
 				x: e?.clientX || 0,
 				y: e?.clientY || 0,
 				items: [
@@ -5285,10 +5303,10 @@ var So = ["title"], Co = ["src"], wo = {
 			onError: s,
 			onMouseover: b,
 			onMouseout: x
-		}, null, 40, Co)) : S() ? (j(), z("div", wo, [n[0] ||= N("div", { style: {
+		}, null, 40, wo)) : S() ? (j(), z("div", To, [n[0] ||= N("div", { style: {
 			"font-size": "18px",
 			"line-height": "1"
-		} }, "♪", -1), N("div", To, R(e.inputFile.filename), 1)])) : (j(), z("img", {
+		} }, "♪", -1), N("div", Eo, R(e.inputFile.filename), 1)])) : (j(), z("img", {
 			key: 2,
 			src: o(),
 			style: {
@@ -5297,16 +5315,16 @@ var So = ["title"], Co = ["src"], wo = {
 				"object-fit": "cover"
 			},
 			onError: s
-		}, null, 40, Eo)), e.inputFile.role && e.inputFile.role !== "secondary" ? (j(), z("div", Do, R(e.inputFile.roleLabel), 1)) : e.inputFile.isVideo ? (j(), z("div", Oo, " Play ")) : F("", !0)], 44, So));
+		}, null, 40, Do)), e.inputFile.role && e.inputFile.role !== "secondary" ? (j(), z("div", Oo, R(e.inputFile.roleLabel), 1)) : e.inputFile.isVideo ? (j(), z("div", ko, " Play ")) : F("", !0)], 44, Co));
 	}
-}, Ao = {
+}, jo = {
 	key: 0,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "12px"
 	}
-}, jo = {
+}, Mo = {
 	key: 0,
 	style: {
 		display: "flex",
@@ -5321,66 +5339,66 @@ var So = ["title"], Co = ["src"], wo = {
 		fontSize: "11px",
 		color: "var(--fg-color, #ccc)"
 	}
-}, Mo = { style: { opacity: "0.85" } }, No = { style: {
+}, No = { style: { opacity: "0.85" } }, Po = { style: {
 	display: "flex",
 	"align-items": "center",
 	gap: "8px",
 	"flex-wrap": "wrap",
 	"justify-content": "flex-end"
-} }, Po = ["title"], Fo = ["title"], Io = { style: {
+} }, Fo = ["title"], Io = ["title"], Lo = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "10px"
-} }, Lo = { style: {
+} }, Ro = { style: {
 	"font-size": "11px",
 	"font-weight": "700",
 	color: "#00BCD4",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.6px"
-} }, Ro = { style: {
+} }, zo = { style: {
 	"font-size": "11px",
 	color: "var(--fg-color, rgba(255,255,255,0.9))",
 	"font-weight": "600"
-} }, zo = { style: {
+} }, Bo = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#FF9800",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, Bo = { style: {
+} }, Vo = { style: {
 	"font-size": "12px",
 	color: "var(--fg-color, rgba(255,255,255,0.9))",
 	"line-height": "1.5",
 	"white-space": "pre-wrap",
 	"word-break": "break-word"
-} }, Vo = { style: {
+} }, Ho = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#9E9E9E",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, Ho = { style: {
+} }, Uo = { style: {
 	"font-size": "12px",
 	color: "var(--fg-color, rgba(255,255,255,0.9))",
 	"line-height": "1.5",
 	"white-space": "pre-wrap",
 	"word-break": "break-word"
-} }, Uo = { style: {
+} }, Wo = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px",
 	"margin-bottom": "10px"
-} }, Wo = { style: {
+} }, Go = { style: {
 	"font-size": "11px",
 	"font-weight": "800",
 	color: "#26C6DA",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px"
-} }, Go = {
+} }, Ko = {
 	key: 0,
 	style: {
 		display: "grid",
@@ -5388,18 +5406,18 @@ var So = ["title"], Co = ["src"], wo = {
 		gap: "8px",
 		"margin-bottom": "10px"
 	}
-}, Ko = { style: {
+}, qo = { style: {
 	"font-size": "9px",
 	"font-weight": "800",
 	color: "rgba(255,255,255,0.55)",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, qo = { style: {
+} }, Jo = { style: {
 	"font-size": "12px",
 	color: "var(--fg-color,#eee)",
 	"font-weight": "650",
 	"word-break": "break-word"
-} }, Jo = {
+} }, Yo = {
 	key: 1,
 	style: {
 		border: "1px solid rgba(76,175,80,0.36)",
@@ -5408,32 +5426,32 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "10px",
 		"margin-bottom": "10px"
 	}
-}, Yo = ["title"], Xo = {
+}, Xo = ["title"], Zo = {
 	key: 2,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "8px"
 	}
-}, Zo = { style: {
+}, Qo = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px",
 	"margin-bottom": "7px"
-} }, Qo = { style: {
+} }, $o = { style: {
 	"font-size": "10px",
 	"font-weight": "800",
 	color: "#26C6DA",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.45px"
-} }, $o = { style: {
+} }, es = { style: {
 	display: "flex",
 	"align-items": "center",
 	gap: "5px",
 	"flex-wrap": "wrap",
 	"justify-content": "flex-end"
-} }, es = {
+} }, ts = {
 	key: 0,
 	style: {
 		"font-size": "10px",
@@ -5444,7 +5462,7 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "2px 6px",
 		"font-weight": "700"
 	}
-}, ts = {
+}, ns = {
 	key: 1,
 	style: {
 		"font-size": "10px",
@@ -5455,15 +5473,15 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "2px 6px",
 		"font-weight": "700"
 	}
-}, ns = { style: {
+}, rs = { style: {
 	display: "flex",
 	gap: "10px",
 	"align-items": "flex-start",
 	"min-width": "0"
-} }, rs = { style: {
+} }, is = { style: {
 	"min-width": "0",
 	flex: "1"
-} }, is = ["title", "onClick"], as = {
+} }, as = ["title", "onClick"], os = {
 	key: 1,
 	style: {
 		"font-size": "10px",
@@ -5473,19 +5491,19 @@ var So = ["title"], Co = ["src"], wo = {
 		gap: "6px",
 		"flex-wrap": "wrap"
 	}
-}, os = { key: 0 }, ss = { key: 1 }, cs = { style: {
+}, ss = { key: 0 }, cs = { key: 1 }, ls = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px",
 	"margin-bottom": "10px"
-} }, ls = { style: {
+} }, us = { style: {
 	"font-size": "11px",
 	"font-weight": "800",
 	color: "#FFB300",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px"
-} }, us = {
+} }, ds = {
 	key: 0,
 	style: {
 		display: "grid",
@@ -5493,18 +5511,18 @@ var So = ["title"], Co = ["src"], wo = {
 		gap: "8px",
 		"margin-bottom": "10px"
 	}
-}, ds = { style: {
+}, fs = { style: {
 	"font-size": "9px",
 	"font-weight": "800",
 	color: "rgba(255,255,255,0.55)",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, fs = { style: {
+} }, ps = { style: {
 	"font-size": "12px",
 	color: "var(--fg-color,#eee)",
 	"font-weight": "650",
 	"word-break": "break-word"
-} }, ps = {
+} }, ms = {
 	key: 1,
 	style: {
 		border: "1px solid rgba(76,175,80,0.34)",
@@ -5513,7 +5531,7 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "10px",
 		"margin-bottom": "10px"
 	}
-}, ms = ["title"], hs = {
+}, hs = ["title"], gs = {
 	key: 2,
 	style: {
 		border: "1px solid rgba(33,150,243,0.32)",
@@ -5522,7 +5540,7 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "10px",
 		"margin-bottom": "10px"
 	}
-}, gs = ["title"], _s = {
+}, _s = ["title"], vs = {
 	key: 3,
 	style: {
 		display: "flex",
@@ -5530,19 +5548,19 @@ var So = ["title"], Co = ["src"], wo = {
 		gap: "8px",
 		"margin-bottom": "10px"
 	}
-}, vs = { style: {
+}, ys = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px",
 	"margin-bottom": "7px"
-} }, ys = { style: {
+} }, bs = { style: {
 	"font-size": "10px",
 	"font-weight": "800",
 	color: "#FFCA28",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.45px"
-} }, bs = {
+} }, xs = {
 	key: 0,
 	style: {
 		"font-size": "10px",
@@ -5553,7 +5571,7 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "2px 6px",
 		"font-weight": "700"
 	}
-}, xs = ["title", "onClick"], Ss = {
+}, Ss = ["title", "onClick"], Cs = {
 	key: 1,
 	style: {
 		display: "flex",
@@ -5561,35 +5579,35 @@ var So = ["title"], Co = ["src"], wo = {
 		gap: "5px",
 		"margin-top": "8px"
 	}
-}, Cs = ["title", "onClick"], ws = { style: {
+}, ws = ["title", "onClick"], Ts = { style: {
 	border: "1px solid rgba(255,179,0,0.30)",
 	"border-radius": "6px",
 	background: "rgba(0,0,0,0.16)",
 	overflow: "hidden"
-} }, Ts = ["title"], Es = { style: {
+} }, Es = ["title"], Ds = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#4CAF50",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, Ds = { style: {
+} }, Os = { style: {
 	display: "flex",
 	"flex-wrap": "wrap",
 	gap: "6px",
 	"margin-bottom": "10px"
-} }, Os = { style: {
+} }, ks = { style: {
 	"font-size": "10px",
 	"font-weight": "700",
 	color: "#4CAF50",
 	"letter-spacing": "0.4px"
-} }, ks = ["onClick"], As = { style: {
+} }, As = ["onClick"], js = { style: {
 	"font-size": "10px",
 	"font-weight": "700",
 	color: "#F44336",
 	"letter-spacing": "0.4px",
 	"margin-top": "4px"
-} }, js = ["onClick"], Ms = { style: {
+} }, Ms = ["onClick"], Ns = { style: {
 	display: "flex",
 	"justify-content": "space-between",
 	"align-items": "center",
@@ -5599,7 +5617,7 @@ var So = ["title"], Co = ["src"], wo = {
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, Ns = ["title"], Ps = ["title"], Fs = { style: {
+} }, Ps = ["title"], Fs = ["title"], Is = { style: {
 	display: "flex",
 	"justify-content": "space-between",
 	"align-items": "center",
@@ -5609,7 +5627,7 @@ var So = ["title"], Co = ["src"], wo = {
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, Is = ["title"], Ls = ["title"], Rs = { style: {
+} }, Ls = ["title"], Rs = ["title"], zs = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#00BCD4",
@@ -5618,17 +5636,17 @@ var So = ["title"], Co = ["src"], wo = {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between"
-} }, zs = ["title"], Bs = { style: {
+} }, Bs = ["title"], Vs = { style: {
 	display: "flex",
 	"align-items": "center",
 	gap: "10px"
-} }, Vs = { style: {
+} }, Hs = { style: {
 	flex: "1",
 	height: "8px",
 	background: "rgba(255,255,255,0.1)",
 	"border-radius": "4px",
 	overflow: "hidden"
-} }, Hs = {
+} }, Us = {
 	key: 0,
 	style: {
 		"font-size": "10px",
@@ -5638,7 +5656,7 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "6px 8px",
 		background: "rgba(255,255,255,0.04)"
 	}
-}, Us = { style: {
+}, Ws = { style: {
 	"font-size": "10px",
 	"font-weight": "600",
 	color: "rgba(0, 188, 212, 0.75)",
@@ -5649,35 +5667,35 @@ var So = ["title"], Co = ["src"], wo = {
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px"
-} }, Ws = ["title"], Gs = { style: {
+} }, Gs = ["title"], Ks = { style: {
 	display: "flex",
 	"align-items": "center",
 	gap: "6px"
-} }, Ks = ["title"], qs = { style: {
+} }, qs = ["title"], Js = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#9C27B0",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, Js = { style: {
+} }, Ys = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(auto-fit, minmax(190px, 1fr))",
 	gap: "10px"
-} }, Ys = { style: {
+} }, Xs = { style: {
 	"font-size": "10px",
 	"font-weight": "700",
 	color: "rgba(255,255,255,0.58)",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, Xs = ["onClick"], Zs = {
+} }, Zs = ["onClick"], Qs = {
 	key: 0,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "5px"
 	}
-}, Qs = ["onClick"], $s = { style: {
+}, $s = ["onClick"], ec = { style: {
 	display: "flex",
 	"justify-content": "space-between",
 	"align-items": "center",
@@ -5687,90 +5705,90 @@ var So = ["title"], Co = ["src"], wo = {
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, ec = { style: {
+} }, tc = { style: {
 	"font-size": "12px",
 	color: "var(--fg-color, rgba(255,255,255,0.9))",
 	"line-height": "1.5",
 	"white-space": "pre-wrap",
 	"word-break": "break-word"
-} }, tc = { style: {
+} }, nc = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#FF9800",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, nc = { style: {
+} }, rc = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(auto-fit, minmax(130px, 1fr))",
 	gap: "8px"
-} }, rc = ["onClick"], ic = { style: {
+} }, ic = ["onClick"], ac = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#9C27B0",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, ac = { style: {
+} }, oc = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(auto-fit, minmax(220px, 1fr))",
 	gap: "10px"
-} }, oc = { style: {
+} }, sc = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "10px"
-} }, sc = { style: {
+} }, cc = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "4px"
-} }, cc = ["onClick"], lc = {
+} }, lc = ["onClick"], uc = {
 	key: 0,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "6px"
 	}
-}, uc = { style: {
+}, dc = { style: {
 	"font-size": "10px",
 	"font-weight": "700",
 	color: "rgba(255,255,255,0.58)",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, dc = { style: {
+} }, fc = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "5px"
-} }, fc = ["onClick"], pc = { style: {
+} }, pc = ["onClick"], mc = { style: {
 	display: "grid",
 	"grid-template-columns": "auto 1fr",
 	gap: "8px 12px",
 	"align-items": "start"
-} }, mc = ["title"], hc = ["title"], gc = ["title", "onClick"], _c = { style: {
+} }, hc = ["title"], gc = ["title"], _c = ["title", "onClick"], vc = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#4CAF50",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, vc = ["title", "onClick"], yc = { style: {
+} }, yc = ["title", "onClick"], bc = { style: {
 	"font-size": "11px",
 	"font-weight": "600",
 	color: "#26C6DA",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "10px"
-} }, bc = { style: {
+} }, xc = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(auto-fit, minmax(190px, 1fr))",
 	gap: "10px"
-} }, xc = { style: {
+} }, Sc = { style: {
 	"font-size": "10px",
 	"font-weight": "700",
 	color: "rgba(255,255,255,0.58)",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, Sc = ["title", "onClick"], Cc = { style: {
+} }, Cc = ["title", "onClick"], wc = { style: {
 	display: "flex",
 	"justify-content": "space-between",
 	"align-items": "center",
@@ -5780,25 +5798,25 @@ var So = ["title"], Co = ["src"], wo = {
 	"text-transform": "uppercase",
 	"letter-spacing": "0.5px",
 	"margin-bottom": "8px"
-} }, wc = ["title"], Tc = { style: {
+} }, Tc = ["title"], Ec = { style: {
 	"font-size": "11px",
 	"font-weight": "700",
 	color: "#E91E63",
 	"text-transform": "uppercase",
 	"letter-spacing": "1px"
-} }, Ec = ["title"], Dc = ["title"], Oc = { style: {
+} }, Dc = ["title"], Oc = ["title"], kc = { style: {
 	display: "flex",
 	gap: "8px",
 	"flex-wrap": "wrap"
-} }, kc = {
+} }, Ac = {
 	__name: "SidebarGenerationSection",
 	props: { asset: {
 		type: Object,
 		required: !0
 	} },
 	setup(e) {
-		let t = e, n = B(0), r = B(0), i = B(""), a = B(O("action.copy", "Copy")), o = B(O("action.generate", "Generate")), c = B(!1), l = B(d()), u = 0;
-		function d() {
+		let t = e, n = B(0), r = B(0), i = B(""), a = B(O("action.copy", "Copy")), o = B(O("action.generate", "Generate")), s = B(!1), c = B(u()), l = 0;
+		function u() {
 			return {
 				scoreText: "...",
 				scoreColor: "#888",
@@ -5811,21 +5829,21 @@ var So = ["title"], Co = ["src"], wo = {
 				aiStatusText: O("sidebar.generation.aiDisabledEnv", "AI features are disabled (enable vector search env var).")
 			};
 		}
-		function f(e, t) {
+		function d(e, t) {
 			let n = String(e || "").trim().replace(/^#/, "");
 			return /^[0-9a-fA-F]{6}$/.test(n) ? `rgba(${Number.parseInt(n.slice(0, 2), 16)}, ${Number.parseInt(n.slice(2, 4), 16)}, ${Number.parseInt(n.slice(4, 6), 16)}, ${t})` : `rgba(255,255,255,${t})`;
 		}
-		function p(e, { emphasis: t = !1, startAlpha: n = .16, endAlpha: r = .08 } = {}) {
+		function f(e, { emphasis: t = !1, startAlpha: n = .16, endAlpha: r = .08 } = {}) {
 			return {
-				background: t ? `linear-gradient(135deg, ${f(e, n)} 0%, ${f(e, r)} 100%)` : "var(--comfy-menu-bg, rgba(0,0,0,0.3))",
+				background: t ? `linear-gradient(135deg, ${d(e, n)} 0%, ${d(e, r)} 100%)` : "var(--comfy-menu-bg, rgba(0,0,0,0.3))",
 				borderLeft: `3px solid ${e}`,
-				border: t ? `1px solid ${f(e, .45)}` : "1px solid var(--border-color, rgba(255,255,255,0.12))",
-				boxShadow: t ? `0 0 0 1px ${f(e, .15)} inset` : "none",
+				border: t ? `1px solid ${d(e, .45)}` : "1px solid var(--border-color, rgba(255,255,255,0.12))",
+				boxShadow: t ? `0 0 0 1px ${d(e, .15)} inset` : "none",
 				borderRadius: "6px",
 				padding: "12px"
 			};
 		}
-		function m() {
+		function p() {
 			return {
 				background: "linear-gradient(135deg, rgba(233, 30, 99, 0.15) 0%, rgba(156, 39, 176, 0.15) 100%)",
 				border: "2px solid #E91E63",
@@ -5837,7 +5855,7 @@ var So = ["title"], Co = ["src"], wo = {
 				gap: "12px"
 			};
 		}
-		function h() {
+		function m() {
 			return {
 				display: "inline-flex",
 				alignItems: "center",
@@ -5854,52 +5872,52 @@ var So = ["title"], Co = ["src"], wo = {
 				whiteSpace: "nowrap"
 			};
 		}
-		let g = I(() => xo(t.asset)), _ = I(() => Ba()), v = I(() => g.value.kind === "full" || g.value.kind === "caption-only"), y = I(() => Ua(i.value) || g.value.emptyCaptionText), b = I(() => _.value && g.value.isImageAsset && !!t.asset?.id), x = I(() => _.value && !!Ua(y.value) && y.value !== g.value.emptyCaptionText), S = I(() => g.value.branchCards.filter((e) => e.modelFields.length || e.loras.length)), C = I(() => g.value.branchCards.filter((e) => e.samplingFields.length));
-		I(() => g.value.branchCards.filter((e) => e.loras.length));
+		let h = I(() => So(t.asset)), g = I(() => Va()), _ = I(() => h.value.kind === "full" || h.value.kind === "caption-only"), v = I(() => Wa(i.value) || h.value.emptyCaptionText), y = I(() => g.value && h.value.isImageAsset && !!t.asset?.id), b = I(() => g.value && !!Wa(v.value) && v.value !== h.value.emptyCaptionText), x = I(() => h.value.branchCards.filter((e) => e.modelFields.length || e.loras.length)), S = I(() => h.value.branchCards.filter((e) => e.samplingFields.length));
+		I(() => h.value.branchCards.filter((e) => e.loras.length));
 		let ee = I(() => {
-			let e = [], t = (e, t) => Aa(e)?.title || t;
-			return !S.value.length && g.value.modelFields.length && e.push({
+			let e = [], t = (e, t) => ja(e)?.title || t;
+			return !x.value.length && h.value.modelFields.length && e.push({
 				key: "model",
 				title: t("model", O("sidebar.generation.modelLora", "Model & LoRA")),
 				accent: "#9C27B0",
 				emphasis: !0,
-				fields: g.value.modelFields
-			}), !C.value.length && g.value.samplingFields.length && e.push({
+				fields: h.value.modelFields
+			}), !S.value.length && h.value.samplingFields.length && e.push({
 				key: "sampling",
 				title: t("sampler", O("sidebar.generation.sampling", "Sampling")),
 				accent: "#FF9800",
 				emphasis: !0,
-				fields: g.value.samplingFields
-			}), (g.value.ttsFields.length || g.value.workflowType.toLowerCase() === "tts") && e.push({
+				fields: h.value.samplingFields
+			}), (h.value.ttsFields.length || h.value.workflowType.toLowerCase() === "tts") && e.push({
 				key: "tts",
 				title: "TTS",
 				accent: "#26A69A",
 				emphasis: !0,
-				fields: g.value.ttsFields
-			}), g.value.ttsEngineFields.length && e.push({
+				fields: h.value.ttsFields
+			}), h.value.ttsEngineFields.length && e.push({
 				key: "tts-engine",
 				title: "TTS Engine",
 				accent: "#00897B",
 				emphasis: !1,
-				fields: g.value.ttsEngineFields
-			}), g.value.ttsRuntimeFields.length && e.push({
+				fields: h.value.ttsEngineFields
+			}), h.value.ttsRuntimeFields.length && e.push({
 				key: "tts-runtime",
 				title: "TTS Runtime",
 				accent: "#00796B",
 				emphasis: !1,
-				fields: g.value.ttsRuntimeFields
-			}), g.value.audioFields.length && e.push({
+				fields: h.value.ttsRuntimeFields
+			}), h.value.audioFields.length && e.push({
 				key: "audio",
 				title: O("sidebar.generation.audio", "Audio"),
 				accent: "#00BCD4",
 				emphasis: !1,
-				fields: g.value.audioFields
-			}), g.value.imageFields.length && e.push({
+				fields: h.value.audioFields
+			}), h.value.imageFields.length && e.push({
 				key: "image",
 				title: O("sidebar.generation.image", "Image"),
 				accent: "#2196F3",
 				emphasis: !1,
-				fields: g.value.imageFields
+				fields: h.value.imageFields
 			}), e;
 		});
 		function w(e, t, n = 450) {
@@ -5911,9 +5929,9 @@ var So = ["title"], Co = ["src"], wo = {
 		}
 		function T(e, t = !0) {
 			return {
-				background: t ? `linear-gradient(135deg, ${f(e, .16)} 0%, ${f(e, .08)} 100%)` : "var(--comfy-menu-bg, rgba(0,0,0,0.3))",
-				border: `1px solid ${f(e, .42)}`,
-				boxShadow: `0 0 0 1px ${f(e, .14)} inset`,
+				background: t ? `linear-gradient(135deg, ${d(e, .16)} 0%, ${d(e, .08)} 100%)` : "var(--comfy-menu-bg, rgba(0,0,0,0.3))",
+				border: `1px solid ${d(e, .42)}`,
+				boxShadow: `0 0 0 1px ${d(e, .14)} inset`,
 				borderRadius: "8px",
 				padding: "12px",
 				display: "flex",
@@ -5921,17 +5939,17 @@ var So = ["title"], Co = ["src"], wo = {
 				gap: "10px"
 			};
 		}
-		function E(e) {
+		function ne(e) {
 			return "#CE6DE0";
 		}
-		function ne(e) {
+		function re(e) {
 			let t = String(e?.key || "").toLowerCase();
 			return t.includes("high") ? "#FFC107" : t.includes("low") ? "#FFB300" : t.includes("base") ? "#FF9800" : t.includes("upscale") || t.includes("refine") ? "#FFCA28" : t.includes("pass") ? "#FDD835" : "#FF9800";
 		}
-		function re(e) {
+		function ie(e) {
 			return e === "high_noise" ? "#FF7043" : e === "low_noise" ? "#29B6F6" : "#AB47BC";
 		}
-		async function D(e, t = null, n = "rgba(76, 175, 80, 0.35)") {
+		async function E(e, t = null, n = "rgba(76, 175, 80, 0.35)") {
 			let r = String(e ?? "").trim();
 			if (!(!r || r === "-")) try {
 				await navigator.clipboard.writeText(r), w(t, n);
@@ -5939,8 +5957,8 @@ var So = ["title"], Co = ["src"], wo = {
 				console.debug?.(e);
 			}
 		}
-		function ie() {
-			l.value = {
+		function ae() {
+			c.value = {
 				scoreText: "AI OFF",
 				scoreColor: "#9E9E9E",
 				qualityText: O("status.disabled", "Disabled"),
@@ -5952,31 +5970,31 @@ var So = ["title"], Co = ["src"], wo = {
 				aiStatusText: O("sidebar.generation.aiDisabledSettings", "AI features are disabled in settings.")
 			};
 		}
-		function ae() {
-			l.value = d();
+		function oe() {
+			c.value = u();
 		}
-		async function oe() {
-			u += 1;
-			let e = u;
-			if (!g.value.showAlignment || !t.asset?.id) {
+		async function se() {
+			l += 1;
+			let e = l;
+			if (!h.value.showAlignment || !t.asset?.id) {
+				oe();
+				return;
+			}
+			if (!g.value) {
 				ae();
 				return;
 			}
-			if (!_.value) {
-				ie();
-				return;
-			}
-			ae();
+			oe();
 			try {
 				let n = await te(t.asset.id);
-				if (e !== u) return;
+				if (e !== l) return;
 				if (!n?.ok && (String(n?.code || "").toUpperCase() === "SERVICE_UNAVAILABLE" || /vector search is not enabled/i.test(String(n?.error || "")))) {
-					ie();
+					ae();
 					return;
 				}
 				let r = n?.ok && n.data != null ? Number(n.data) : null;
 				if (!Number.isFinite(r)) {
-					l.value = {
+					c.value = {
 						scoreText: "N/A",
 						scoreColor: "#888",
 						qualityText: O("status.na", "N/A"),
@@ -5989,11 +6007,11 @@ var So = ["title"], Co = ["src"], wo = {
 					};
 					return;
 				}
-				let i = Math.round(r * 100), a = Va(r);
-				l.value = {
+				let i = Math.round(r * 100), a = Ha(r);
+				c.value = {
 					scoreText: `${i}%`,
 					scoreColor: a,
-					qualityText: Ha(r),
+					qualityText: Ua(r),
 					qualityColor: a,
 					qualityBackground: `${a}33`,
 					fillWidth: `${i}%`,
@@ -6002,8 +6020,8 @@ var So = ["title"], Co = ["src"], wo = {
 					aiStatusText: ""
 				};
 			} catch (t) {
-				if (console.debug?.(t), e !== u) return;
-				l.value = {
+				if (console.debug?.(t), e !== l) return;
+				c.value = {
 					scoreText: "-",
 					scoreColor: "#888",
 					qualityText: O("status.unavailable", "Unavailable"),
@@ -6016,42 +6034,42 @@ var So = ["title"], Co = ["src"], wo = {
 				};
 			}
 		}
-		async function se() {
-			if (!(!b.value || c.value)) {
-				c.value = !0, o.value = O("status.generating", "Generating...");
+		async function ce() {
+			if (!(!y.value || s.value)) {
+				s.value = !0, o.value = O("status.generating", "Generating...");
 				try {
-					let e = await s(t.asset.id);
+					let e = await C(t.asset.id);
 					e?.ok && (i.value = String(e?.data || "").trim());
 				} catch (e) {
 					console.debug?.(e);
 				} finally {
-					c.value = !1, o.value = O("action.generate", "Generate");
+					s.value = !1, o.value = O("action.generate", "Generate");
 				}
 			}
 		}
-		async function ce() {
-			if (x.value) try {
-				await navigator.clipboard.writeText(y.value), a.value = O("viewer.copySuccessShort", "Copied!"), setTimeout(() => {
+		async function le() {
+			if (b.value) try {
+				await navigator.clipboard.writeText(v.value), a.value = O("viewer.copySuccessShort", "Copied!"), setTimeout(() => {
 					a.value = O("action.copy", "Copy");
 				}, 900);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		return Ze(() => t.asset, () => {
+		return Qe(() => t.asset, () => {
 			n.value = 0, r.value = 0, i.value = String(t.asset?.enhanced_caption || "").trim(), a.value = O("action.copy", "Copy"), o.value = O("action.generate", "Generate");
-		}, { immediate: !0 }), Ze(() => [
+		}, { immediate: !0 }), Qe(() => [
 			t.asset?.id,
-			g.value.kind,
-			g.value.showAlignment,
-			_.value
+			h.value.kind,
+			h.value.showAlignment,
+			g.value
 		], () => {
-			oe();
+			se();
 		}, { immediate: !0 }), (e, t) => {
-			let r = nt("MButton");
-			return g.value.kind === "empty" ? F("", !0) : (j(), z("div", Ao, [
-				g.value.workflowType ? (j(), z("div", jo, [N("span", Mo, R(L(O)("viewer.workflow", "Workflow")), 1), N("div", No, [N("span", {
-					title: L(O)("sidebar.generation.workflowEngine", "Workflow engine: {value}", { value: g.value.workflowType }),
+			let r = rt("MButton");
+			return h.value.kind === "empty" ? F("", !0) : (j(), z("div", jo, [
+				h.value.workflowType ? (j(), z("div", Mo, [N("span", No, R(L(O)("viewer.workflow", "Workflow")), 1), N("div", Po, [N("span", {
+					title: L(O)("sidebar.generation.workflowEngine", "Workflow engine: {value}", { value: h.value.workflowType }),
 					style: {
 						background: "#2196F3",
 						color: "white",
@@ -6061,9 +6079,9 @@ var So = ["title"], Co = ["src"], wo = {
 						"font-size": "10px",
 						"letter-spacing": "0.2px"
 					}
-				}, R(g.value.workflowLabel || g.value.workflowType), 9, Po), g.value.workflowBadge ? (j(), z("span", {
+				}, R(h.value.workflowLabel || h.value.workflowType), 9, Fo), h.value.workflowBadge ? (j(), z("span", {
 					key: 0,
-					title: L(O)("sidebar.generation.apiProvider", "API provider: {value}", { value: g.value.workflowBadge }),
+					title: L(O)("sidebar.generation.apiProvider", "API provider: {value}", { value: h.value.workflowBadge }),
 					style: {
 						background: "rgba(255,255,255,0.08)",
 						color: "var(--fg-color, #eee)",
@@ -6074,41 +6092,41 @@ var So = ["title"], Co = ["src"], wo = {
 						"font-size": "10px",
 						"letter-spacing": "0.2px"
 					}
-				}, R(g.value.workflowBadge), 9, Fo)) : F("", !0)])])) : F("", !0),
-				g.value.isOverride ? (j(), z("div", {
+				}, R(h.value.workflowBadge), 9, Io)) : F("", !0)])])) : F("", !0),
+				h.value.isOverride ? (j(), z("div", {
 					key: 1,
-					style: V(p("#00BCD4", {
+					style: V(f("#00BCD4", {
 						emphasis: !0,
 						startAlpha: .14,
 						endAlpha: .08
 					}))
-				}, [N("div", Io, [N("span", Lo, R(L(O)("sidebar.generation.override", "Override")), 1), N("span", Ro, R(g.value.overrideLabel), 1)])], 4)) : F("", !0),
-				g.value.isTruncated ? (j(), z("div", {
+				}, [N("div", Lo, [N("span", Ro, R(L(O)("sidebar.generation.override", "Override")), 1), N("span", zo, R(h.value.overrideLabel), 1)])], 4)) : F("", !0),
+				h.value.isTruncated ? (j(), z("div", {
 					key: 2,
-					style: V(p("#FF9800", {
+					style: V(f("#FF9800", {
 						emphasis: !0,
 						startAlpha: .12,
 						endAlpha: .08
 					}))
-				}, [N("div", zo, R(L(O)("sidebar.generation.metadataTruncated", "Metadata Truncated")), 1), N("div", Bo, R(L(O)("sidebar.generation.metadataTruncatedBody", "Generation data is incomplete because it exceeded the size limit.")), 1)], 4)) : F("", !0),
-				g.value.kind === "media-only" ? (j(), z("div", {
+				}, [N("div", Bo, R(L(O)("sidebar.generation.metadataTruncated", "Metadata Truncated")), 1), N("div", Vo, R(L(O)("sidebar.generation.metadataTruncatedBody", "Generation data is incomplete because it exceeded the size limit.")), 1)], 4)) : F("", !0),
+				h.value.kind === "media-only" ? (j(), z("div", {
 					key: 3,
-					style: V(p("#9E9E9E", {
+					style: V(f("#9E9E9E", {
 						emphasis: !0,
 						startAlpha: .1,
 						endAlpha: .06
 					}))
-				}, [N("div", Vo, R(L(O)("sidebar.generation.generationData", "Generation Data")), 1), N("div", Ho, R(g.value.mediaOnlyMessage), 1)], 4)) : F("", !0),
-				g.value.kind === "full" ? (j(), z(M, { key: 4 }, [
-					g.value.ltxDirector ? (j(), z("div", {
+				}, [N("div", Ho, R(L(O)("sidebar.generation.generationData", "Generation Data")), 1), N("div", Uo, R(h.value.mediaOnlyMessage), 1)], 4)) : F("", !0),
+				h.value.kind === "full" ? (j(), z(M, { key: 4 }, [
+					h.value.ltxDirector ? (j(), z("div", {
 						key: 0,
-						style: V(p("#26C6DA", {
+						style: V(f("#26C6DA", {
 							emphasis: !0,
 							startAlpha: .15,
 							endAlpha: .08
 						}))
 					}, [
-						N("div", Uo, [N("div", Wo, R(g.value.ltxDirector.title || "LTX Director"), 1), t[8] ||= N("span", { style: {
+						N("div", Wo, [N("div", Go, R(h.value.ltxDirector.title || "LTX Director"), 1), t[8] ||= N("span", { style: {
 							"font-size": "10px",
 							"font-weight": "700",
 							color: "#26C6DA",
@@ -6117,7 +6135,7 @@ var So = ["title"], Co = ["src"], wo = {
 							"border-radius": "999px",
 							padding: "2px 8px"
 						} }, " Director ", -1)]),
-						g.value.ltxDirector.fields.length ? (j(), z("div", Go, [(j(!0), z(M, null, P(g.value.ltxDirector.fields, (e) => (j(), z("div", {
+						h.value.ltxDirector.fields.length ? (j(), z("div", Ko, [(j(!0), z(M, null, P(h.value.ltxDirector.fields, (e) => (j(), z("div", {
 							key: `ltx-field-${e.label}`,
 							style: {
 								border: "1px solid rgba(255,255,255,0.10)",
@@ -6126,8 +6144,8 @@ var So = ["title"], Co = ["src"], wo = {
 								padding: "7px 8px",
 								"min-width": "0"
 							}
-						}, [N("div", Ko, R(e.label), 1), N("div", qo, R(e.value), 1)]))), 128))])) : F("", !0),
-						g.value.ltxDirector.globalPrompt ? (j(), z("div", Jo, [t[9] ||= N("div", { style: {
+						}, [N("div", qo, R(e.label), 1), N("div", Jo, R(e.value), 1)]))), 128))])) : F("", !0),
+						h.value.ltxDirector.globalPrompt ? (j(), z("div", Yo, [t[9] ||= N("div", { style: {
 							"font-size": "10px",
 							"font-weight": "800",
 							color: "#66BB6A",
@@ -6144,9 +6162,9 @@ var So = ["title"], Co = ["src"], wo = {
 								"word-break": "break-word",
 								cursor: "pointer"
 							},
-							onClick: t[0] ||= (e) => D(g.value.ltxDirector.globalPrompt, e.currentTarget)
-						}, R(g.value.ltxDirector.globalPrompt), 9, Yo)])) : F("", !0),
-						g.value.ltxDirector.segments.length ? (j(), z("div", Xo, [(j(!0), z(M, null, P(g.value.ltxDirector.segments, (e) => (j(), z("div", {
+							onClick: t[0] ||= (e) => E(h.value.ltxDirector.globalPrompt, e.currentTarget)
+						}, R(h.value.ltxDirector.globalPrompt), 9, Xo)])) : F("", !0),
+						h.value.ltxDirector.segments.length ? (j(), z("div", Zo, [(j(!0), z(M, null, P(h.value.ltxDirector.segments, (e) => (j(), z("div", {
 							key: e.key,
 							style: {
 								border: "1px solid rgba(38,198,218,0.30)",
@@ -6154,7 +6172,7 @@ var So = ["title"], Co = ["src"], wo = {
 								background: "rgba(38,198,218,0.075)",
 								padding: "10px"
 							}
-						}, [N("div", Zo, [N("div", Qo, R(e.label), 1), N("div", $o, [e.inLabel ? (j(), z("span", es, " in " + R(e.inLabel), 1)) : F("", !0), e.outLabel ? (j(), z("span", ts, " out " + R(e.outLabel), 1)) : F("", !0)])]), N("div", ns, [e.filename ? (j(), Xe(ko, {
+						}, [N("div", Qo, [N("div", $o, R(e.label), 1), N("div", es, [e.inLabel ? (j(), z("span", ts, " in " + R(e.inLabel), 1)) : F("", !0), e.outLabel ? (j(), z("span", ns, " out " + R(e.outLabel), 1)) : F("", !0)])]), N("div", rs, [e.filename ? (j(), Ze(Ao, {
 							key: 0,
 							"input-file": {
 								filename: e.filename,
@@ -6165,7 +6183,7 @@ var So = ["title"], Co = ["src"], wo = {
 								isAudio: e.isAudio,
 								previewCandidates: e.previewCandidates
 							}
-						}, null, 8, ["input-file"])) : F("", !0), N("div", rs, [e.prompt ? (j(), z("div", {
+						}, null, 8, ["input-file"])) : F("", !0), N("div", is, [e.prompt ? (j(), z("div", {
 							key: 0,
 							title: L(O)("action.clickToCopy", "Click to copy"),
 							style: {
@@ -6176,18 +6194,18 @@ var So = ["title"], Co = ["src"], wo = {
 								"word-break": "break-word",
 								cursor: "pointer"
 							},
-							onClick: (t) => D(e.prompt, t.currentTarget)
-						}, R(e.prompt), 9, is)) : F("", !0), e.filename || e.type ? (j(), z("div", as, [e.type ? (j(), z("span", os, R(e.type), 1)) : F("", !0), e.filename ? (j(), z("span", ss, R(e.filename), 1)) : F("", !0)])) : F("", !0)])])]))), 128))])) : F("", !0)
+							onClick: (t) => E(e.prompt, t.currentTarget)
+						}, R(e.prompt), 9, as)) : F("", !0), e.filename || e.type ? (j(), z("div", os, [e.type ? (j(), z("span", ss, R(e.type), 1)) : F("", !0), e.filename ? (j(), z("span", cs, R(e.filename), 1)) : F("", !0)])) : F("", !0)])])]))), 128))])) : F("", !0)
 					], 4)) : F("", !0),
-					g.value.ideogram ? (j(), z("div", {
+					h.value.ideogram ? (j(), z("div", {
 						key: 1,
-						style: V(p("#FFB300", {
+						style: V(f("#FFB300", {
 							emphasis: !0,
 							startAlpha: .15,
 							endAlpha: .08
 						}))
 					}, [
-						N("div", cs, [N("div", ls, R(g.value.ideogram.title || "Ideogram 4"), 1), t[10] ||= N("span", { style: {
+						N("div", ls, [N("div", us, R(h.value.ideogram.title || "Ideogram 4"), 1), t[10] ||= N("span", { style: {
 							"font-size": "10px",
 							"font-weight": "700",
 							color: "#FFCA28",
@@ -6196,7 +6214,7 @@ var So = ["title"], Co = ["src"], wo = {
 							"border-radius": "999px",
 							padding: "2px 8px"
 						} }, " Prompt JSON ", -1)]),
-						g.value.ideogram.fields.length ? (j(), z("div", us, [(j(!0), z(M, null, P(g.value.ideogram.fields, (e) => (j(), z("div", {
+						h.value.ideogram.fields.length ? (j(), z("div", ds, [(j(!0), z(M, null, P(h.value.ideogram.fields, (e) => (j(), z("div", {
 							key: `ideogram-field-${e.label}`,
 							style: {
 								border: "1px solid rgba(255,255,255,0.10)",
@@ -6205,8 +6223,8 @@ var So = ["title"], Co = ["src"], wo = {
 								padding: "7px 8px",
 								"min-width": "0"
 							}
-						}, [N("div", ds, R(e.label), 1), N("div", fs, R(e.value), 1)]))), 128))])) : F("", !0),
-						g.value.ideogram.highLevelDescription ? (j(), z("div", ps, [t[11] ||= N("div", { style: {
+						}, [N("div", fs, R(e.label), 1), N("div", ps, R(e.value), 1)]))), 128))])) : F("", !0),
+						h.value.ideogram.highLevelDescription ? (j(), z("div", ms, [t[11] ||= N("div", { style: {
 							"font-size": "10px",
 							"font-weight": "800",
 							color: "#81C784",
@@ -6223,9 +6241,9 @@ var So = ["title"], Co = ["src"], wo = {
 								"word-break": "break-word",
 								cursor: "pointer"
 							},
-							onClick: t[1] ||= (e) => D(g.value.ideogram.highLevelDescription, e.currentTarget)
-						}, R(g.value.ideogram.highLevelDescription), 9, ms)])) : F("", !0),
-						g.value.ideogram.background ? (j(), z("div", hs, [t[12] ||= N("div", { style: {
+							onClick: t[1] ||= (e) => E(h.value.ideogram.highLevelDescription, e.currentTarget)
+						}, R(h.value.ideogram.highLevelDescription), 9, hs)])) : F("", !0),
+						h.value.ideogram.background ? (j(), z("div", gs, [t[12] ||= N("div", { style: {
 							"font-size": "10px",
 							"font-weight": "800",
 							color: "#64B5F6",
@@ -6242,9 +6260,9 @@ var So = ["title"], Co = ["src"], wo = {
 								"word-break": "break-word",
 								cursor: "pointer"
 							},
-							onClick: t[2] ||= (e) => D(g.value.ideogram.background, e.currentTarget)
-						}, R(g.value.ideogram.background), 9, gs)])) : F("", !0),
-						g.value.ideogram.elements.length ? (j(), z("div", _s, [(j(!0), z(M, null, P(g.value.ideogram.elements, (e) => (j(), z("div", {
+							onClick: t[2] ||= (e) => E(h.value.ideogram.background, e.currentTarget)
+						}, R(h.value.ideogram.background), 9, _s)])) : F("", !0),
+						h.value.ideogram.elements.length ? (j(), z("div", vs, [(j(!0), z(M, null, P(h.value.ideogram.elements, (e) => (j(), z("div", {
 							key: e.key,
 							style: {
 								border: "1px solid rgba(255,179,0,0.30)",
@@ -6253,7 +6271,7 @@ var So = ["title"], Co = ["src"], wo = {
 								padding: "10px"
 							}
 						}, [
-							N("div", vs, [N("div", ys, R(e.label), 1), e.bbox ? (j(), z("span", bs, " bbox " + R(e.bbox), 1)) : F("", !0)]),
+							N("div", ys, [N("div", bs, R(e.label), 1), e.bbox ? (j(), z("span", xs, " bbox " + R(e.bbox), 1)) : F("", !0)]),
 							e.description ? (j(), z("div", {
 								key: 0,
 								title: L(O)("action.clickToCopy", "Click to copy"),
@@ -6265,9 +6283,9 @@ var So = ["title"], Co = ["src"], wo = {
 									"word-break": "break-word",
 									cursor: "pointer"
 								},
-								onClick: (t) => D(e.description, t.currentTarget)
-							}, R(e.description), 9, xs)) : F("", !0),
-							e.palette.length ? (j(), z("div", Ss, [(j(!0), z(M, null, P(e.palette, (t) => (j(), z("span", {
+								onClick: (t) => E(e.description, t.currentTarget)
+							}, R(e.description), 9, Ss)) : F("", !0),
+							e.palette.length ? (j(), z("div", Cs, [(j(!0), z(M, null, P(e.palette, (t) => (j(), z("span", {
 								key: `${e.key}-${t}`,
 								title: t,
 								style: V({
@@ -6277,10 +6295,10 @@ var So = ["title"], Co = ["src"], wo = {
 									border: "1px solid rgba(255,255,255,0.28)",
 									background: t
 								}),
-								onClick: (e) => D(t, e.currentTarget)
-							}, null, 12, Cs))), 128))])) : F("", !0)
+								onClick: (e) => E(t, e.currentTarget)
+							}, null, 12, ws))), 128))])) : F("", !0)
 						]))), 128))])) : F("", !0),
-						N("details", ws, [t[13] ||= N("summary", { style: {
+						N("details", Ts, [t[13] ||= N("summary", { style: {
 							cursor: "pointer",
 							padding: "8px 10px",
 							"font-size": "10px",
@@ -6302,19 +6320,19 @@ var So = ["title"], Co = ["src"], wo = {
 								"word-break": "break-word",
 								cursor: "pointer"
 							},
-							onClick: t[3] ||= (e) => D(g.value.ideogram.json, e.currentTarget)
-						}, R(g.value.ideogram.json), 9, Ts)])
+							onClick: t[3] ||= (e) => E(h.value.ideogram.json, e.currentTarget)
+						}, R(h.value.ideogram.json), 9, Es)])
 					], 4)) : F("", !0),
-					!g.value.ltxDirector && !g.value.ideogram && g.value.promptTabs.length ? (j(), z("div", {
+					!h.value.ltxDirector && !h.value.ideogram && h.value.promptTabs.length ? (j(), z("div", {
 						key: 2,
-						style: V(p("#4CAF50", {
+						style: V(f("#4CAF50", {
 							emphasis: !0,
 							startAlpha: .16,
 							endAlpha: .1
 						}))
 					}, [
-						N("div", Es, R(L(O)("sidebar.generation.promptPipeline", "Prompt Pipeline ({count} variants)", { count: g.value.promptTabs.length })), 1),
-						N("div", Ds, [(j(!0), z(M, null, P(g.value.promptTabs, (e, t) => (j(), Xe(r, {
+						N("div", Ds, R(L(O)("sidebar.generation.promptPipeline", "Prompt Pipeline ({count} variants)", { count: h.value.promptTabs.length })), 1),
+						N("div", Os, [(j(!0), z(M, null, P(h.value.promptTabs, (e, t) => (j(), Ze(r, {
 							key: e.label,
 							type: "button",
 							severity: "secondary",
@@ -6334,10 +6352,10 @@ var So = ["title"], Co = ["src"], wo = {
 							}),
 							onClick: (e) => n.value = t
 						}, {
-							default: yt(() => [Ye(R(e.label), 1)]),
+							default: bt(() => [Xe(R(e.label), 1)]),
 							_: 2
 						}, 1032, ["style", "onClick"]))), 128))]),
-						(j(!0), z(M, null, P(g.value.promptTabs, (e, t) => Qe((j(), z("div", {
+						(j(!0), z(M, null, P(h.value.promptTabs, (e, t) => $e((j(), z("div", {
 							key: `${e.label}-panel`,
 							style: {
 								display: "flex",
@@ -6350,7 +6368,7 @@ var So = ["title"], Co = ["src"], wo = {
 								padding: "10px"
 							}
 						}, [
-							N("div", Os, R(L(O)("sidebar.generation.positive", "POSITIVE")), 1),
+							N("div", ks, R(L(O)("sidebar.generation.positive", "POSITIVE")), 1),
 							N("div", {
 								style: {
 									"font-size": "12px",
@@ -6359,9 +6377,9 @@ var So = ["title"], Co = ["src"], wo = {
 									"line-height": "1.35",
 									cursor: "pointer"
 								},
-								onClick: (t) => D(e.positive, t.currentTarget)
-							}, R(e.positive), 9, ks),
-							e.negative ? (j(), z(M, { key: 0 }, [N("div", As, R(L(O)("sidebar.generation.negative", "NEGATIVE")), 1), N("div", {
+								onClick: (t) => E(e.positive, t.currentTarget)
+							}, R(e.positive), 9, As),
+							e.negative ? (j(), z(M, { key: 0 }, [N("div", js, R(L(O)("sidebar.generation.negative", "NEGATIVE")), 1), N("div", {
 								style: {
 									"font-size": "12px",
 									color: "var(--fg-color, #ddd)",
@@ -6369,21 +6387,21 @@ var So = ["title"], Co = ["src"], wo = {
 									"line-height": "1.35",
 									cursor: "pointer"
 								},
-								onClick: (t) => D(e.negative, t.currentTarget)
-							}, R(e.negative), 9, js)], 64)) : F("", !0)
-						])), [[at, n.value === t]])), 128))
-					], 4)) : !g.value.ltxDirector && !g.value.ideogram && g.value.positivePrompt ? (j(), z("div", {
+								onClick: (t) => E(e.negative, t.currentTarget)
+							}, R(e.negative), 9, Ms)], 64)) : F("", !0)
+						])), [[ot, n.value === t]])), 128))
+					], 4)) : !h.value.ltxDirector && !h.value.ideogram && h.value.positivePrompt ? (j(), z("div", {
 						key: 3,
-						style: V(p("#4CAF50", {
+						style: V(f("#4CAF50", {
 							emphasis: !0,
 							startAlpha: .16,
 							endAlpha: .1
 						}))
-					}, [N("div", Ms, [N("span", null, R(L(O)("sidebar.generation.positivePrompt", "Positive Prompt")), 1), g.value.positivePromptOverride ? (j(), z("span", {
+					}, [N("div", Ns, [N("span", null, R(L(O)("sidebar.generation.positivePrompt", "Positive Prompt")), 1), h.value.positivePromptOverride ? (j(), z("span", {
 						key: 0,
-						style: V(h()),
+						style: V(m()),
 						title: L(O)("sidebar.generation.overrideTooltip", "This field was forced by Majoor Gen Info Override")
-					}, R(L(O)("sidebar.generation.override", "override")), 13, Ns)) : F("", !0)]), N("div", {
+					}, R(L(O)("sidebar.generation.override", "override")), 13, Ps)) : F("", !0)]), N("div", {
 						title: L(O)("action.clickToCopy", "Click to copy"),
 						style: {
 							"font-size": "12px",
@@ -6393,20 +6411,20 @@ var So = ["title"], Co = ["src"], wo = {
 							"word-break": "break-word",
 							cursor: "pointer"
 						},
-						onClick: t[4] ||= (e) => D(g.value.positivePrompt, e.currentTarget)
-					}, R(g.value.positivePrompt), 9, Ps)], 4)) : F("", !0),
-					!g.value.ltxDirector && !g.value.ideogram && !g.value.promptTabs.length && g.value.negativePrompt ? (j(), z("div", {
+						onClick: t[4] ||= (e) => E(h.value.positivePrompt, e.currentTarget)
+					}, R(h.value.positivePrompt), 9, Fs)], 4)) : F("", !0),
+					!h.value.ltxDirector && !h.value.ideogram && !h.value.promptTabs.length && h.value.negativePrompt ? (j(), z("div", {
 						key: 4,
-						style: V(p("#F44336", {
+						style: V(f("#F44336", {
 							emphasis: !0,
 							startAlpha: .16,
 							endAlpha: .1
 						}))
-					}, [N("div", Fs, [N("span", null, R(L(O)("sidebar.generation.negativePrompt", "Negative Prompt")), 1), g.value.negativePromptOverride ? (j(), z("span", {
+					}, [N("div", Is, [N("span", null, R(L(O)("sidebar.generation.negativePrompt", "Negative Prompt")), 1), h.value.negativePromptOverride ? (j(), z("span", {
 						key: 0,
-						style: V(h()),
+						style: V(m()),
 						title: L(O)("sidebar.generation.overrideTooltip", "This field was forced by Majoor Gen Info Override")
-					}, R(L(O)("sidebar.generation.override", "override")), 13, Is)) : F("", !0)]), N("div", {
+					}, R(L(O)("sidebar.generation.override", "override")), 13, Ls)) : F("", !0)]), N("div", {
 						title: L(O)("action.clickToCopy", "Click to copy"),
 						style: {
 							"font-size": "12px",
@@ -6416,10 +6434,10 @@ var So = ["title"], Co = ["src"], wo = {
 							"word-break": "break-word",
 							cursor: "pointer"
 						},
-						onClick: t[5] ||= (e) => D(g.value.negativePrompt, e.currentTarget)
-					}, R(g.value.negativePrompt), 9, Ls)], 4)) : F("", !0)
+						onClick: t[5] ||= (e) => E(h.value.negativePrompt, e.currentTarget)
+					}, R(h.value.negativePrompt), 9, Rs)], 4)) : F("", !0)
 				], 64)) : F("", !0),
-				v.value ? (j(), z("div", {
+				_.value ? (j(), z("div", {
 					key: 5,
 					style: {
 						background: "linear-gradient(135deg, rgba(0, 188, 212, 0.14) 0%, rgba(33, 150, 243, 0.10) 100%)",
@@ -6430,45 +6448,68 @@ var So = ["title"], Co = ["src"], wo = {
 						"flex-direction": "column",
 						gap: "10px"
 					},
-					class: mt({ "mjr-ai-disabled-block": !_.value })
+					class: ht({ "mjr-ai-disabled-block": !g.value })
 				}, [
-					g.value.showAlignment ? (j(), z(M, { key: 0 }, [
-						N("div", Rs, [N("span", { title: L(O)("sidebar.generation.promptAlignmentTooltip", "How closely the generated image matches the prompt (SigLIP2 score)") }, R(L(O)("sidebar.generation.promptAlignment", "Prompt Alignment")), 9, zs)]),
-						N("div", Bs, [
-							N("div", Vs, [N("div", { style: V({
+					h.value.showAlignment ? (j(), z(M, { key: 0 }, [
+						N("div", zs, [N("span", { title: L(O)("sidebar.generation.promptAlignmentTooltip", "How closely the generated image matches the prompt (SigLIP2 score)") }, R(L(O)("sidebar.generation.promptAlignment", "Prompt Alignment")), 9, Bs)]),
+						N("div", Vs, [
+							N("div", Hs, [N("div", { style: V({
 								height: "100%",
-								width: l.value.fillWidth,
-								background: l.value.fillColor,
+								width: c.value.fillWidth,
+								background: c.value.fillColor,
 								borderRadius: "4px",
 								transition: "width 0.6s ease, background 0.4s ease"
 							}) }, null, 4)]),
 							N("span", { style: V({
 								fontSize: "13px",
 								fontWeight: "700",
-								color: l.value.scoreColor,
+								color: c.value.scoreColor,
 								minWidth: "60px",
 								textAlign: "right",
 								fontFamily: "'Consolas', 'Monaco', monospace"
-							}) }, R(l.value.scoreText), 5),
+							}) }, R(c.value.scoreText), 5),
 							N("span", { style: V({
 								fontSize: "9px",
 								fontWeight: "700",
 								padding: "2px 6px",
 								borderRadius: "3px",
-								background: l.value.qualityBackground,
-								color: l.value.qualityColor,
+								background: c.value.qualityBackground,
+								color: c.value.qualityColor,
 								textTransform: "uppercase",
 								letterSpacing: "0.5px"
-							}) }, R(l.value.qualityText), 5)
+							}) }, R(c.value.qualityText), 5)
 						]),
-						l.value.aiStatusVisible ? (j(), z("div", Hs, R(l.value.aiStatusText), 1)) : F("", !0)
+						c.value.aiStatusVisible ? (j(), z("div", Us, R(c.value.aiStatusText), 1)) : F("", !0)
 					], 64)) : F("", !0),
-					N("div", Us, [N("span", { title: L(O)("sidebar.generation.aiCaptionTooltip", "AI caption generated by Florence-2") }, R(g.value.captionLabel), 9, Ws), N("div", Gs, [ft(r, {
+					N("div", Ws, [N("span", { title: L(O)("sidebar.generation.aiCaptionTooltip", "AI caption generated by Florence-2") }, R(h.value.captionLabel), 9, Gs), N("div", Ks, [pt(r, {
 						type: "button",
 						class: "mjr-ai-control",
 						severity: "secondary",
 						text: "",
-						disabled: !b.value || c.value,
+						disabled: !y.value || s.value,
+						style: V([{
+							border: "1px solid rgba(0,188,212,0.45)",
+							background: "rgba(0,188,212,0.12)",
+							color: "#00BCD4",
+							"border-radius": "4px",
+							"font-size": "10px",
+							"font-weight": "600",
+							padding: "2px 8px",
+							cursor: "pointer"
+						}, {
+							opacity: y.value ? "1" : "0.6",
+							cursor: y.value ? "pointer" : "default"
+						}]),
+						onClick: nt(ce, ["stop"])
+					}, {
+						default: bt(() => [Xe(R(o.value), 1)]),
+						_: 1
+					}, 8, ["disabled", "style"]), pt(r, {
+						type: "button",
+						class: "mjr-ai-control",
+						severity: "secondary",
+						text: "",
+						disabled: !b.value,
 						style: V([{
 							border: "1px solid rgba(0,188,212,0.45)",
 							background: "rgba(0,188,212,0.12)",
@@ -6482,36 +6523,13 @@ var So = ["title"], Co = ["src"], wo = {
 							opacity: b.value ? "1" : "0.6",
 							cursor: b.value ? "pointer" : "default"
 						}]),
-						onClick: tt(se, ["stop"])
+						onClick: nt(le, ["stop"])
 					}, {
-						default: yt(() => [Ye(R(o.value), 1)]),
-						_: 1
-					}, 8, ["disabled", "style"]), ft(r, {
-						type: "button",
-						class: "mjr-ai-control",
-						severity: "secondary",
-						text: "",
-						disabled: !x.value,
-						style: V([{
-							border: "1px solid rgba(0,188,212,0.45)",
-							background: "rgba(0,188,212,0.12)",
-							color: "#00BCD4",
-							"border-radius": "4px",
-							"font-size": "10px",
-							"font-weight": "600",
-							padding: "2px 8px",
-							cursor: "pointer"
-						}, {
-							opacity: x.value ? "1" : "0.6",
-							cursor: x.value ? "pointer" : "default"
-						}]),
-						onClick: tt(ce, ["stop"])
-					}, {
-						default: yt(() => [Ye(R(a.value), 1)]),
+						default: bt(() => [Xe(R(a.value), 1)]),
 						_: 1
 					}, 8, ["disabled", "style"])])]),
 					N("div", {
-						title: _.value ? L(O)("sidebar.generation.copyCaptionTooltip", "Click to copy caption") : L(O)("sidebar.generation.aiCaptionDisabled", "AI caption controls are disabled"),
+						title: g.value ? L(O)("sidebar.generation.copyCaptionTooltip", "Click to copy caption") : L(O)("sidebar.generation.aiCaptionDisabled", "AI caption controls are disabled"),
 						style: V({
 							marginTop: "4px",
 							padding: "8px",
@@ -6523,26 +6541,26 @@ var So = ["title"], Co = ["src"], wo = {
 							lineHeight: "1.45",
 							whiteSpace: "pre-wrap",
 							wordBreak: "break-word",
-							cursor: x.value ? "copy" : "default"
+							cursor: b.value ? "copy" : "default"
 						}),
-						onClick: ce
-					}, R(y.value), 13, Ks)
+						onClick: le
+					}, R(v.value), 13, qs)
 				], 2)) : F("", !0),
-				S.value.length ? (j(), z("div", {
+				x.value.length ? (j(), z("div", {
 					key: 6,
-					style: V(p("#9C27B0", {
+					style: V(f("#9C27B0", {
 						emphasis: !0,
 						startAlpha: .18,
 						endAlpha: .1
 					}))
-				}, [N("div", qs, R(L(O)("sidebar.generation.models", "Models")), 1), N("div", Js, [(j(!0), z(M, null, P(S.value, (e) => (j(), z("div", {
+				}, [N("div", Js, R(L(O)("sidebar.generation.models", "Models")), 1), N("div", Ys, [(j(!0), z(M, null, P(x.value, (e) => (j(), z("div", {
 					key: `models-top-${e.key}`,
-					style: V(T(E(e), !0))
+					style: V(T(ne(e), !0))
 				}, [
 					N("div", { style: V({
 						fontSize: "10px",
 						fontWeight: "800",
-						color: E(e),
+						color: ne(e),
 						letterSpacing: "0.6px",
 						textTransform: "uppercase"
 					}) }, R(e.label), 5),
@@ -6554,7 +6572,7 @@ var So = ["title"], Co = ["src"], wo = {
 							gap: "3px",
 							"min-width": "0"
 						}
-					}, [N("span", Ys, R(t.label), 1), N("span", {
+					}, [N("span", Xs, R(t.label), 1), N("span", {
 						style: {
 							"font-size": "12px",
 							color: "var(--fg-color, rgba(255,255,255,0.96))",
@@ -6562,9 +6580,9 @@ var So = ["title"], Co = ["src"], wo = {
 							"word-break": "break-word",
 							cursor: "pointer"
 						},
-						onClick: (e) => D(t.value, e.currentTarget)
-					}, R(t.value || "-"), 9, Xs)]))), 128)),
-					e.loras.length ? (j(), z("div", Zs, [t[14] ||= N("span", { style: {
+						onClick: (e) => E(t.value, e.currentTarget)
+					}, R(t.value || "-"), 9, Zs)]))), 128)),
+					e.loras.length ? (j(), z("div", Qs, [t[14] ||= N("span", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.58)",
@@ -6583,29 +6601,29 @@ var So = ["title"], Co = ["src"], wo = {
 							border: "1px solid rgba(255,255,255,0.08)",
 							cursor: "pointer"
 						},
-						onClick: (e) => D(t, e.currentTarget)
-					}, R(t), 9, Qs))), 128))])) : F("", !0)
+						onClick: (e) => E(t, e.currentTarget)
+					}, R(t), 9, $s))), 128))])) : F("", !0)
 				], 4))), 128))])], 4)) : F("", !0),
-				g.value.lyrics ? (j(), z("div", {
+				h.value.lyrics ? (j(), z("div", {
 					key: 7,
-					style: V(p("#00BCD4", { emphasis: !1 }))
-				}, [N("div", $s, [N("span", null, R(L(O)("sidebar.generation.lyrics", "Lyrics")), 1)]), N("div", ec, R(g.value.lyrics), 1)], 4)) : F("", !0),
-				g.value.branchCards.length ? (j(), z(M, { key: 8 }, [
+					style: V(f("#00BCD4", { emphasis: !1 }))
+				}, [N("div", ec, [N("span", null, R(L(O)("sidebar.generation.lyrics", "Lyrics")), 1)]), N("div", tc, R(h.value.lyrics), 1)], 4)) : F("", !0),
+				h.value.branchCards.length ? (j(), z(M, { key: 8 }, [
 					F("", !0),
-					C.value.length ? (j(), z("div", {
+					S.value.length ? (j(), z("div", {
 						key: 1,
-						style: V(p("#FF9800", {
+						style: V(f("#FF9800", {
 							emphasis: !0,
 							startAlpha: .16,
 							endAlpha: .1
 						}))
-					}, [N("div", tc, R(L(O)("sidebar.generation.sampling", "Sampling")), 1), N("div", nc, [(j(!0), z(M, null, P(C.value, (e) => (j(), z("div", {
+					}, [N("div", nc, R(L(O)("sidebar.generation.sampling", "Sampling")), 1), N("div", rc, [(j(!0), z(M, null, P(S.value, (e) => (j(), z("div", {
 						key: `sampling-${e.key}`,
-						style: V(T(ne(e), !0))
+						style: V(T(re(e), !0))
 					}, [N("div", { style: V({
 						fontSize: "10px",
 						fontWeight: "800",
-						color: ne(e),
+						color: re(e),
 						letterSpacing: "0.6px",
 						textTransform: "uppercase"
 					}) }, R(e.label), 5), (j(!0), z(M, null, P(e.samplingFields, (t) => (j(), z("div", {
@@ -6625,38 +6643,38 @@ var So = ["title"], Co = ["src"], wo = {
 							"text-align": "right",
 							cursor: "pointer"
 						},
-						onClick: (e) => D(t.value, e.currentTarget)
-					}, R(t.value), 9, rc)]))), 128))], 4))), 128))])], 4)) : F("", !0),
+						onClick: (e) => E(t.value, e.currentTarget)
+					}, R(t.value), 9, ic)]))), 128))], 4))), 128))])], 4)) : F("", !0),
 					F("", !0)
-				], 64)) : g.value.modelGroups.length ? (j(), z("div", {
+				], 64)) : h.value.modelGroups.length ? (j(), z("div", {
 					key: 9,
-					style: V(p("#9C27B0", {
+					style: V(f("#9C27B0", {
 						emphasis: !0,
 						startAlpha: .18,
 						endAlpha: .1
 					}))
-				}, [N("div", ic, R(L(O)("sidebar.generation.models", "Models")), 1), N("div", ac, [(j(!0), z(M, null, P(g.value.modelGroups, (e) => (j(), z("div", {
+				}, [N("div", ac, R(L(O)("sidebar.generation.models", "Models")), 1), N("div", oc, [(j(!0), z(M, null, P(h.value.modelGroups, (e) => (j(), z("div", {
 					key: `model-group-${e.key}`,
-					style: V(T(re(e.key), !0))
+					style: V(T(ie(e.key), !0))
 				}, [
-					N("div", oc, [N("div", { style: V({
+					N("div", sc, [N("div", { style: V({
 						fontSize: "10px",
 						fontWeight: "800",
-						color: re(e.key),
+						color: ie(e.key),
 						letterSpacing: "0.6px",
 						textTransform: "uppercase"
 					}) }, R(e.label), 5), N("span", { style: V({
 						fontSize: "9px",
 						fontWeight: "700",
 						color: "#fff",
-						background: f(re(e.key), .22),
-						border: `1px solid ${f(re(e.key), .48)}`,
+						background: d(ie(e.key), .22),
+						border: `1px solid ${d(ie(e.key), .48)}`,
 						borderRadius: "999px",
 						padding: "2px 8px",
 						letterSpacing: "0.4px",
 						textTransform: "uppercase"
 					}) }, R(e.loras?.length || 0) + " LoRA ", 5)]),
-					N("div", sc, [t[15] ||= N("div", { style: {
+					N("div", cc, [t[15] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.58)",
@@ -6670,9 +6688,9 @@ var So = ["title"], Co = ["src"], wo = {
 							"word-break": "break-word",
 							cursor: "pointer"
 						},
-						onClick: (t) => D(e.model, t.currentTarget)
-					}, R(e.model || "-"), 9, cc)]),
-					e.loras?.length ? (j(), z("div", lc, [N("div", uc, R(L(O)("sidebar.generation.loraStack", "LoRA Stack")), 1), N("div", dc, [(j(!0), z(M, null, P(e.loras, (t, n) => (j(), z("div", {
+						onClick: (t) => E(e.model, t.currentTarget)
+					}, R(e.model || "-"), 9, lc)]),
+					e.loras?.length ? (j(), z("div", uc, [N("div", dc, R(L(O)("sidebar.generation.loraStack", "LoRA Stack")), 1), N("div", fc, [(j(!0), z(M, null, P(e.loras, (t, n) => (j(), z("div", {
 						key: `${e.key}-lora-${n}`,
 						style: {
 							"font-size": "12px",
@@ -6685,12 +6703,12 @@ var So = ["title"], Co = ["src"], wo = {
 							border: "1px solid rgba(255,255,255,0.08)",
 							cursor: "pointer"
 						},
-						onClick: (e) => D(t, e.currentTarget)
-					}, R(t), 9, fc))), 128))])])) : F("", !0)
+						onClick: (e) => E(t, e.currentTarget)
+					}, R(t), 9, pc))), 128))])])) : F("", !0)
 				], 4))), 128))])], 4)) : F("", !0),
 				(j(!0), z(M, null, P(ee.value, (e) => (j(), z("div", {
 					key: e.key,
-					style: V(p(e.accent, { emphasis: e.emphasis }))
+					style: V(f(e.accent, { emphasis: e.emphasis }))
 				}, [N("div", { style: V({
 					fontSize: "11px",
 					fontWeight: "600",
@@ -6698,7 +6716,7 @@ var So = ["title"], Co = ["src"], wo = {
 					textTransform: "uppercase",
 					letterSpacing: "0.5px",
 					marginBottom: "10px"
-				}) }, R(e.title), 5), N("div", pc, [(j(!0), z(M, null, P(e.fields, (t) => (j(), z(M, { key: `${e.key}-${t.label}` }, [N("div", {
+				}) }, R(e.title), 5), N("div", mc, [(j(!0), z(M, null, P(e.fields, (t) => (j(), z(M, { key: `${e.key}-${t.label}` }, [N("div", {
 					title: t.label,
 					style: {
 						"font-size": "11px",
@@ -6710,9 +6728,9 @@ var So = ["title"], Co = ["src"], wo = {
 					}
 				}, [N("span", null, R(t.label) + ":", 1), t.override ? (j(), z("span", {
 					key: 0,
-					style: V(h()),
+					style: V(m()),
 					title: L(O)("sidebar.generation.overrideTooltip", "This field was forced by Majoor Gen Info Override")
-				}, R(L(O)("sidebar.generation.override", "override")), 13, hc)) : F("", !0)], 8, mc), N("div", {
+				}, R(L(O)("sidebar.generation.override", "override")), 13, gc)) : F("", !0)], 8, hc), N("div", {
 					title: `${t.label}: ${t.value}`,
 					style: {
 						"font-size": "12px",
@@ -6721,12 +6739,12 @@ var So = ["title"], Co = ["src"], wo = {
 						"white-space": "pre-wrap",
 						cursor: "pointer"
 					},
-					onClick: (e) => D(t.value, e.currentTarget)
-				}, R(t.value), 9, gc)], 64))), 128))])], 4))), 128)),
-				g.value.notesFields.length ? (j(), z("div", {
+					onClick: (e) => E(t.value, e.currentTarget)
+				}, R(t.value), 9, _c)], 64))), 128))])], 4))), 128)),
+				h.value.notesFields.length ? (j(), z("div", {
 					key: 10,
-					style: V(p("#4CAF50", { emphasis: !1 }))
-				}, [N("div", _c, R(L(O)("sidebar.generation.notes", "Notes")), 1), (j(!0), z(M, null, P(g.value.notesFields, (e) => (j(), z("div", {
+					style: V(f("#4CAF50", { emphasis: !1 }))
+				}, [N("div", vc, R(L(O)("sidebar.generation.notes", "Notes")), 1), (j(!0), z(M, null, P(h.value.notesFields, (e) => (j(), z("div", {
 					key: e.label,
 					title: `${e.label}: ${e.value}`,
 					style: {
@@ -6737,16 +6755,16 @@ var So = ["title"], Co = ["src"], wo = {
 						"word-break": "break-word",
 						cursor: "pointer"
 					},
-					onClick: (t) => D(e.value, t.currentTarget)
-				}, R(e.value), 9, vc))), 128))], 4)) : F("", !0),
-				g.value.moduleBlocks.length ? (j(), z("div", {
+					onClick: (t) => E(e.value, t.currentTarget)
+				}, R(e.value), 9, yc))), 128))], 4)) : F("", !0),
+				h.value.moduleBlocks.length ? (j(), z("div", {
 					key: 11,
-					style: V(p("#26C6DA", {
+					style: V(f("#26C6DA", {
 						emphasis: !0,
 						startAlpha: .14,
 						endAlpha: .08
 					}))
-				}, [N("div", yc, R(L(O)("sidebar.generation.modules", "Modules")), 1), N("div", bc, [(j(!0), z(M, null, P(g.value.moduleBlocks, (e) => (j(), z("div", {
+				}, [N("div", bc, R(L(O)("sidebar.generation.modules", "Modules")), 1), N("div", xc, [(j(!0), z(M, null, P(h.value.moduleBlocks, (e) => (j(), z("div", {
 					key: `module-${e.key}-${e.title}`,
 					style: V(T(e.accent, !1))
 				}, [N("div", { style: V({
@@ -6763,7 +6781,7 @@ var So = ["title"], Co = ["src"], wo = {
 						gap: "3px",
 						"min-width": "0"
 					}
-				}, [N("span", xc, R(t.label), 1), N("span", {
+				}, [N("span", Sc, R(t.label), 1), N("span", {
 					title: `${t.label}: ${t.value}`,
 					style: {
 						"font-size": "12px",
@@ -6773,12 +6791,12 @@ var So = ["title"], Co = ["src"], wo = {
 						"word-break": "break-word",
 						cursor: "pointer"
 					},
-					onClick: (e) => D(t.value, e.currentTarget)
-				}, R(t.value), 9, Sc)]))), 128))], 4))), 128))])], 4)) : F("", !0),
-				g.value.ttsInstruction ? (j(), z("div", {
+					onClick: (e) => E(t.value, e.currentTarget)
+				}, R(t.value), 9, Cc)]))), 128))], 4))), 128))])], 4)) : F("", !0),
+				h.value.ttsInstruction ? (j(), z("div", {
 					key: 12,
-					style: V(p("#26A69A", { emphasis: !1 }))
-				}, [N("div", Cc, [N("span", null, R(L(O)("sidebar.generation.ttsInstruction", "TTS Instruction")), 1)]), N("div", {
+					style: V(f("#26A69A", { emphasis: !1 }))
+				}, [N("div", wc, [N("span", null, R(L(O)("sidebar.generation.ttsInstruction", "TTS Instruction")), 1)]), N("div", {
 					title: L(O)("action.clickToCopy", "Click to copy"),
 					style: {
 						"font-size": "12px",
@@ -6788,13 +6806,13 @@ var So = ["title"], Co = ["src"], wo = {
 						"word-break": "break-word",
 						cursor: "pointer"
 					},
-					onClick: t[6] ||= (e) => D(g.value.ttsInstruction, e.currentTarget)
-				}, R(g.value.ttsInstruction), 9, wc)], 4)) : F("", !0),
-				g.value.seed !== null && g.value.seed !== void 0 && g.value.seed !== "" ? (j(), z("div", {
+					onClick: t[6] ||= (e) => E(h.value.ttsInstruction, e.currentTarget)
+				}, R(h.value.ttsInstruction), 9, Tc)], 4)) : F("", !0),
+				h.value.seed !== null && h.value.seed !== void 0 && h.value.seed !== "" ? (j(), z("div", {
 					key: 13,
-					style: V(m())
-				}, [N("div", Tc, R(L(O)("sidebar.generation.seed", "SEED")), 1), N("div", {
-					title: L(O)("sidebar.generation.copySeedTooltip", "Click to copy seed: {seed}", { seed: g.value.seed }),
+					style: V(p())
+				}, [N("div", Ec, R(L(O)("sidebar.generation.seed", "SEED")), 1), N("div", {
+					title: L(O)("sidebar.generation.copySeedTooltip", "Click to copy seed: {seed}", { seed: h.value.seed }),
 					style: {
 						"font-size": "18px",
 						"font-weight": "700",
@@ -6806,11 +6824,11 @@ var So = ["title"], Co = ["src"], wo = {
 						"border-radius": "4px",
 						transition: "background 0.2s"
 					},
-					onClick: t[7] ||= (e) => D(g.value.seed, e.currentTarget, "rgba(76, 175, 80, 0.4)")
-				}, R(g.value.seed), 9, Ec)], 4)) : F("", !0),
-				g.value.inputFiles.length ? (j(), z("div", {
+					onClick: t[7] ||= (e) => E(h.value.seed, e.currentTarget, "rgba(76, 175, 80, 0.4)")
+				}, R(h.value.seed), 9, Dc)], 4)) : F("", !0),
+				h.value.inputFiles.length ? (j(), z("div", {
 					key: 14,
-					style: V(p("#4CAF50", {
+					style: V(f("#4CAF50", {
 						emphasis: !0,
 						startAlpha: .16,
 						endAlpha: .1
@@ -6825,14 +6843,14 @@ var So = ["title"], Co = ["src"], wo = {
 						"letter-spacing": "0.5px",
 						"margin-bottom": "8px"
 					}
-				}, R(L(O)("sidebar.generation.sourceFiles", "Source Files")), 9, Dc), N("div", Oc, [(j(!0), z(M, null, P(g.value.inputFiles, (e) => (j(), Xe(ko, {
+				}, R(L(O)("sidebar.generation.sourceFiles", "Source Files")), 9, Oc), N("div", kc, [(j(!0), z(M, null, P(h.value.inputFiles, (e) => (j(), Ze(Ao, {
 					key: e.id,
 					"input-file": e
 				}, null, 8, ["input-file"]))), 128))])], 4)) : F("", !0)
 			]));
 		};
 	}
-}, Ac = {
+}, jc = {
 	key: 0,
 	class: "mjr-sidebar-section",
 	style: {
@@ -6842,14 +6860,14 @@ var So = ["title"], Co = ["src"], wo = {
 		padding: "12px",
 		"min-width": "300px"
 	}
-}, jc = { style: { "margin-bottom": "12px" } }, Mc = { style: {
+}, Mc = { style: { "margin-bottom": "12px" } }, Nc = { style: {
 	"font-size": "16px",
 	"font-weight": "800",
 	color: "rgba(255,255,255,0.94)",
 	"line-height": "1.25",
 	overflow: "hidden",
 	"text-overflow": "ellipsis"
-} }, Nc = ["title"], Pc = {
+} }, Pc = ["title"], Fc = {
 	key: 1,
 	style: {
 		display: "flex",
@@ -6859,16 +6877,16 @@ var So = ["title"], Co = ["src"], wo = {
 		"min-width": "0"
 	},
 	"aria-label": "Workflow metadata badges"
-}, Fc = ["title"], Ic = { style: {
+}, Ic = ["title"], Lc = { style: {
 	overflow: "hidden",
 	"text-overflow": "ellipsis",
 	"white-space": "nowrap"
-} }, Lc = { style: {
+} }, Rc = { style: {
 	display: "flex",
 	"flex-wrap": "wrap",
 	gap: "8px",
 	"margin-bottom": "10px"
-} }, Rc = { style: {
+} }, zc = { style: {
 	padding: "4px 9px",
 	"border-radius": "999px",
 	background: "rgba(33,150,243,0.14)",
@@ -6878,7 +6896,7 @@ var So = ["title"], Co = ["src"], wo = {
 	color: "#90CAF9",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, zc = {
+} }, Bc = {
 	key: 0,
 	style: {
 		padding: "4px 9px",
@@ -6889,12 +6907,12 @@ var So = ["title"], Co = ["src"], wo = {
 		"font-weight": "600",
 		color: "rgba(255,255,255,0.82)"
 	}
-}, Bc = { style: {
+}, Vc = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(2, minmax(0, 1fr))",
 	gap: "8px",
 	"margin-bottom": "12px"
-} }, Vc = {
+} }, Hc = {
 	key: 0,
 	style: {
 		padding: "8px 10px",
@@ -6902,12 +6920,12 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(255,255,255,0.04)",
 		border: "1px solid rgba(255,255,255,0.10)"
 	}
-}, Hc = { style: {
+}, Uc = { style: {
 	"font-size": "13px",
 	"font-weight": "750",
 	color: "rgba(255,255,255,0.92)",
 	"margin-top": "3px"
-} }, Uc = {
+} }, Wc = {
 	key: 1,
 	style: {
 		padding: "8px 10px",
@@ -6915,12 +6933,12 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(255,255,255,0.04)",
 		border: "1px solid rgba(255,255,255,0.10)"
 	}
-}, Wc = { style: {
+}, Gc = { style: {
 	"font-size": "13px",
 	"font-weight": "750",
 	color: "rgba(255,255,255,0.92)",
 	"margin-top": "3px"
-} }, Gc = {
+} }, Kc = {
 	key: 2,
 	style: {
 		padding: "8px 10px",
@@ -6928,12 +6946,12 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(255,255,255,0.04)",
 		border: "1px solid rgba(255,255,255,0.10)"
 	}
-}, Kc = { style: {
+}, qc = { style: {
 	"font-size": "13px",
 	"font-weight": "750",
 	color: "rgba(255,255,255,0.92)",
 	"margin-top": "3px"
-} }, qc = {
+} }, Jc = {
 	key: 3,
 	style: {
 		padding: "8px 10px",
@@ -6941,19 +6959,19 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(255,255,255,0.04)",
 		border: "1px solid rgba(255,255,255,0.10)"
 	}
-}, Jc = { style: {
+}, Yc = { style: {
 	"font-size": "12px",
 	"font-weight": "650",
 	color: "rgba(255,255,255,0.84)",
 	"margin-top": "3px"
-} }, Yc = {
+} }, Xc = {
 	key: 0,
 	style: {
 		"font-size": "11px",
 		color: "rgba(255,255,255,0.54)",
 		"margin-top": "2px"
 	}
-}, Xc = {
+}, Zc = {
 	key: 0,
 	style: {
 		"margin-bottom": "12px",
@@ -6962,14 +6980,14 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(244,67,54,0.08)",
 		border: "1px solid rgba(244,67,54,0.25)"
 	}
-}, Zc = {
+}, Qc = {
 	key: 1,
 	style: {
 		display: "flex",
 		"flex-wrap": "wrap",
 		gap: "5px"
 	}
-}, Qc = {
+}, $c = {
 	key: 1,
 	style: {
 		"margin-bottom": "12px",
@@ -6978,7 +6996,7 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(255,255,255,0.035)",
 		border: "1px solid rgba(255,255,255,0.10)"
 	}
-}, $c = {
+}, el = {
 	key: 0,
 	style: {
 		"font-size": "12px",
@@ -6986,12 +7004,12 @@ var So = ["title"], Co = ["src"], wo = {
 		color: "rgba(255,255,255,0.82)",
 		"white-space": "pre-wrap"
 	}
-}, el = { style: {
+}, tl = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(3, minmax(0, 1fr))",
 	gap: "8px",
 	"margin-bottom": "12px"
-} }, tl = {
+} }, nl = {
 	key: 2,
 	style: {
 		"margin-bottom": "12px",
@@ -7000,31 +7018,24 @@ var So = ["title"], Co = ["src"], wo = {
 		background: "rgba(76,175,80,0.07)",
 		border: "1px solid rgba(76,175,80,0.22)"
 	}
-}, nl = { style: {
+}, rl = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "8px",
 	"margin-bottom": "7px"
-} }, rl = { style: {
+} }, il = { style: {
 	"font-size": "11px",
 	color: "rgba(255,255,255,0.62)"
-} }, il = {
+} }, al = {
 	key: 0,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "6px"
 	}
-}, al = {
-	key: 0,
-	style: {
-		display: "flex",
-		"flex-wrap": "wrap",
-		gap: "5px"
-	}
 }, ol = {
-	key: 1,
+	key: 0,
 	style: {
 		display: "flex",
 		"flex-wrap": "wrap",
@@ -7033,99 +7044,106 @@ var So = ["title"], Co = ["src"], wo = {
 }, sl = {
 	key: 1,
 	style: {
+		display: "flex",
+		"flex-wrap": "wrap",
+		gap: "5px"
+	}
+}, cl = {
+	key: 1,
+	style: {
 		"font-size": "12px",
 		color: "rgba(255,255,255,0.78)"
 	}
-}, cl = {
+}, ll = {
 	key: 2,
 	style: {
 		"margin-top": "7px",
 		"font-size": "11px",
 		color: "rgba(255,255,255,0.58)"
 	}
-}, ll = {
+}, ul = {
 	key: 3,
 	style: {
 		"margin-top": "8px",
 		"font-size": "11px",
 		color: "rgba(255,255,255,0.62)"
 	}
-}, ul = { key: 0 }, dl = { style: {
+}, dl = { key: 0 }, fl = { style: {
 	display: "grid",
 	"grid-template-columns": "repeat(3, minmax(0, 1fr))",
 	gap: "8px",
 	"margin-bottom": "12px"
-} }, fl = { style: {
-	padding: "8px 10px",
-	"border-radius": "10px",
-	background: "rgba(255,255,255,0.04)",
-	border: "1px solid rgba(255,255,255,0.10)"
 } }, pl = { style: {
-	"font-size": "18px",
-	"font-weight": "700",
-	color: "rgba(255,255,255,0.94)",
-	"margin-top": "2px"
+	padding: "8px 10px",
+	"border-radius": "10px",
+	background: "rgba(255,255,255,0.04)",
+	border: "1px solid rgba(255,255,255,0.10)"
 } }, ml = { style: {
-	padding: "8px 10px",
-	"border-radius": "10px",
-	background: "rgba(255,255,255,0.04)",
-	border: "1px solid rgba(255,255,255,0.10)"
+	"font-size": "18px",
+	"font-weight": "700",
+	color: "rgba(255,255,255,0.94)",
+	"margin-top": "2px"
 } }, hl = { style: {
-	"font-size": "18px",
-	"font-weight": "700",
-	color: "rgba(255,255,255,0.94)",
-	"margin-top": "2px"
-} }, gl = { style: {
 	padding: "8px 10px",
 	"border-radius": "10px",
 	background: "rgba(255,255,255,0.04)",
 	border: "1px solid rgba(255,255,255,0.10)"
-} }, _l = { style: {
+} }, gl = { style: {
 	"font-size": "18px",
 	"font-weight": "700",
 	color: "rgba(255,255,255,0.94)",
 	"margin-top": "2px"
+} }, _l = { style: {
+	padding: "8px 10px",
+	"border-radius": "10px",
+	background: "rgba(255,255,255,0.04)",
+	border: "1px solid rgba(255,255,255,0.10)"
 } }, vl = { style: {
+	"font-size": "18px",
+	"font-weight": "700",
+	color: "rgba(255,255,255,0.94)",
+	"margin-top": "2px"
+} }, yl = { style: {
 	"margin-bottom": "12px",
 	padding: "10px",
 	"border-radius": "10px",
 	background: "rgba(255,255,255,0.03)",
 	border: "1px solid rgba(255,255,255,0.10)"
-} }, yl = { style: {
+} }, bl = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "10px",
 	"margin-bottom": "8px",
 	"min-width": "0"
-} }, bl = { style: {
+} }, xl = { style: {
 	"min-width": "0",
 	flex: "1 1 auto"
-} }, xl = ["title"], Sl = ["title"], Cl = { style: {
+} }, Sl = ["title"], Cl = ["title"], wl = { style: {
 	display: "flex",
 	gap: "8px",
 	"align-items": "center"
-} }, wl = ["placeholder"], Tl = {
+} }, Tl = ["placeholder"], El = {
 	key: 3,
 	class: "mjr-workflow-tree-wrap"
-}, El = { class: "mjr-workflow-tree-node" }, Dl = { class: "mjr-workflow-tree-node-name" }, Ol = {
+}, Dl = { class: "mjr-workflow-tree-node" }, Ol = { class: "mjr-workflow-tree-node-name" }, kl = {
 	key: 0,
 	class: "mjr-workflow-tree-node-type"
-}, kl = { class: "mjr-menu-item-hint" }, Al = {
+}, Al = { class: "mjr-menu-item-hint" }, jl = {
 	key: 0,
 	class: "mjr-section-hint"
-}, jl = { style: {
+}, Ml = { style: {
 	display: "flex",
 	"align-items": "center",
 	"justify-content": "space-between",
 	gap: "10px",
 	"margin-top": "8px"
-} }, Ml = { style: {
+} }, Nl = { style: {
 	display: "flex",
 	"flex-wrap": "wrap",
 	gap: "6px",
 	"align-items": "center"
-} }, Nl = {
+} }, Pl = {
 	key: 4,
 	style: {
 		display: "grid",
@@ -7135,23 +7153,23 @@ var So = ["title"], Co = ["src"], wo = {
 		"margin-top": "10px",
 		"margin-bottom": "10px"
 	}
-}, Pl = { style: {
+}, Fl = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "2px",
 	"min-width": "0"
-} }, Fl = { style: {
+} }, Il = { style: {
 	"font-size": "13px",
 	"font-weight": "600"
-} }, Il = { style: {
+} }, Ll = { style: {
 	"font-size": "11px",
 	color: "rgba(255,255,255,0.58)"
-} }, Ll = { style: {
+} }, Rl = { style: {
 	display: "flex",
 	gap: "10px",
 	"align-items": "stretch",
 	"margin-top": "10px"
-} }, Rl = { style: {
+} }, zl = { style: {
 	display: "flex",
 	"justify-content": "space-between",
 	"align-items": "center",
@@ -7159,7 +7177,7 @@ var So = ["title"], Co = ["src"], wo = {
 	"margin-top": "8px",
 	"font-size": "11px",
 	color: "rgba(255,255,255,0.58)"
-} }, zl = ["open"], Bl = { style: {
+} }, Bl = ["open"], Vl = { style: {
 	background: "rgba(0,0,0,0.5)",
 	padding: "10px",
 	"border-radius": "6px",
@@ -7169,7 +7187,7 @@ var So = ["title"], Co = ["src"], wo = {
 	margin: "10px 0 0 0",
 	color: "#90CAF9",
 	"font-family": "'Consolas', 'Monaco', monospace"
-} }, Vl = 1, Hl = 8, Ul = 250, Wl = {
+} }, Hl = 1, Ul = 8, Wl = 250, Gl = {
 	__name: "SidebarWorkflowSection",
 	props: { asset: {
 		type: Object,
@@ -7206,23 +7224,23 @@ var So = ["title"], Co = ["src"], wo = {
 				label: "Expanded",
 				height: 220
 			}
-		]), a = B(null), o = B(""), s = B(!1), l = B(!1), u = B(null), d = B(!1), f = B(null), p = B([]), h = B(null), _ = B(!1), v = B(!1), y = B(ce()), b = B({ ...r }), S = B("crosshair"), ee = B(""), te = null, w = null, E = null;
+		]), a = B(null), s = B(""), c = B(!1), l = B(!1), d = B(null), p = B(!1), m = B(null), h = B([]), g = B(null), _ = B(!1), v = B(!1), b = B(ue()), S = B({ ...r }), C = B("crosshair"), ee = B(""), te = null, w = null, T = null;
 		function ne(e, t, n) {
 			let r = Number(e);
 			return Number.isFinite(r) ? Math.max(t, Math.min(n, r)) : t;
 		}
 		function re(e) {
-			!e || typeof e != "object" || (b.value = {
-				...b.value,
-				zoom: ne(e.zoom ?? b.value.zoom, Vl, Hl),
+			!e || typeof e != "object" || (S.value = {
+				...S.value,
+				zoom: ne(e.zoom ?? S.value.zoom, Hl, Ul),
 				centerX: Number.isFinite(Number(e.centerX)) ? Number(e.centerX) : null,
 				centerY: Number.isFinite(Number(e.centerY)) ? Number(e.centerY) : null
 			});
 		}
-		function D() {
-			b.value = { ...r }, ee.value = "";
+		function ie() {
+			S.value = { ...r }, ee.value = "";
 		}
-		function ie(e) {
+		function oe(e) {
 			let t = e?.metadata_raw ?? null;
 			if (!t) return null;
 			if (typeof t == "object") return t;
@@ -7238,7 +7256,7 @@ var So = ["title"], Co = ["src"], wo = {
 			}
 			return null;
 		}
-		function ae(e) {
+		function se(e) {
 			try {
 				let t = Object.entries(e || {});
 				if (!t.length) return !1;
@@ -7249,8 +7267,8 @@ var So = ["title"], Co = ["src"], wo = {
 			}
 			return !1;
 		}
-		function oe(e) {
-			let t = ie(e), n = e?.workflow || e?.Workflow || e?.comfy_workflow || t?.workflow || t?.Workflow || t?.comfy_workflow || null;
+		function ce(e) {
+			let t = oe(e), n = e?.workflow || e?.Workflow || e?.comfy_workflow || t?.workflow || t?.Workflow || t?.comfy_workflow || null;
 			if (!n) return null;
 			if (typeof n == "object") return n;
 			if (typeof n == "string") {
@@ -7264,25 +7282,25 @@ var So = ["title"], Co = ["src"], wo = {
 			}
 			return null;
 		}
-		function se(e) {
-			let t = ie(e), n = e?.prompt || e?.Prompt || t?.prompt || t?.Prompt || null;
+		function le(e) {
+			let t = oe(e), n = e?.prompt || e?.Prompt || t?.prompt || t?.Prompt || null;
 			if (!n) return null;
-			if (typeof n == "object") return ae(n) ? n : null;
+			if (typeof n == "object") return se(n) ? n : null;
 			if (typeof n == "string") {
 				let e = n.trim();
 				if (!e) return null;
 				try {
 					let t = JSON.parse(e);
-					return ae(t) ? t : null;
+					return se(t) ? t : null;
 				} catch {
 					return null;
 				}
 			}
 			return null;
 		}
-		function ce() {
+		function ue() {
 			try {
-				let e = Ut?.()?.workflowMinimap;
+				let e = Wt?.()?.workflowMinimap;
 				if (e && typeof e == "object") return {
 					...n,
 					...e
@@ -7291,7 +7309,7 @@ var So = ["title"], Co = ["src"], wo = {
 				console.debug?.(e);
 			}
 			try {
-				let e = localStorage?.getItem?.(le);
+				let e = localStorage?.getItem?.(ae);
 				if (!e) return { ...n };
 				let t = JSON.parse(e);
 				if (!t || typeof t != "object") return { ...n };
@@ -7300,11 +7318,11 @@ var So = ["title"], Co = ["src"], wo = {
 					...t
 				};
 				try {
-					let e = Ut();
+					let e = Wt();
 					e.workflowMinimap = {
 						...e.workflowMinimap,
 						...r
-					}, G(e), localStorage?.removeItem?.(le);
+					}, G(e), localStorage?.removeItem?.(ae);
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -7313,9 +7331,9 @@ var So = ["title"], Co = ["src"], wo = {
 				return { ...n };
 			}
 		}
-		function ue(e) {
+		function de(e) {
 			try {
-				let t = Ut();
+				let t = Wt();
 				t.workflowMinimap = {
 					...t.workflowMinimap,
 					...e
@@ -7324,29 +7342,29 @@ var So = ["title"], Co = ["src"], wo = {
 				console.debug?.(e);
 			}
 		}
-		let de = I(() => {
-			let e = oe(t.asset) || oe(u.value), n = se(t.asset) || se(u.value);
-			return !e && !n ? null : e || ua(n);
+		let D = I(() => {
+			let e = ce(t.asset) || ce(d.value), n = le(t.asset) || le(d.value);
+			return !e && !n ? null : e || da(n);
 		}), fe = I(() => String(t.asset?.filepath || t.asset?.path || t.asset?.file_info?.filepath || "").trim()), pe = I(() => String(t.asset?.display_name || t.asset?.name || t.asset?.filename || t.asset?.title || "Workflow").trim()), me = I(() => String(t.asset?.task || t.asset?.workflow_task || "").trim()), he = I(() => String(t.asset?.model_family || t.asset?.workflow_model_family || "").trim()), _e = I(() => String(t.asset?.provider || t.asset?.workflow_provider || "").trim()), ve = I(() => String(t.asset?.runs_on || t.asset?.runsOn || "").trim().toLowerCase()), ye = I(() => {
 			let e = ve.value, t = _e.value;
 			return e === "api" && t ? `API · ${t}` : e ? t && t.toLowerCase() !== e ? `${e} · ${t}` : e : t;
-		}), be = I(() => String(t.asset?.notes || "").trim()), Se = I(() => [
+		}), be = I(() => String(t.asset?.notes || "").trim()), xe = I(() => [
 			t.asset?.detected_task ? `detected: ${t.asset.detected_task}` : "",
 			t.asset?.detected_model_family ? t.asset.detected_model_family : "",
 			t.asset?.detected_provider ? t.asset.detected_provider : ""
-		].filter(Boolean).join(" · ")), Ce = I(() => Le(t.asset?.missing_nodes || t.asset?.missingNodes)), we = I(() => Le(t.asset?.missing_models || t.asset?.missingModels)), Te = I(() => Le(t.asset?.tags || t.asset?.workflow_tags || t.asset?.tags_json)), Ee = I(() => Te.value.slice(0, 3)), De = I(() => Math.max(0, Te.value.length - Ee.value.length)), Oe = I(() => Le(f.value?.missing_nodes)), ke = I(() => Le(f.value?.missing_models)), Ae = I(() => Le(f.value?.warnings)), je = I(() => {
-			let e = f.value;
+		].filter(Boolean).join(" · ")), Ce = I(() => A(t.asset?.missing_nodes || t.asset?.missingNodes)), we = I(() => A(t.asset?.missing_models || t.asset?.missingModels)), Te = I(() => A(t.asset?.tags || t.asset?.workflow_tags || t.asset?.tags_json)), Ee = I(() => Te.value.slice(0, 3)), De = I(() => Math.max(0, Te.value.length - Ee.value.length)), Oe = I(() => A(m.value?.missing_nodes)), ke = I(() => A(m.value?.missing_models)), Ae = I(() => A(m.value?.warnings)), je = I(() => {
+			let e = m.value;
 			return e ? `${Number(e.node_count || 0)} nodes | ${Number(e.subgraph_count || 0)} subgraphs | ${Array.isArray(e.required_nodes) ? e.required_nodes.length : 0} node types` : "";
 		}), Me = I(() => {
-			let e = p.value?.[0];
+			let e = h.value?.[0];
 			return e ? String(e.filename || "").replace(/\.json$/i, "") : "";
 		}), Ne = I(() => {
-			let e = h.value;
+			let e = g.value;
 			return e ? `${Number(e.changed?.length || 0)} changed | ${Number(e.added?.length || 0)} added | ${Number(e.removed?.length || 0)} removed` : "";
 		}), Pe = I(() => {
 			let e = Number(t.asset?.usage_count || t.asset?.usageCount || 0);
 			return !Number.isFinite(e) || e <= 0 ? "" : `${Math.floor(e)} use${e === 1 ? "" : "s"}`;
-		}), k = I(() => Re(t.asset?.last_loaded_at || t.asset?.lastLoadedAt)), Fe = I(() => Re(t.asset?.mtime || t.asset?.modified_at || t.asset?.updated_at)), Ie = I(() => {
+		}), Fe = I(() => Re(t.asset?.last_loaded_at || t.asset?.lastLoadedAt)), k = I(() => Re(t.asset?.mtime || t.asset?.modified_at || t.asset?.updated_at)), Ie = I(() => {
 			let e = [];
 			t.asset?.favorite && e.push({
 				key: "favorite",
@@ -7358,9 +7376,9 @@ var So = ["title"], Co = ["src"], wo = {
 				label: Pe.value,
 				icon: "pi pi-play-circle",
 				tone: "usage"
-			}), k.value && e.push({
+			}), Fe.value && e.push({
 				key: "last-loaded",
-				label: `Loaded ${k.value}`,
+				label: `Loaded ${Fe.value}`,
 				icon: "pi pi-clock",
 				tone: "loaded"
 			});
@@ -7377,18 +7395,18 @@ var So = ["title"], Co = ["src"], wo = {
 				tone: "tag"
 			}), e;
 		});
-		function A(e) {
+		function Le(e) {
 			let t = "display:inline-flex;align-items:center;gap:5px;max-width:100%;padding:4px 8px;border-radius:999px;font-size:10px;font-weight:750;line-height:1.1;overflow:hidden";
 			return e === "favorite" ? `${t};background:rgba(255,193,7,0.15);border:1px solid rgba(255,193,7,0.34);color:#ffe082` : e === "usage" ? `${t};background:rgba(33,150,243,0.14);border:1px solid rgba(33,150,243,0.30);color:#90caf9` : e === "loaded" ? `${t};background:rgba(76,175,80,0.13);border:1px solid rgba(76,175,80,0.28);color:#a5d6a7` : `${t};background:rgba(255,255,255,0.07);border:1px solid rgba(255,255,255,0.14);color:rgba(255,255,255,0.82)`;
 		}
-		function Le(e) {
+		function A(e) {
 			if (Array.isArray(e)) return e.map((e) => String(e || "").trim()).filter(Boolean);
 			if (typeof e == "string") {
 				let t = e.trim();
 				if (!t) return [];
 				try {
 					let e = JSON.parse(t);
-					if (Array.isArray(e)) return Le(e);
+					if (Array.isArray(e)) return A(e);
 				} catch {
 					return t.split(/[,\n]/).map((e) => e.trim()).filter(Boolean);
 				}
@@ -7406,16 +7424,16 @@ var So = ["title"], Co = ["src"], wo = {
 			}
 		}
 		async function ze() {
-			if (de.value) return;
+			if (D.value) return;
 			let e = fe.value;
 			if (e && !l.value) {
 				l.value = !0;
 				try {
-					let t = await x(e, { timeoutMs: 25e3 });
+					let t = await y(e, { timeoutMs: 25e3 });
 					if (!t?.ok) return;
 					let n = t?.data?.workflow || t?.workflow || null, r = t?.data?.prompt || t?.prompt || null;
 					if (!n && !r) return;
-					u.value = {
+					d.value = {
 						workflow: n,
 						prompt: r
 					};
@@ -7426,124 +7444,124 @@ var So = ["title"], Co = ["src"], wo = {
 				}
 			}
 		}
-		let Ve = I(() => t.asset?.has_generation_data ? "Complete" : "Partial"), He = I(() => de.value ? JSON.stringify(de.value, null, 2) : ""), Ue = I(() => String(t.asset?.category || t.asset?.subfolder || t.asset?.folder || "").trim().replace(/^\/+|\/+$/g, "")), We = I(() => Ue.value ? Ue.value.split(/[\\/]+/).filter(Boolean) : []), Ge = I(() => We.value.at(-1) || Ue.value || "Root"), Ke = I(() => We.value.slice(-1));
+		let Be = I(() => t.asset?.has_generation_data ? "Complete" : "Partial"), He = I(() => D.value ? JSON.stringify(D.value, null, 2) : ""), Ue = I(() => String(t.asset?.category || t.asset?.subfolder || t.asset?.folder || "").trim().replace(/^\/+|\/+$/g, "")), We = I(() => Ue.value ? Ue.value.split(/[\\/]+/).filter(Boolean) : []), Ge = I(() => We.value.at(-1) || Ue.value || "Root"), Ke = I(() => We.value.slice(-1));
 		function qe(e, t) {
 			let n = e?.id ?? e?.key ?? t + 1;
 			return String(e?.title || e?._meta?.title || e?.type || e?.class_type || e?.name || `Node ${n}`);
 		}
-		function tt(e) {
+		function Je(e) {
 			return String(e?.type || e?.class_type || e?.name || "").trim();
 		}
-		function rt() {
-			o.value = Ue.value;
+		function nt() {
+			s.value = Ue.value;
 		}
 		async function it() {
 			let e = String(t.asset?.filepath || t.asset?.path || t.asset?.file_info?.filepath || "").trim();
 			if (!e) {
-				T(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+				E(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 				return;
 			}
-			let n = String(o.value || "").trim();
+			let n = String(s.value || "").trim();
 			if (n !== Ue.value) {
-				s.value = !0;
+				c.value = !0;
 				try {
-					let t = await g({
+					let t = await f({
 						filepath: e,
 						category: n
 					}, { timeoutMs: 3e4 });
 					if (!t?.ok) {
-						T(t?.error || O("toast.workflowMoveFailed", "Failed to move workflow."), "error");
+						E(t?.error || O("toast.workflowMoveFailed", "Failed to move workflow."), "error");
 						return;
 					}
-					o.value = String(t?.data?.workflow?.category || n || "").trim(), T(O("toast.workflowCategoryUpdated", "Workflow category updated"), "success", 1800);
+					s.value = String(t?.data?.workflow?.category || n || "").trim(), E(O("toast.workflowCategoryUpdated", "Workflow category updated"), "success", 1800);
 				} catch {
-					T(O("toast.workflowMoveFailed", "Failed to move workflow."), "error");
+					E(O("toast.workflowMoveFailed", "Failed to move workflow."), "error");
 				} finally {
-					s.value = !1;
+					c.value = !1;
 				}
 			}
 		}
 		async function at() {
 			let e = fe.value;
 			if (!e) {
-				T(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+				E(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 				return;
 			}
-			let n = await xe({
+			let n = await Se({
 				filepath: e,
 				limit: 12
 			}, { timeoutMs: 15e3 });
 			if (!n?.ok) {
-				T(n?.error || O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+				E(n?.error || O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 				return;
 			}
 			let r = Array.isArray(n.data) ? n.data : [];
 			if (!r.length) {
-				T(O("toast.workflowThumbnailNoCandidates", "No linked outputs are available for this workflow yet."), "warning", 2600);
+				E(O("toast.workflowThumbnailNoCandidates", "No linked outputs are available for this workflow yet."), "warning", 2600);
 				return;
 			}
-			let i = await fa({
+			let i = await pa({
 				title: O("ctx.setWorkflowThumbnail", "Set workflow thumbnail"),
 				workflow: t.asset,
 				items: r
 			});
 			if (!i?.filepath) return;
-			let a = await m({
+			let a = await u({
 				filepath: e,
 				source_filepath: i.filepath
 			}, { timeoutMs: 3e4 });
 			if (!a?.ok) {
-				T(a?.error || O("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+				E(a?.error || O("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 				return;
 			}
-			T(O("toast.workflowUpdated", "Workflow updated"), "success", 1800), window?.dispatchEvent?.(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-thumbnail-sidebar" } }));
+			E(O("toast.workflowUpdated", "Workflow updated"), "success", 1800), window?.dispatchEvent?.(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-thumbnail-sidebar" } }));
 		}
 		async function ot() {
-			if (await ze(), !de.value) {
-				T(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+			if (await ze(), !D.value) {
+				E(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 				return;
 			}
 			try {
-				await Je.openAssets({
+				await Ye.openAssets({
 					assets: [{
 						...t.asset,
-						workflow: de.value,
-						Workflow: de.value
+						workflow: D.value,
+						Workflow: D.value
 					}],
 					index: 0,
 					mode: "graph"
 				});
 			} catch (e) {
-				console.debug?.(e), T(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+				console.debug?.(e), E(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 			}
 		}
 		async function st() {
 			let e = fe.value;
 			if (!e) {
-				T(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+				E(O("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 				return;
 			}
-			d.value = !0, f.value = null, p.value = [], h.value = null;
+			p.value = !0, m.value = null, h.value = [], g.value = null;
 			try {
-				let [t, n] = await Promise.all([c(e, { timeoutMs: 2e4 }), C(e, { timeoutMs: 15e3 })]);
+				let [t, n] = await Promise.all([o(e, { timeoutMs: 2e4 }), x(e, { timeoutMs: 15e3 })]);
 				if (!t?.ok) {
-					T(t?.error || O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+					E(t?.error || O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 					return;
 				}
-				f.value = t.data || {}, p.value = Array.isArray(n?.data?.versions) ? n.data.versions : [];
-				let r = p.value[0];
+				m.value = t.data || {}, h.value = Array.isArray(n?.data?.versions) ? n.data.versions : [];
+				let r = h.value[0];
 				if (r?.filepath) {
 					let t = await ge(e, r.filepath, { timeoutMs: 15e3 });
-					t?.ok && (h.value = t.data || null);
+					t?.ok && (g.value = t.data || null);
 				}
 			} catch (e) {
-				console.debug?.(e), T(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+				console.debug?.(e), E(O("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 			} finally {
-				d.value = !1;
+				p.value = !1;
 			}
 		}
-		let ct = I(() => (Array.isArray(de.value?.nodes) ? de.value.nodes : []).slice(0, Ul).map((e, t) => {
-			let n = e?.id ?? e?.key ?? t + 1, r = tt(e);
+		let ct = I(() => (Array.isArray(D.value?.nodes) ? D.value.nodes : []).slice(0, Wl).map((e, t) => {
+			let n = e?.id ?? e?.key ?? t + 1, r = Je(e);
 			return {
 				key: String(n),
 				label: qe(e, t),
@@ -7554,7 +7572,7 @@ var So = ["title"], Co = ["src"], wo = {
 				}
 			};
 		})), lt = I(() => Math.max(0, Number(ut.value.nodes || 0) - ct.value.length)), ut = I(() => {
-			let e = de.value;
+			let e = D.value;
 			return e ? {
 				nodes: Array.isArray(e?.nodes) ? e.nodes.length : 0,
 				links: Array.isArray(e?.links) && e.links.length || Array.isArray(e?.extra?.links) && e.extra.links.length || 0,
@@ -7567,9 +7585,9 @@ var So = ["title"], Co = ["src"], wo = {
 				source: ""
 			};
 		}), dt = I(() => {
-			let e = String(y.value?.size || "comfortable");
+			let e = String(b.value?.size || "comfortable");
 			return i.find((t) => t.key === e) || i[1];
-		}), pt = I(() => `${dt.value.height}px`), ht = I(() => [
+		}), ft = I(() => `${dt.value.height}px`), mt = I(() => [
 			{
 				key: "showNodeLabels",
 				label: "Node Labels",
@@ -7607,18 +7625,18 @@ var So = ["title"], Co = ["src"], wo = {
 			}
 		]);
 		function gt() {
-			let e = a.value, t = de.value;
+			let e = a.value, t = D.value;
 			if (!e || !t) return;
 			let n = Math.max(1, e.clientWidth || 320), r = Math.max(1, e.clientHeight || 120), i = Math.max(1, Math.min(2, window.devicePixelRatio || 1));
 			e.width = Math.floor(n * i), e.height = Math.floor(r * i);
 			let o = e.getContext("2d");
-			o && o.setTransform(i, 0, 0, i, 0, 0), w = ea(e, t, {
-				...y.value,
-				view: b.value
+			o && o.setTransform(i, 0, 0, i, 0, 0), w = ta(e, t, {
+				...b.value,
+				view: S.value
 			}) || null, re(w?.resolvedView);
 		}
 		function _t(e) {
-			Be(e);
+			Ve(e);
 		}
 		function vt(e) {
 			let t = a.value;
@@ -7629,7 +7647,7 @@ var So = ["title"], Co = ["src"], wo = {
 				y: Number(e?.clientY) - n.top
 			} : null;
 		}
-		function bt(e) {
+		function yt(e) {
 			let t = vt(e);
 			return !t || !w?.canvasToWorld ? null : {
 				local: t,
@@ -7637,95 +7655,95 @@ var So = ["title"], Co = ["src"], wo = {
 			};
 		}
 		function xt(e) {
-			let t = vt(e), n = t && w?.hitTestNode ? w.hitTestNode(t.x, t.y) : null, r = n?.id !== null && n?.id !== void 0 ? String(n.id) : null, i = b.value.hoveredNodeId !== null && b.value.hoveredNodeId !== void 0 ? String(b.value.hoveredNodeId) : null;
-			ee.value = n?.label || "", r !== i && (b.value = {
-				...b.value,
+			let t = vt(e), n = t && w?.hitTestNode ? w.hitTestNode(t.x, t.y) : null, r = n?.id !== null && n?.id !== void 0 ? String(n.id) : null, i = S.value.hoveredNodeId !== null && S.value.hoveredNodeId !== void 0 ? String(S.value.hoveredNodeId) : null;
+			ee.value = n?.label || "", r !== i && (S.value = {
+				...S.value,
 				hoveredNodeId: r
 			}, gt());
 		}
 		function St(e) {
-			e && (_t(e), b.value = {
-				...b.value,
+			e && (_t(e), S.value = {
+				...S.value,
 				centerX: Number(e.x),
 				centerY: Number(e.y)
 			}, gt());
 		}
 		function Ct(e) {
 			if (Number(e?.button ?? 0) !== 0) return;
-			let t = bt(e);
-			t && (E = e.pointerId ?? 1, S.value = "grabbing", a.value?.setPointerCapture?.(E), St(t.world), xt(e), e.preventDefault?.(), e.stopPropagation?.());
+			let t = yt(e);
+			t && (T = e.pointerId ?? 1, C.value = "grabbing", a.value?.setPointerCapture?.(T), St(t.world), xt(e), e.preventDefault?.(), e.stopPropagation?.());
 		}
 		function wt(e) {
-			if (E !== null && e.pointerId === E) {
-				let t = bt(e);
+			if (T !== null && e.pointerId === T) {
+				let t = yt(e);
 				t && St(t.world), e.preventDefault?.(), e.stopPropagation?.();
 				return;
 			}
 			xt(e);
 		}
-		function Et(e) {
-			E !== null && e?.pointerId === E && (a.value?.releasePointerCapture?.(E), E = null, S.value = "crosshair"), e?.type === "pointerleave" && (ee.value = "", b.value.hoveredNodeId !== null && (b.value = {
-				...b.value,
+		function Tt(e) {
+			T !== null && e?.pointerId === T && (a.value?.releasePointerCapture?.(T), T = null, C.value = "crosshair"), e?.type === "pointerleave" && (ee.value = "", S.value.hoveredNodeId !== null && (S.value = {
+				...S.value,
 				hoveredNodeId: null
 			}, gt()));
 		}
 		function Dt(e) {
-			let t = bt(e), n = w?.resolvedView;
+			let t = yt(e), n = w?.resolvedView;
 			if (!t || !n) return;
-			let r = ne(Number(e?.deltaY) || 0, -240, 240), i = Math.exp(-r * .0025), a = ne((Number(b.value.zoom) || 1) * i, Vl, Hl);
-			if (Math.abs(a - (Number(b.value.zoom) || 1)) < .001) {
+			let r = ne(Number(e?.deltaY) || 0, -240, 240), i = Math.exp(-r * .0025), a = ne((Number(S.value.zoom) || 1) * i, Hl, Ul);
+			if (Math.abs(a - (Number(S.value.zoom) || 1)) < .001) {
 				e.preventDefault?.(), e.stopPropagation?.();
 				return;
 			}
 			let o = Math.max(1, Number(w?.bounds?.width || 1) / a), s = Math.max(1, Number(w?.bounds?.height || 1) / a), c = ne((Number(t.world.x) - Number(n.viewMinX || 0)) / Math.max(1, Number(n.visibleW || 1)), 0, 1), l = ne((Number(t.world.y) - Number(n.viewMinY || 0)) / Math.max(1, Number(n.visibleH || 1)), 0, 1);
-			b.value = {
-				...b.value,
+			S.value = {
+				...S.value,
 				zoom: a,
 				centerX: Number(t.world.x) + (.5 - c) * o,
 				centerY: Number(t.world.y) + (.5 - l) * s
 			}, gt(), xt(e), e.preventDefault?.(), e.stopPropagation?.();
 		}
 		function Ot(e) {
-			let t = bt(e);
-			D(), t && _t(t.world), gt(), e.preventDefault?.(), e.stopPropagation?.();
+			let t = yt(e);
+			ie(), t && _t(t.world), gt(), e.preventDefault?.(), e.stopPropagation?.();
 		}
 		function kt(e) {
-			y.value = {
-				...y.value,
-				[e]: !y.value?.[e]
-			}, ue(y.value);
+			b.value = {
+				...b.value,
+				[e]: !b.value?.[e]
+			}, de(b.value);
 		}
 		function At(e) {
-			i.some((t) => t.key === e) && (y.value = {
-				...y.value,
+			i.some((t) => t.key === e) && (b.value = {
+				...b.value,
 				size: e
-			}, ue(y.value));
+			}, de(b.value));
 		}
-		return et(() => {
-			a.value && typeof ResizeObserver == "function" && (te = new ResizeObserver(() => gt()), te.observe(a.value)), rt(), ze(), gt();
-		}), Ze(de, () => {
-			D(), gt();
-		}, { flush: "post" }), Ze(fe, () => {
-			u.value = null, ze();
-		}, { immediate: !0 }), Ze(Ue, () => {
-			rt();
-		}), Ze(y, () => {
+		return tt(() => {
+			a.value && typeof ResizeObserver == "function" && (te = new ResizeObserver(() => gt()), te.observe(a.value)), nt(), ze(), gt();
+		}), Qe(D, () => {
+			ie(), gt();
+		}, { flush: "post" }), Qe(fe, () => {
+			d.value = null, ze();
+		}, { immediate: !0 }), Qe(Ue, () => {
+			nt();
+		}), Qe(b, () => {
 			gt();
 		}, {
 			deep: !0,
 			flush: "post"
-		}), Ze(_, () => {
+		}), Qe(_, () => {
 			gt();
-		}, { flush: "post" }), $e(() => {
+		}, { flush: "post" }), et(() => {
 			try {
 				te?.disconnect?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
-			te = null, E = null;
+			te = null, T = null;
 		}), (e, t) => {
-			let n = nt("MButton"), r = nt("MTree");
-			return de.value ? (j(), z("div", Ac, [
+			let n = rt("MButton"), r = rt("MTree");
+			return D.value ? (j(), z("div", jc, [
 				t[18] ||= N("div", { style: {
 					"font-size": "13px",
 					"font-weight": "600",
@@ -7734,8 +7752,8 @@ var So = ["title"], Co = ["src"], wo = {
 					"text-transform": "uppercase",
 					"letter-spacing": "0.5px"
 				} }, " ComfyUI Workflow ", -1),
-				N("div", jc, [
-					N("div", Mc, R(pe.value), 1),
+				N("div", Mc, [
+					N("div", Nc, R(pe.value), 1),
 					fe.value ? (j(), z("div", {
 						key: 0,
 						style: {
@@ -7747,43 +7765,43 @@ var So = ["title"], Co = ["src"], wo = {
 							"white-space": "nowrap"
 						},
 						title: fe.value
-					}, R(fe.value), 9, Nc)) : F("", !0),
-					Ie.value.length ? (j(), z("div", Pc, [(j(!0), z(M, null, P(Ie.value, (e) => (j(), z("span", {
+					}, R(fe.value), 9, Pc)) : F("", !0),
+					Ie.value.length ? (j(), z("div", Fc, [(j(!0), z(M, null, P(Ie.value, (e) => (j(), z("span", {
 						key: e.key,
-						style: V(A(e.tone)),
+						style: V(Le(e.tone)),
 						title: e.label
 					}, [N("i", {
-						class: mt(e.icon),
+						class: ht(e.icon),
 						style: {
 							"font-size": "10px",
 							flex: "0 0 auto"
 						}
-					}, null, 2), N("span", Ic, R(e.label), 1)], 12, Fc))), 128))])) : F("", !0)
+					}, null, 2), N("span", Lc, R(e.label), 1)], 12, Ic))), 128))])) : F("", !0)
 				]),
-				N("div", Lc, [N("div", Rc, R(Ve.value), 1), ut.value.source ? (j(), z("div", zc, R(ut.value.source), 1)) : F("", !0)]),
-				N("div", Bc, [
-					me.value ? (j(), z("div", Vc, [t[3] ||= N("div", { style: {
+				N("div", Rc, [N("div", zc, R(Be.value), 1), ut.value.source ? (j(), z("div", Bc, R(ut.value.source), 1)) : F("", !0)]),
+				N("div", Vc, [
+					me.value ? (j(), z("div", Hc, [t[3] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Task", -1), N("div", Hc, R(me.value), 1)])) : F("", !0),
-					he.value ? (j(), z("div", Uc, [t[4] ||= N("div", { style: {
+					} }, "Task", -1), N("div", Uc, R(me.value), 1)])) : F("", !0),
+					he.value ? (j(), z("div", Wc, [t[4] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Model", -1), N("div", Wc, R(he.value), 1)])) : F("", !0),
-					ye.value ? (j(), z("div", Gc, [t[5] ||= N("div", { style: {
+					} }, "Model", -1), N("div", Gc, R(he.value), 1)])) : F("", !0),
+					ye.value ? (j(), z("div", Kc, [t[5] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Runs on", -1), N("div", Kc, R(ye.value), 1)])) : F("", !0),
-					Pe.value || Fe.value ? (j(), z("div", qc, [
+					} }, "Runs on", -1), N("div", qc, R(ye.value), 1)])) : F("", !0),
+					Pe.value || k.value ? (j(), z("div", Jc, [
 						t[6] ||= N("div", { style: {
 							"font-size": "10px",
 							"font-weight": "700",
@@ -7791,11 +7809,11 @@ var So = ["title"], Co = ["src"], wo = {
 							"text-transform": "uppercase",
 							"letter-spacing": "0.4px"
 						} }, "Library", -1),
-						N("div", Jc, R(Pe.value || Fe.value), 1),
-						Pe.value && Fe.value ? (j(), z("div", Yc, R(Fe.value), 1)) : F("", !0)
+						N("div", Yc, R(Pe.value || k.value), 1),
+						Pe.value && k.value ? (j(), z("div", Xc, R(k.value), 1)) : F("", !0)
 					])) : F("", !0)
 				]),
-				Ce.value.length || we.value.length ? (j(), z("div", Xc, [
+				Ce.value.length || we.value.length ? (j(), z("div", Zc, [
 					t[7] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "800",
@@ -7823,7 +7841,7 @@ var So = ["title"], Co = ["src"], wo = {
 							color: "#ffcdd2"
 						}
 					}, R(e), 1))), 128))], 4)) : F("", !0),
-					we.value.length ? (j(), z("div", Zc, [(j(!0), z(M, null, P(we.value, (e) => (j(), z("span", {
+					we.value.length ? (j(), z("div", Qc, [(j(!0), z(M, null, P(we.value, (e) => (j(), z("span", {
 						key: `model-${e}`,
 						style: {
 							padding: "3px 7px",
@@ -7835,16 +7853,16 @@ var So = ["title"], Co = ["src"], wo = {
 						}
 					}, R(e), 1))), 128))])) : F("", !0)
 				])) : F("", !0),
-				be.value || Se.value ? (j(), z("div", Qc, [be.value ? (j(), z("div", $c, R(be.value), 1)) : F("", !0), Se.value ? (j(), z("div", {
+				be.value || xe.value ? (j(), z("div", $c, [be.value ? (j(), z("div", el, R(be.value), 1)) : F("", !0), xe.value ? (j(), z("div", {
 					key: 1,
 					style: V({
 						fontSize: "11px",
 						color: "rgba(255,255,255,0.48)",
 						marginTop: be.value ? "7px" : "0"
 					})
-				}, R(Se.value), 5)) : F("", !0)])) : F("", !0),
-				N("div", el, [
-					ft(n, {
+				}, R(xe.value), 5)) : F("", !0)])) : F("", !0),
+				N("div", tl, [
+					pt(n, {
 						type: "button",
 						severity: "secondary",
 						text: "",
@@ -7864,10 +7882,10 @@ var So = ["title"], Co = ["src"], wo = {
 						},
 						onClick: at
 					}, {
-						default: yt(() => [t[8] ||= N("i", { class: "pi pi-image" }, null, -1), N("span", null, R(L(O)("ctx.setWorkflowThumbnail", "Set workflow thumbnail")), 1)]),
+						default: bt(() => [t[8] ||= N("i", { class: "pi pi-image" }, null, -1), N("span", null, R(L(O)("ctx.setWorkflowThumbnail", "Set workflow thumbnail")), 1)]),
 						_: 1
 					}),
-					ft(n, {
+					pt(n, {
 						type: "button",
 						severity: "secondary",
 						text: "",
@@ -7887,15 +7905,15 @@ var So = ["title"], Co = ["src"], wo = {
 						},
 						onClick: ot
 					}, {
-						default: yt(() => [t[9] ||= N("i", { class: "pi pi-search" }, null, -1), N("span", null, R(L(O)("ctx.inspect", "Inspect")), 1)]),
+						default: bt(() => [t[9] ||= N("i", { class: "pi pi-search" }, null, -1), N("span", null, R(L(O)("ctx.inspect", "Inspect")), 1)]),
 						_: 1
 					}),
-					ft(n, {
+					pt(n, {
 						type: "button",
 						severity: "secondary",
 						text: "",
 						rounded: "",
-						disabled: d.value,
+						disabled: p.value,
 						style: {
 							height: "34px",
 							"border-radius": "9px",
@@ -7911,19 +7929,19 @@ var So = ["title"], Co = ["src"], wo = {
 						},
 						onClick: st
 					}, {
-						default: yt(() => [N("i", { class: mt(d.value ? "pi pi-spin pi-spinner" : "pi pi-check-circle") }, null, 2), N("span", null, R(d.value ? "Checking" : "Validate"), 1)]),
+						default: bt(() => [N("i", { class: ht(p.value ? "pi pi-spin pi-spinner" : "pi pi-check-circle") }, null, 2), N("span", null, R(p.value ? "Checking" : "Validate"), 1)]),
 						_: 1
 					}, 8, ["disabled"])
 				]),
-				f.value ? (j(), z("div", tl, [
-					N("div", nl, [t[10] ||= N("div", { style: {
+				m.value ? (j(), z("div", nl, [
+					N("div", rl, [t[10] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "800",
 						color: "#a5d6a7",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Workflow diagnostics", -1), N("div", rl, R(je.value), 1)]),
-					Oe.value.length || ke.value.length ? (j(), z("div", il, [Oe.value.length ? (j(), z("div", al, [(j(!0), z(M, null, P(Oe.value, (e) => (j(), z("span", {
+					} }, "Workflow diagnostics", -1), N("div", il, R(je.value), 1)]),
+					Oe.value.length || ke.value.length ? (j(), z("div", al, [Oe.value.length ? (j(), z("div", ol, [(j(!0), z(M, null, P(Oe.value, (e) => (j(), z("span", {
 						key: `diag-node-${e}`,
 						style: {
 							padding: "3px 7px",
@@ -7933,7 +7951,7 @@ var So = ["title"], Co = ["src"], wo = {
 							"font-weight": "700",
 							color: "#ffcdd2"
 						}
-					}, " Missing node: " + R(e), 1))), 128))])) : F("", !0), ke.value.length ? (j(), z("div", ol, [(j(!0), z(M, null, P(ke.value, (e) => (j(), z("span", {
+					}, " Missing node: " + R(e), 1))), 128))])) : F("", !0), ke.value.length ? (j(), z("div", sl, [(j(!0), z(M, null, P(ke.value, (e) => (j(), z("span", {
 						key: `diag-model-${e}`,
 						style: {
 							padding: "3px 7px",
@@ -7943,34 +7961,34 @@ var So = ["title"], Co = ["src"], wo = {
 							"font-weight": "700",
 							color: "#ffe0b2"
 						}
-					}, " Missing model: " + R(e), 1))), 128))])) : F("", !0)])) : (j(), z("div", sl, " No missing dependencies detected by the current ComfyUI runtime. ")),
-					Ae.value.length ? (j(), z("div", cl, R(Ae.value.join(" | ")), 1)) : F("", !0),
-					Me.value || Ne.value ? (j(), z("div", ll, [Ye(" Latest version: " + R(Me.value || "none"), 1), Ne.value ? (j(), z("span", ul, " | Diff: " + R(Ne.value), 1)) : F("", !0)])) : F("", !0)
+					}, " Missing model: " + R(e), 1))), 128))])) : F("", !0)])) : (j(), z("div", cl, " No missing dependencies detected by the current ComfyUI runtime. ")),
+					Ae.value.length ? (j(), z("div", ll, R(Ae.value.join(" | ")), 1)) : F("", !0),
+					Me.value || Ne.value ? (j(), z("div", ul, [Xe(" Latest version: " + R(Me.value || "none"), 1), Ne.value ? (j(), z("span", dl, " | Diff: " + R(Ne.value), 1)) : F("", !0)])) : F("", !0)
 				])) : F("", !0),
-				N("div", dl, [
-					N("div", fl, [t[11] ||= N("div", { style: {
+				N("div", fl, [
+					N("div", pl, [t[11] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Nodes", -1), N("div", pl, R(ut.value.nodes), 1)]),
-					N("div", ml, [t[12] ||= N("div", { style: {
+					} }, "Nodes", -1), N("div", ml, R(ut.value.nodes), 1)]),
+					N("div", hl, [t[12] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Links", -1), N("div", hl, R(ut.value.links), 1)]),
-					N("div", gl, [t[13] ||= N("div", { style: {
+					} }, "Links", -1), N("div", gl, R(ut.value.links), 1)]),
+					N("div", _l, [t[13] ||= N("div", { style: {
 						"font-size": "10px",
 						"font-weight": "700",
 						color: "rgba(255,255,255,0.55)",
 						"text-transform": "uppercase",
 						"letter-spacing": "0.4px"
-					} }, "Groups", -1), N("div", _l, R(ut.value.groups), 1)])
+					} }, "Groups", -1), N("div", vl, R(ut.value.groups), 1)])
 				]),
-				N("div", vl, [N("div", yl, [N("div", bl, [t[14] ||= N("div", { style: {
+				N("div", yl, [N("div", bl, [N("div", xl, [t[14] ||= N("div", { style: {
 					"font-size": "10px",
 					"font-weight": "700",
 					color: "rgba(255,255,255,0.55)",
@@ -7987,7 +8005,7 @@ var So = ["title"], Co = ["src"], wo = {
 						"white-space": "nowrap",
 						"max-width": "100%"
 					}
-				}, R(Ge.value), 9, xl)]), Ke.value.length ? (j(), z("div", {
+				}, R(Ge.value), 9, Sl)]), Ke.value.length ? (j(), z("div", {
 					key: 0,
 					title: Ue.value,
 					style: {
@@ -8015,8 +8033,8 @@ var So = ["title"], Co = ["src"], wo = {
 						"text-overflow": "ellipsis",
 						"white-space": "nowrap"
 					}
-				}, R(e), 1))), 128))], 8, Sl)) : F("", !0)]), N("div", Cl, [Qe(N("input", {
-					"onUpdate:modelValue": t[0] ||= (e) => o.value = e,
+				}, R(e), 1))), 128))], 8, Cl)) : F("", !0)]), N("div", wl, [$e(N("input", {
+					"onUpdate:modelValue": t[0] ||= (e) => s.value = e,
 					type: "text",
 					placeholder: L(O)("dialog.workflowCategory", "Workflow category"),
 					style: {
@@ -8029,31 +8047,31 @@ var So = ["title"], Co = ["src"], wo = {
 						color: "rgba(255,255,255,0.92)",
 						"font-size": "12px"
 					}
-				}, null, 8, wl), [[Tt, o.value]]), ft(n, {
+				}, null, 8, Tl), [[Et, s.value]]), pt(n, {
 					type: "button",
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					disabled: s.value,
+					disabled: c.value,
 					style: V({
 						padding: "8px 12px",
 						borderRadius: "8px",
 						border: "1px solid rgba(255,255,255,0.12)",
-						background: s.value ? "rgba(255,255,255,0.06)" : "rgba(33,150,243,0.16)",
+						background: c.value ? "rgba(255,255,255,0.06)" : "rgba(33,150,243,0.16)",
 						color: "rgba(255,255,255,0.92)",
-						cursor: s.value ? "wait" : "pointer",
+						cursor: c.value ? "wait" : "pointer",
 						fontSize: "12px",
 						fontWeight: "700",
 						whiteSpace: "nowrap"
 					}),
 					onClick: it
 				}, {
-					default: yt(() => [Ye(R(s.value ? "Saving..." : "Move"), 1)]),
+					default: bt(() => [Xe(R(c.value ? "Saving..." : "Move"), 1)]),
 					_: 1
 				}, 8, ["disabled", "style"])])]),
-				ct.value.length ? (j(), z("div", Tl, [
+				ct.value.length ? (j(), z("div", El, [
 					t[15] ||= N("div", { class: "mjr-section-title" }, " Workflow Nodes ", -1),
-					ft(r, {
+					pt(r, {
 						value: ct.value,
 						class: "mjr-workflow-tree",
 						"scroll-height": "180px",
@@ -8066,16 +8084,16 @@ var So = ["title"], Co = ["src"], wo = {
 							nodeLabel: { class: "mjr-workflow-tree-label" }
 						}
 					}, {
-						default: yt(({ node: e }) => [N("span", El, [
-							N("span", Dl, R(e.label), 1),
-							e.data?.type ? (j(), z("span", Ol, R(e.data.type), 1)) : F("", !0),
-							N("span", kl, "#" + R(e.data?.id), 1)
+						default: bt(({ node: e }) => [N("span", Dl, [
+							N("span", Ol, R(e.label), 1),
+							e.data?.type ? (j(), z("span", kl, R(e.data.type), 1)) : F("", !0),
+							N("span", Al, "#" + R(e.data?.id), 1)
 						])]),
 						_: 1
 					}, 8, ["value"]),
-					lt.value ? (j(), z("div", Al, " +" + R(lt.value) + " more nodes ", 1)) : F("", !0)
+					lt.value ? (j(), z("div", jl, " +" + R(lt.value) + " more nodes ", 1)) : F("", !0)
 				])) : F("", !0),
-				N("div", jl, [N("div", Ml, [(j(!0), z(M, null, P(L(i), (e) => (j(), Xe(n, {
+				N("div", Ml, [N("div", Nl, [(j(!0), z(M, null, P(L(i), (e) => (j(), Ze(n, {
 					key: e.key,
 					type: "button",
 					severity: "secondary",
@@ -8084,24 +8102,24 @@ var So = ["title"], Co = ["src"], wo = {
 					title: `${e.label} minimap`,
 					style: V({
 						appearance: "none",
-						border: y.value.size === e.key ? "1px solid rgba(33,150,243,0.55)" : "1px solid rgba(255,255,255,0.12)",
+						border: b.value.size === e.key ? "1px solid rgba(33,150,243,0.55)" : "1px solid rgba(255,255,255,0.12)",
 						borderRadius: "999px",
 						padding: "4px 10px",
-						background: y.value.size === e.key ? "rgba(33,150,243,0.18)" : "rgba(255,255,255,0.04)",
-						color: y.value.size === e.key ? "#90CAF9" : "rgba(255,255,255,0.78)",
+						background: b.value.size === e.key ? "rgba(33,150,243,0.18)" : "rgba(255,255,255,0.04)",
+						color: b.value.size === e.key ? "#90CAF9" : "rgba(255,255,255,0.78)",
 						fontSize: "11px",
-						fontWeight: y.value.size === e.key ? "700" : "600",
+						fontWeight: b.value.size === e.key ? "700" : "600",
 						cursor: "pointer"
 					}),
 					onClick: (t) => At(e.key)
 				}, {
-					default: yt(() => [Ye(R(e.label), 1)]),
+					default: bt(() => [Xe(R(e.label), 1)]),
 					_: 2
 				}, 1032, [
 					"title",
 					"style",
 					"onClick"
-				]))), 128))]), ft(n, {
+				]))), 128))]), pt(n, {
 					type: "button",
 					class: "mjr-btn mjr-icon-btn",
 					severity: "secondary",
@@ -8122,10 +8140,10 @@ var So = ["title"], Co = ["src"], wo = {
 					},
 					onClick: t[1] ||= (e) => _.value = !_.value
 				}, {
-					default: yt(() => [...t[16] ||= [N("i", { class: "pi pi-sliders-h" }, null, -1)]]),
+					default: bt(() => [...t[16] ||= [N("i", { class: "pi pi-sliders-h" }, null, -1)]]),
 					_: 1
 				}, 8, ["title"])]),
-				_.value ? (j(), z("div", Nl, [(j(!0), z(M, null, P(ht.value, (e) => (j(), Xe(n, {
+				_.value ? (j(), z("div", Pl, [(j(!0), z(M, null, P(mt.value, (e) => (j(), Ze(n, {
 					key: e.key,
 					type: "button",
 					severity: "secondary",
@@ -8136,15 +8154,15 @@ var So = ["title"], Co = ["src"], wo = {
 						gap: "10px",
 						padding: "9px 10px",
 						borderRadius: "10px",
-						border: y.value?.[e.key] ? "1px solid rgba(76,175,80,0.40)" : "1px solid rgba(255,255,255,0.12)",
-						background: y.value?.[e.key] ? "rgba(76,175,80,0.10)" : "rgba(255,255,255,0.04)",
+						border: b.value?.[e.key] ? "1px solid rgba(76,175,80,0.40)" : "1px solid rgba(255,255,255,0.12)",
+						background: b.value?.[e.key] ? "rgba(76,175,80,0.10)" : "rgba(255,255,255,0.04)",
 						cursor: "pointer",
 						color: "rgba(255,255,255,0.92)",
 						textAlign: "left"
 					}),
 					onClick: (t) => kt(e.key)
 				}, {
-					default: yt(() => [
+					default: bt(() => [
 						N("span", { style: V({
 							width: "22px",
 							height: "22px",
@@ -8152,35 +8170,35 @@ var So = ["title"], Co = ["src"], wo = {
 							display: "inline-flex",
 							alignItems: "center",
 							justifyContent: "center",
-							background: y.value?.[e.key] ? "rgba(76,175,80,0.95)" : "rgba(255,255,255,0.08)",
-							border: y.value?.[e.key] ? "1px solid rgba(76,175,80,0.35)" : "1px solid rgba(255,255,255,0.12)",
+							background: b.value?.[e.key] ? "rgba(76,175,80,0.95)" : "rgba(255,255,255,0.08)",
+							border: b.value?.[e.key] ? "1px solid rgba(76,175,80,0.35)" : "1px solid rgba(255,255,255,0.12)",
 							flex: "0 0 auto"
 						}) }, [N("i", {
 							class: "pi pi-check",
 							style: V({
 								fontSize: "12px",
-								opacity: y.value?.[e.key] ? "1" : "0"
+								opacity: b.value?.[e.key] ? "1" : "0"
 							})
 						}, null, 4)], 4),
 						N("i", {
-							class: mt(e.iconClass),
+							class: ht(e.iconClass),
 							style: {
 								"font-size": "18px",
 								opacity: "0.9",
 								width: "18px"
 							}
 						}, null, 2),
-						N("div", Pl, [N("div", Fl, R(e.label), 1), N("div", Il, R(y.value?.[e.key] ? "On" : "Off"), 1)])
+						N("div", Fl, [N("div", Il, R(e.label), 1), N("div", Ll, R(b.value?.[e.key] ? "On" : "Off"), 1)])
 					]),
 					_: 2
 				}, 1032, ["style", "onClick"]))), 128))])) : F("", !0),
-				N("div", Ll, [N("canvas", {
+				N("div", Rl, [N("canvas", {
 					ref_key: "canvasRef",
 					ref: a,
 					style: V({
 						width: "100%",
-						height: pt.value,
-						cursor: S.value,
+						height: ft.value,
+						cursor: C.value,
 						touchAction: "none",
 						borderRadius: "10px",
 						marginTop: "0",
@@ -8190,13 +8208,13 @@ var So = ["title"], Co = ["src"], wo = {
 					}),
 					onPointerdown: Ct,
 					onPointermove: wt,
-					onPointerup: Et,
-					onPointercancel: Et,
-					onPointerleave: Et,
+					onPointerup: Tt,
+					onPointercancel: Tt,
+					onPointerleave: Tt,
 					onWheel: Dt,
 					onDblclick: Ot
 				}, null, 36)]),
-				N("div", Rl, [N("span", null, R(ee.value || "Click/drag to navigate | wheel to zoom"), 1), N("span", null, R(Math.round((b.value.zoom || 1) * 100)) + "% | " + R(dt.value.label), 1)]),
+				N("div", zl, [N("span", null, R(ee.value || "Click/drag to navigate | wheel to zoom"), 1), N("span", null, R(Math.round((S.value.zoom || 1) * 100)) + "% | " + R(dt.value.label), 1)]),
 				N("details", {
 					open: v.value,
 					style: { "margin-top": "10px" },
@@ -8206,10 +8224,10 @@ var So = ["title"], Co = ["src"], wo = {
 					color: "var(--mjr-muted, rgba(255,255,255,0.65))",
 					"font-size": "12px",
 					"user-select": "none"
-				} }, " Show raw JSON ", -1), N("pre", Bl, R(He.value), 1)], 40, zl)
+				} }, " Show raw JSON ", -1), N("pre", Vl, R(He.value), 1)], 40, Bl)
 			])) : F("", !0);
 		};
 	}
 };
 //#endregion
-export { G as $, ci as A, Ar as B, Fi as C, Si as D, Mi as E, Kr as F, Er as G, Y as H, Nr as I, gr as J, Or as K, jr as L, oi as M, yi as N, Ci as O, Jr as P, Ut as Q, Mr as R, Ii as S, Ni as T, Cr as U, Dr as V, wr as W, an as X, hr as Y, K as Z, ea as _, Oa as a, Vi as b, Ea as c, xa as d, Sa as f, X as g, da as h, Fa as i, bi as j, si as k, Ta as l, fa as m, kc as n, ka as o, pa as p, Sr as q, xo as r, wa as s, Wl as t, ga as u, ua as v, ji as w, Wi as x, Ui as y, xr as z };
+export { G as $, li as A, jr as B, Ii as C, Ci as D, Ni as E, qr as F, Dr as G, Y as H, Pr as I, _r as J, kr as K, Mr as L, si as M, bi as N, wi as O, Yr as P, Wt as Q, Nr as R, Li as S, Pi as T, wr as U, Or as V, Tr as W, on as X, gr as Y, K as Z, ta as _, ka as a, Hi as b, Da as c, Sa as d, Ca as f, X as g, fa as h, Ia as i, xi as j, ci as k, Ea as l, pa as m, Ac as n, Aa as o, ma as p, Cr as q, So as r, Ta as s, Gl as t, _a as u, da as v, Mi as w, Gi as x, Wi as y, Sr as z };

--- a/dist/chunks/TagsEditor-xxM6vyn1.js
+++ b/dist/chunks/TagsEditor-xxM6vyn1.js
@@ -1,7 +1,7 @@
-import { F as e, Xt as t, v as n } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { St as r, m as i, n as a } from "./events-CwzwyUFJ.js";
-import { Y as o } from "./Viewer--Cuhs0TQ.js";
-import { A as s, B as c, C as l, E as u, G as d, H as f, I as ee, J as te, L as p, R as ne, T as m, W as h, b as g, ct as _, dt as v, j as y, k as b, lt as x, nt as S, q as C } from "./mjr-primevue-n1rsQYJg.js";
+import { F as e, Zt as t, v as n } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { St as r, m as i, n as a } from "./events-C2U9lj7y.js";
+import { Y as o } from "./Viewer-pHo9CcXS.js";
+import { A as s, B as c, C as l, E as u, G as d, H as f, I as ee, J as te, L as p, R as ne, T as m, W as h, b as g, ct as _, dt as v, j as y, k as b, lt as x, nt as S, q as C } from "./mjr-primevue-BOCpq3qH.js";
 //#region ui/vue/components/common/TagsEditor.vue
 var w = ["aria-busy"], T = ["aria-label"], re = {
 	key: 0,

--- a/dist/chunks/Viewer-pHo9CcXS.js
+++ b/dist/chunks/Viewer-pHo9CcXS.js
@@ -1,9 +1,9 @@
-import { H as e, P as t, Xt as n, _ as r, _t as i, c as a, d as o, g as s, ht as c, n as l, o as u, r as d, s as f, x as p, y as m } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { Ct as h, D as g, a as _, ct as v, h as y, i as b, j as x, k as S, m as C, n as w, o as T, pt as E, r as D, rt as O, t as k } from "./events-CwzwyUFJ.js";
-import { T as A, nt as j, tt as M } from "./mjr-primevue-n1rsQYJg.js";
-import { n as N, r as ee } from "./mjr-vue-vendor-D2GeV7Qd.js";
+import { H as e, P as t, Zt as n, _ as r, _t as i, c as a, d as o, g as s, ht as c, n as l, o as u, r as d, s as f, x as p, y as m } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { Ct as h, D as g, a as _, ct as v, h as y, i as b, j as x, k as S, m as C, n as w, o as T, pt as E, r as D, rt as O, t as k } from "./events-C2U9lj7y.js";
+import { T as A, nt as j, tt as M } from "./mjr-primevue-BOCpq3qH.js";
+import { n as N, r as ee } from "./mjr-vue-vendor-B7WqP-K6.js";
 import { n as P, r as te, t as F } from "./state-DPiaUMw1.js";
-import { a as ne, c as re, i as ie, o as ae, r as oe, s as se } from "./model3dRenderer-Bzlr-goo.js";
+import { a as ne, c as re, i as ie, o as ae, r as oe, s as se } from "./model3dRenderer-C365Y-Y-.js";
 //#region ui/utils/events.ts
 function ce(e, t, { target: n = null, warnPrefix: r = "[Majoor]" } = {}) {
 	let i = n || (typeof window < "u" ? window : null);
@@ -9703,9 +9703,9 @@ function Hr({ state: e, buildAssetViewURL: t, onNavigate: n, onCompare: r }) {
 //#region ui/features/viewer/viewerOverlayDismiss.ts
 function Ur({ overlay: e, requestClose: t }) {
 	try {
-		let n = null;
+		let t = null;
 		e.addEventListener("pointerdown", (e) => {
-			e.isPrimary !== !1 && (n = {
+			e.isPrimary !== !1 && (t = {
 				x: e.clientX,
 				y: e.clientY,
 				t: Date.now()
@@ -9716,13 +9716,12 @@ function Ur({ overlay: e, requestClose: t }) {
 		}), e.addEventListener("click", (e) => {
 			try {
 				if (e.defaultPrevented || e.button !== 0) return;
-				if (n) {
-					let t = e.clientX - n.x, r = e.clientY - n.y;
-					if (Math.hypot(t, r) > 6 || Date.now() - n.t > 600) return;
+				if (t) {
+					let n = e.clientX - t.x, r = e.clientY - t.y;
+					if (Math.hypot(n, r) > 6 || Date.now() - t.t > 600) return;
 				}
-				let r = e.target;
-				if (dt(r, ".mjr-viewer-header") || dt(r, ".mjr-viewer-footer") || dt(r, ".mjr-viewer-geninfo") || dt(r, ".mjr-video-controls") || dt(r, ".mjr-context-menu") || dt(r, ".mjr-ab-slider") || dt(r, ".mjr-viewer-loupe") || dt(r, ".mjr-viewer-probe") || dt(r, ".mjr-viewer-media") || r && (r.tagName === "IMG" || r.tagName === "VIDEO" || r.tagName === "CANVAS")) return;
-				t?.();
+				let n = e.target;
+				if (dt(n, ".mjr-viewer-header") || dt(n, ".mjr-viewer-footer") || dt(n, ".mjr-viewer-geninfo") || dt(n, ".mjr-video-controls") || dt(n, ".mjr-context-menu") || dt(n, ".mjr-ab-slider") || dt(n, ".mjr-viewer-loupe") || dt(n, ".mjr-viewer-probe") || dt(n, ".mjr-viewer-media") || n && (n.tagName === "IMG" || n.tagName === "VIDEO" || n.tagName === "CANVAS")) return;
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -9737,13 +9736,13 @@ var Wr = null, Gr = null, Kr = null, qr = null, Jr = null, Yr = null;
 function Xr() {
 	Wr || import("./abCompare-BXOoRlmV.js").then((e) => {
 		Wr = e;
-	}), Gr || import("./sideBySide-BcWJTMio.js").then((e) => {
+	}), Gr || import("./sideBySide-CEWLgiuN.js").then((e) => {
 		Gr = e;
-	}), Kr || import("./model3dRenderer-Bzlr-goo.js").then((e) => e.t).then((e) => {
+	}), Kr || import("./model3dRenderer-C365Y-Y-.js").then((e) => e.t).then((e) => {
 		Kr = e;
 	}), qr || import("./scopes-X1iFrTle.js").then((e) => {
 		qr = e;
-	}), Jr || import("./genInfo-fRSdoinb.js").then((e) => e.n).then((e) => {
+	}), Jr || import("./genInfo-DZ6soYaj.js").then((e) => e.n).then((e) => {
 		Jr = e;
 	}), Yr || import("./frameExport-tksSZ7sb.js").then((e) => {
 		Yr = e;

--- a/dist/chunks/ViewerPortal-dpNifhYe.js
+++ b/dist/chunks/ViewerPortal-dpNifhYe.js
@@ -1,9 +1,9 @@
-import { a as e, i as t } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { r as n } from "./events-CwzwyUFJ.js";
-import { a as r, c as i, i as a, l as o, o as s, s as c, t as l, u } from "./Viewer--Cuhs0TQ.js";
-import { i as d, r as f } from "./floatingViewerManager-CGdpmtv-.js";
-import { B as p, C as m, D as h, E as g, G as _, H as v, I as y, O as b, R as x, T as S, W as C, ct as w, dt as T, j as E, k as D, lt as O, nt as k, q as A, ut as j, w as M, z as N } from "./mjr-primevue-n1rsQYJg.js";
-import { t as P } from "./TagsEditor-Ba8mdFJF.js";
+import { a as e, i as t } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { r as n } from "./events-C2U9lj7y.js";
+import { a as r, c as i, i as a, l as o, o as s, s as c, t as l, u } from "./Viewer-pHo9CcXS.js";
+import { i as d, r as f } from "./floatingViewerManager-C0fDYFQu.js";
+import { B as p, C as m, D as h, E as g, G as _, H as v, I as y, O as b, R as x, T as S, W as C, ct as w, dt as T, j as E, k as D, lt as O, nt as k, q as A, ut as j, w as M, z as N } from "./mjr-primevue-BOCpq3qH.js";
+import { t as P } from "./TagsEditor-xxM6vyn1.js";
 //#region ui/vue/components/viewer/FloatingViewerHost.vue
 var F = {
 	__name: "FloatingViewerHost",

--- a/dist/chunks/events-C2U9lj7y.js
+++ b/dist/chunks/events-C2U9lj7y.js
@@ -118,6 +118,7 @@ var m = 200, h = 0, g = {
 	SETTINGS_STARTUP_LOGGING: "/mjr/am/settings/startup-logging",
 	SETTINGS_LTXAV_RGB_FALLBACK: "/mjr/am/settings/ltxav-rgb-fallback",
 	SETTINGS_JXL: "/mjr/am/settings/jxl",
+	SETTINGS_BROWSER_SHOW_FOLDERS: "/mjr/am/settings/browser-show-folders",
 	VIEW: "/view",
 	CUSTOM_VIEW: "/mjr/am/custom-view",
 	VIEWER_INFO: "/mjr/am/viewer/info",

--- a/dist/chunks/floatingViewerManager-C0fDYFQu.js
+++ b/dist/chunks/floatingViewerManager-C0fDYFQu.js
@@ -1,6 +1,6 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { _ as t, d as n, o as r, s as i, t as a } from "./viewerRuntimeHosts-B0n5DSKG.js";
-import { o, r as s, z as c } from "./events-CwzwyUFJ.js";
+import { _ as t, d as n, o as r, s as i, t as a } from "./viewerRuntimeHosts-P4vwR-ik.js";
+import { o, r as s, z as c } from "./events-C2U9lj7y.js";
 //#region ui/features/panel/panelRuntimeRefs.ts
 var l = null;
 function u(e) {
@@ -98,7 +98,7 @@ var ie = /* @__PURE__ */ e({
 	teardownFloatingViewerManager: () => $
 }), h = null, g = null;
 async function ae() {
-	return h || (g ||= import("./FloatingViewer-D8ClOZbL.js").then((e) => (h = e.FloatingViewer, h)), g);
+	return h || (g ||= import("./FloatingViewer-caILYx57.js").then((e) => (h = e.FloatingViewer, h)), g);
 }
 var _ = null, oe = null;
 async function se() {

--- a/dist/chunks/genInfo-DZ6soYaj.js
+++ b/dist/chunks/genInfo-DZ6soYaj.js
@@ -1,8 +1,8 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { m as t, o as n } from "./events-CwzwyUFJ.js";
-import { h as r } from "./Viewer--Cuhs0TQ.js";
-import { i, n as a, r as o, t as s, u as c } from "./SidebarWorkflowSection-B_0hBSuQ.js";
-import { B as l, D as u, E as d, O as f, T as p, ct as m, dt as h, k as g, ut as _ } from "./mjr-primevue-n1rsQYJg.js";
+import { m as t, o as n } from "./events-C2U9lj7y.js";
+import { h as r } from "./Viewer-pHo9CcXS.js";
+import { i, n as a, r as o, t as s, u as c } from "./SidebarWorkflowSection-2pSEjXh9.js";
+import { B as l, D as u, E as d, O as f, T as p, ct as m, dt as h, k as g, ut as _ } from "./mjr-primevue-BOCpq3qH.js";
 //#region ui/vue/components/viewer/ViewerMetadataBlock.vue
 var v = { style: {
 	display: "flex",

--- a/dist/chunks/mjr-primevue-BOCpq3qH.js
+++ b/dist/chunks/mjr-primevue-BOCpq3qH.js
@@ -1,5 +1,5 @@
 //#region node_modules/@vue/shared/dist/shared.esm-bundler.js
-/* @__NO_SIDE_EFFECTS__ */
+// @__NO_SIDE_EFFECTS__
 function e(e) {
 	let t = /* @__PURE__ */ Object.create(null);
 	for (let n of e.split(",")) t[n] = 1;
@@ -393,13 +393,13 @@ function st(e, t) {
 }
 function ct(e) {
 	let t = /* @__PURE__ */ j(e);
-	return t === e ? t : (at(t, "iterate", it), /* @__PURE__ */ Jt(e) ? t : t.map(Zt));
+	return t === e ? t : (at(t, "iterate", it), /* @__PURE__ */ qt(e) ? t : t.map(Xt));
 }
 function lt(e) {
 	return at(e = /* @__PURE__ */ j(e), "iterate", it), e;
 }
 function ut(e, t) {
-	return /* @__PURE__ */ qt(e) ? Qt(/* @__PURE__ */ Kt(e) ? Zt(t) : t) : Zt(t);
+	return /* @__PURE__ */ Kt(e) ? Zt(/* @__PURE__ */ Gt(e) ? Xt(t) : t) : Xt(t);
 }
 var dt = {
 	__proto__: null,
@@ -487,17 +487,17 @@ var dt = {
 };
 function ft(e, t, n) {
 	let r = lt(e), i = r[t]();
-	return r !== e && !/* @__PURE__ */ Jt(e) && (i._next = i.next, i.next = () => {
+	return r !== e && !/* @__PURE__ */ qt(e) && (i._next = i.next, i.next = () => {
 		let e = i._next();
 		return e.done || (e.value = n(e.value)), e;
 	}), i;
 }
 var pt = Array.prototype;
 function mt(e, t, n, r, i, a) {
-	let o = lt(e), s = o !== e && !/* @__PURE__ */ Jt(e), c = o[t];
+	let o = lt(e), s = o !== e && !/* @__PURE__ */ qt(e), c = o[t];
 	if (c !== pt[t]) {
 		let t = c.apply(e, a);
-		return s ? Zt(t) : t;
+		return s ? Xt(t) : t;
 	}
 	let l = n;
 	o !== e && (s ? l = function(t, r) {
@@ -509,7 +509,7 @@ function mt(e, t, n, r, i, a) {
 	return s && i ? i(u) : u;
 }
 function ht(e, t, n, r) {
-	let i = lt(e), a = i !== e && !/* @__PURE__ */ Jt(e), o = n, s = !1;
+	let i = lt(e), a = i !== e && !/* @__PURE__ */ qt(e), o = n, s = !1;
 	i !== e && (a ? (s = r.length === 0, o = function(t, r, i) {
 		return s && (s = !1, t = ut(e, t)), n.call(this, t, ut(e, r), i, e);
 	}) : n.length > 3 && (o = function(t, r, i) {
@@ -522,7 +522,7 @@ function gt(e, t, n) {
 	let r = /* @__PURE__ */ j(e);
 	at(r, "iterate", it);
 	let i = r[t](...n);
-	return (i === -1 || i === !1) && /* @__PURE__ */ Yt(n[0]) ? (n[0] = /* @__PURE__ */ j(n[0]), r[t](...n)) : i;
+	return (i === -1 || i === !1) && /* @__PURE__ */ Jt(n[0]) ? (n[0] = /* @__PURE__ */ j(n[0]), r[t](...n)) : i;
 }
 function _t(e, t, n = []) {
 	Je(), Re();
@@ -556,9 +556,9 @@ var xt = class {
 		if ((_(t) ? yt.has(t) : vt(t)) || (r || at(e, "get", t), i)) return o;
 		if (/* @__PURE__ */ M(o)) {
 			let e = a && w(t) ? o : o.value;
-			return r && v(e) ? /* @__PURE__ */ Wt(e) : e;
+			return r && v(e) ? /* @__PURE__ */ Ut(e) : e;
 		}
-		return v(o) ? r ? /* @__PURE__ */ Wt(o) : /* @__PURE__ */ Ht(o) : o;
+		return v(o) ? r ? /* @__PURE__ */ Ut(o) : /* @__PURE__ */ Vt(o) : o;
 	}
 }, St = class extends xt {
 	constructor(e = !1) {
@@ -567,8 +567,8 @@ var xt = class {
 	set(e, t, n, r) {
 		let i = e[t], a = d(e) && w(t);
 		if (!this._isShallow) {
-			let e = /* @__PURE__ */ qt(i);
-			if (!/* @__PURE__ */ Jt(n) && !/* @__PURE__ */ qt(n) && (i = /* @__PURE__ */ j(i), n = /* @__PURE__ */ j(n)), !a && /* @__PURE__ */ M(i) && !/* @__PURE__ */ M(n)) return e || (i.value = n), !0;
+			let e = /* @__PURE__ */ Kt(i);
+			if (!/* @__PURE__ */ qt(n) && !/* @__PURE__ */ Kt(n) && (i = /* @__PURE__ */ j(i), n = /* @__PURE__ */ j(n)), !a && /* @__PURE__ */ M(i) && !/* @__PURE__ */ M(n)) return e || (i.value = n), !0;
 		}
 		let o = a ? Number(t) < e.length : u(e, t), s = Reflect.set(e, t, n, /* @__PURE__ */ M(e) ? e : r);
 		return e === /* @__PURE__ */ j(r) && (o ? oe(n, i) && ot(e, "set", t, n, i) : ot(e, "add", t, n)), s;
@@ -597,7 +597,7 @@ var xt = class {
 }, wt = /* @__PURE__ */ new St(), Tt = /* @__PURE__ */ new Ct(), Et = /* @__PURE__ */ new St(!0), Dt = (e) => e, Ot = (e) => Reflect.getPrototypeOf(e);
 function kt(e, t, n) {
 	return function(...r) {
-		let i = this.__v_raw, a = /* @__PURE__ */ j(i), o = f(a), c = e === "entries" || e === Symbol.iterator && o, l = e === "keys" && o, u = i[e](...r), d = n ? Dt : t ? Qt : Zt;
+		let i = this.__v_raw, a = /* @__PURE__ */ j(i), o = f(a), c = e === "entries" || e === Symbol.iterator && o, l = e === "keys" && o, u = i[e](...r), d = n ? Dt : t ? Zt : Xt;
 		return !t && at(a, "iterate", l ? rt : nt), s(Object.create(u), { next() {
 			let { value: e, done: t } = u.next();
 			return t ? {
@@ -620,7 +620,7 @@ function jt(e, t) {
 		get(n) {
 			let r = this.__v_raw, i = /* @__PURE__ */ j(r), a = /* @__PURE__ */ j(n);
 			e || (oe(n, a) && at(i, "get", n), at(i, "get", a));
-			let { has: o } = Ot(i), s = t ? Dt : e ? Qt : Zt;
+			let { has: o } = Ot(i), s = t ? Dt : e ? Zt : Xt;
 			if (o.call(i, n)) return s(r.get(n));
 			if (o.call(i, a)) return s(r.get(a));
 			r !== i && r.get(n);
@@ -634,7 +634,7 @@ function jt(e, t) {
 			return e || (oe(t, i) && at(r, "has", t), at(r, "has", i)), t === i ? n.has(t) : n.has(t) || n.has(i);
 		},
 		forEach(n, r) {
-			let i = this, a = i.__v_raw, o = /* @__PURE__ */ j(a), s = t ? Dt : e ? Qt : Zt;
+			let i = this, a = i.__v_raw, o = /* @__PURE__ */ j(a), s = t ? Dt : e ? Zt : Xt;
 			return !e && at(o, "iterate", nt), a.forEach((e, t) => n.call(r, s(e), s(t), i));
 		}
 	};
@@ -645,11 +645,11 @@ function jt(e, t) {
 		clear: At("clear")
 	} : {
 		add(e) {
-			let n = /* @__PURE__ */ j(this), r = Ot(n), i = /* @__PURE__ */ j(e), a = !t && !/* @__PURE__ */ Jt(e) && !/* @__PURE__ */ qt(e) ? i : e;
+			let n = /* @__PURE__ */ j(this), r = Ot(n), i = /* @__PURE__ */ j(e), a = !t && !/* @__PURE__ */ qt(e) && !/* @__PURE__ */ Kt(e) ? i : e;
 			return r.has.call(n, a) || oe(e, a) && r.has.call(n, e) || oe(i, a) && r.has.call(n, i) || (n.add(a), ot(n, "add", a, a)), this;
 		},
 		set(e, n) {
-			!t && !/* @__PURE__ */ Jt(n) && !/* @__PURE__ */ qt(n) && (n = /* @__PURE__ */ j(n));
+			!t && !/* @__PURE__ */ qt(n) && !/* @__PURE__ */ Kt(n) && (n = /* @__PURE__ */ j(n));
 			let r = /* @__PURE__ */ j(this), { has: i, get: a } = Ot(r), o = i.call(r, e);
 			o ||= (e = /* @__PURE__ */ j(e), i.call(r, e));
 			let s = a.call(r, e);
@@ -690,116 +690,113 @@ function Bt(e) {
 		default: return 0;
 	}
 }
+// @__NO_SIDE_EFFECTS__
 function Vt(e) {
-	return e.__v_skip || !Object.isExtensible(e) ? 0 : Bt(S(e));
+	return /* @__PURE__ */ Kt(e) ? e : Wt(e, !1, wt, Nt, It);
 }
-/* @__NO_SIDE_EFFECTS__ */
+// @__NO_SIDE_EFFECTS__
 function Ht(e) {
-	return /* @__PURE__ */ qt(e) ? e : Gt(e, !1, wt, Nt, It);
+	return Wt(e, !1, Et, Pt, Lt);
 }
-/* @__NO_SIDE_EFFECTS__ */
+// @__NO_SIDE_EFFECTS__
 function Ut(e) {
-	return Gt(e, !1, Et, Pt, Lt);
+	return Wt(e, !0, Tt, Ft, Rt);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function Wt(e) {
-	return Gt(e, !0, Tt, Ft, Rt);
-}
-function Gt(e, t, n, r, i) {
-	if (!v(e) || e.__v_raw && !(t && e.__v_isReactive)) return e;
-	let a = Vt(e);
-	if (a === 0) return e;
-	let o = i.get(e);
-	if (o) return o;
-	let s = new Proxy(e, a === 2 ? r : n);
+function Wt(e, t, n, r, i) {
+	if (!v(e) || e.__v_raw && !(t && e.__v_isReactive) || e.__v_skip || !Object.isExtensible(e)) return e;
+	let a = i.get(e);
+	if (a) return a;
+	let o = Bt(S(e));
+	if (o === 0) return e;
+	let s = new Proxy(e, o === 2 ? r : n);
 	return i.set(e, s), s;
 }
-/* @__NO_SIDE_EFFECTS__ */
-function Kt(e) {
-	return /* @__PURE__ */ qt(e) ? /* @__PURE__ */ Kt(e.__v_raw) : !!(e && e.__v_isReactive);
+// @__NO_SIDE_EFFECTS__
+function Gt(e) {
+	return /* @__PURE__ */ Kt(e) ? /* @__PURE__ */ Gt(e.__v_raw) : !!(e && e.__v_isReactive);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function qt(e) {
+// @__NO_SIDE_EFFECTS__
+function Kt(e) {
 	return !!(e && e.__v_isReadonly);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function Jt(e) {
+// @__NO_SIDE_EFFECTS__
+function qt(e) {
 	return !!(e && e.__v_isShallow);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function Yt(e) {
+// @__NO_SIDE_EFFECTS__
+function Jt(e) {
 	return e ? !!e.__v_raw : !1;
 }
-/* @__NO_SIDE_EFFECTS__ */
+// @__NO_SIDE_EFFECTS__
 function j(e) {
 	let t = e && e.__v_raw;
 	return t ? /* @__PURE__ */ j(t) : e;
 }
-function Xt(e) {
+function Yt(e) {
 	return !u(e, "__v_skip") && Object.isExtensible(e) && ce(e, "__v_skip", !0), e;
 }
-var Zt = (e) => v(e) ? /* @__PURE__ */ Ht(e) : e, Qt = (e) => v(e) ? /* @__PURE__ */ Wt(e) : e;
-/* @__NO_SIDE_EFFECTS__ */
+var Xt = (e) => v(e) ? /* @__PURE__ */ Vt(e) : e, Zt = (e) => v(e) ? /* @__PURE__ */ Ut(e) : e;
+// @__NO_SIDE_EFFECTS__
 function M(e) {
 	return e ? e.__v_isRef === !0 : !1;
 }
-/* @__NO_SIDE_EFFECTS__ */
+// @__NO_SIDE_EFFECTS__
+function Qt(e) {
+	return en(e, !1);
+}
+// @__NO_SIDE_EFFECTS__
 function $t(e) {
-	return tn(e, !1);
+	return en(e, !0);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function en(e) {
-	return tn(e, !0);
+function en(e, t) {
+	return /* @__PURE__ */ M(e) ? e : new tn(e, t);
 }
-function tn(e, t) {
-	return /* @__PURE__ */ M(e) ? e : new nn(e, t);
-}
-var nn = class {
+var tn = class {
 	constructor(e, t) {
-		this.dep = new $e(), this.__v_isRef = !0, this.__v_isShallow = !1, this._rawValue = t ? e : /* @__PURE__ */ j(e), this._value = t ? e : Zt(e), this.__v_isShallow = t;
+		this.dep = new $e(), this.__v_isRef = !0, this.__v_isShallow = !1, this._rawValue = t ? e : /* @__PURE__ */ j(e), this._value = t ? e : Xt(e), this.__v_isShallow = t;
 	}
 	get value() {
 		return this.dep.track(), this._value;
 	}
 	set value(e) {
-		let t = this._rawValue, n = this.__v_isShallow || /* @__PURE__ */ Jt(e) || /* @__PURE__ */ qt(e);
-		e = n ? e : /* @__PURE__ */ j(e), oe(e, t) && (this._rawValue = e, this._value = n ? e : Zt(e), this.dep.trigger());
+		let t = this._rawValue, n = this.__v_isShallow || /* @__PURE__ */ qt(e) || /* @__PURE__ */ Kt(e);
+		e = n ? e : /* @__PURE__ */ j(e), oe(e, t) && (this._rawValue = e, this._value = n ? e : Xt(e), this.dep.trigger());
 	}
 };
-function rn(e) {
+function nn(e) {
 	e.dep && e.dep.trigger();
 }
-function an(e) {
+function rn(e) {
 	return /* @__PURE__ */ M(e) ? e.value : e;
 }
-var on = {
-	get: (e, t, n) => t === "__v_raw" ? e : an(Reflect.get(e, t, n)),
+var an = {
+	get: (e, t, n) => t === "__v_raw" ? e : rn(Reflect.get(e, t, n)),
 	set: (e, t, n, r) => {
 		let i = e[t];
 		return /* @__PURE__ */ M(i) && !/* @__PURE__ */ M(n) ? (i.value = n, !0) : Reflect.set(e, t, n, r);
 	}
 };
-function sn(e) {
-	return /* @__PURE__ */ Kt(e) ? e : new Proxy(e, on);
+function on(e) {
+	return /* @__PURE__ */ Gt(e) ? e : new Proxy(e, an);
 }
-/* @__NO_SIDE_EFFECTS__ */
-function cn(e) {
+// @__NO_SIDE_EFFECTS__
+function sn(e) {
 	let t = d(e) ? Array(e.length) : {};
-	for (let n in e) t[n] = un(e, n);
+	for (let n in e) t[n] = ln(e, n);
 	return t;
 }
-var ln = class {
+var cn = class {
 	constructor(e, t, n) {
 		this._object = e, this._defaultValue = n, this.__v_isRef = !0, this._value = void 0, this._key = _(t) ? t : String(t), this._raw = /* @__PURE__ */ j(e);
 		let r = !0, i = e;
 		if (!d(e) || _(this._key) || !w(this._key)) do
-			r = !/* @__PURE__ */ Yt(i) || /* @__PURE__ */ Jt(i);
+			r = !/* @__PURE__ */ Jt(i) || /* @__PURE__ */ qt(i);
 		while (r && (i = i.__v_raw));
 		this._shallow = r;
 	}
 	get value() {
 		let e = this._object[this._key];
-		return this._shallow && (e = an(e)), this._value = e === void 0 ? this._defaultValue : e;
+		return this._shallow && (e = rn(e)), this._value = e === void 0 ? this._defaultValue : e;
 	}
 	set value(e) {
 		if (this._shallow && /* @__PURE__ */ M(this._raw[this._key])) {
@@ -815,10 +812,10 @@ var ln = class {
 		return st(this._raw, this._key);
 	}
 };
-function un(e, t, n) {
-	return new ln(e, t, n);
+function ln(e, t, n) {
+	return new cn(e, t, n);
 }
-var dn = class {
+var un = class {
 	constructor(e, t, n) {
 		this.fn = e, this.setter = t, this._value = void 0, this.dep = new $e(this), this.__v_isRef = !0, this.deps = void 0, this.depsTail = void 0, this.flags = 16, this.globalVersion = Ze - 1, this.next = void 0, this.effect = this, this.__v_isReadonly = !t, this.isSSR = n;
 	}
@@ -833,23 +830,23 @@ var dn = class {
 		this.setter && this.setter(e);
 	}
 };
-/* @__NO_SIDE_EFFECTS__ */
-function fn(e, t, n = !1) {
+// @__NO_SIDE_EFFECTS__
+function dn(e, t, n = !1) {
 	let r, i;
-	return h(e) ? r = e : (r = e.get, i = e.set), new dn(r, i, n);
+	return h(e) ? r = e : (r = e.get, i = e.set), new un(r, i, n);
 }
-var pn = {}, mn = /* @__PURE__ */ new WeakMap(), hn = void 0;
-function gn(e, t = !1, n = hn) {
+var fn = {}, pn = /* @__PURE__ */ new WeakMap(), mn = void 0;
+function hn(e, t = !1, n = mn) {
 	if (n) {
-		let t = mn.get(n);
-		t || mn.set(n, t = []), t.push(e);
+		let t = pn.get(n);
+		t || pn.set(n, t = []), t.push(e);
 	}
 }
-function _n(e, n, i = t) {
-	let { immediate: a, deep: o, once: s, scheduler: l, augmentJob: u, call: f } = i, p = (e) => o ? e : /* @__PURE__ */ Jt(e) || o === !1 || o === 0 ? vn(e, 1) : vn(e), m, g, _, v, y = !1, b = !1;
-	if (/* @__PURE__ */ M(e) ? (g = () => e.value, y = /* @__PURE__ */ Jt(e)) : /* @__PURE__ */ Kt(e) ? (g = () => p(e), y = !0) : d(e) ? (b = !0, y = e.some((e) => /* @__PURE__ */ Kt(e) || /* @__PURE__ */ Jt(e)), g = () => e.map((e) => {
+function gn(e, n, i = t) {
+	let { immediate: a, deep: o, once: s, scheduler: l, augmentJob: u, call: f } = i, p = (e) => o ? e : /* @__PURE__ */ qt(e) || o === !1 || o === 0 ? _n(e, 1) : _n(e), m, g, _, v, y = !1, b = !1;
+	if (/* @__PURE__ */ M(e) ? (g = () => e.value, y = /* @__PURE__ */ qt(e)) : /* @__PURE__ */ Gt(e) ? (g = () => p(e), y = !0) : d(e) ? (b = !0, y = e.some((e) => /* @__PURE__ */ Gt(e) || /* @__PURE__ */ qt(e)), g = () => e.map((e) => {
 		if (/* @__PURE__ */ M(e)) return e.value;
-		if (/* @__PURE__ */ Kt(e)) return p(e);
+		if (/* @__PURE__ */ Gt(e)) return p(e);
 		if (h(e)) return f ? f(e, 2) : e();
 	})) : g = h(e) ? n ? f ? () => f(e, 2) : e : () => {
 		if (_) {
@@ -860,16 +857,16 @@ function _n(e, n, i = t) {
 				Ye();
 			}
 		}
-		let t = hn;
-		hn = m;
+		let t = mn;
+		mn = m;
 		try {
 			return f ? f(e, 3, [v]) : e(v);
 		} finally {
-			hn = t;
+			mn = t;
 		}
 	} : r, n && o) {
 		let e = g, t = o === !0 ? Infinity : o;
-		g = () => vn(e(), t);
+		g = () => _n(e(), t);
 	}
 	let x = Ae(), S = () => {
 		m.stop(), x && x.active && c(x.effects, m);
@@ -880,71 +877,71 @@ function _n(e, n, i = t) {
 			e(...t), S();
 		};
 	}
-	let C = b ? Array(e.length).fill(pn) : pn, w = (e) => {
+	let C = b ? Array(e.length).fill(fn) : fn, w = (e) => {
 		if (!(!(m.flags & 1) || !m.dirty && !e)) if (n) {
 			let e = m.run();
 			if (o || y || (b ? e.some((e, t) => oe(e, C[t])) : oe(e, C))) {
 				_ && _();
-				let t = hn;
-				hn = m;
+				let t = mn;
+				mn = m;
 				try {
 					let t = [
 						e,
-						C === pn ? void 0 : b && C[0] === pn ? [] : C,
+						C === fn ? void 0 : b && C[0] === fn ? [] : C,
 						v
 					];
 					C = e, f ? f(n, 3, t) : n(...t);
 				} finally {
-					hn = t;
+					mn = t;
 				}
 			}
 		} else m.run();
 	};
-	return u && u(w), m = new Ne(g), m.scheduler = l ? () => l(w, !1) : w, v = (e) => gn(e, !1, m), _ = m.onStop = () => {
-		let e = mn.get(m);
+	return u && u(w), m = new Ne(g), m.scheduler = l ? () => l(w, !1) : w, v = (e) => hn(e, !1, m), _ = m.onStop = () => {
+		let e = pn.get(m);
 		if (e) {
 			if (f) f(e, 4);
 			else for (let t of e) t();
-			mn.delete(m);
+			pn.delete(m);
 		}
 	}, n ? a ? w(!0) : C = m.run() : l ? l(w.bind(null, !0), !0) : m.run(), S.pause = m.pause.bind(m), S.resume = m.resume.bind(m), S.stop = S, S;
 }
-function vn(e, t = Infinity, n) {
+function _n(e, t = Infinity, n) {
 	if (t <= 0 || !v(e) || e.__v_skip || (n ||= /* @__PURE__ */ new Map(), (n.get(e) || 0) >= t)) return e;
-	if (n.set(e, t), t--, /* @__PURE__ */ M(e)) vn(e.value, t, n);
-	else if (d(e)) for (let r = 0; r < e.length; r++) vn(e[r], t, n);
+	if (n.set(e, t), t--, /* @__PURE__ */ M(e)) _n(e.value, t, n);
+	else if (d(e)) for (let r = 0; r < e.length; r++) _n(e[r], t, n);
 	else if (p(e) || f(e)) e.forEach((e) => {
-		vn(e, t, n);
+		_n(e, t, n);
 	});
 	else if (C(e)) {
-		for (let r in e) vn(e[r], t, n);
-		for (let r of Object.getOwnPropertySymbols(e)) Object.prototype.propertyIsEnumerable.call(e, r) && vn(e[r], t, n);
+		for (let r in e) _n(e[r], t, n);
+		for (let r of Object.getOwnPropertySymbols(e)) Object.prototype.propertyIsEnumerable.call(e, r) && _n(e[r], t, n);
 	}
 	return e;
 }
 //#endregion
 //#region node_modules/@vue/runtime-core/dist/runtime-core.esm-bundler.js
-function yn(e, t, n, r) {
+function vn(e, t, n, r) {
 	try {
 		return r ? e(...r) : e();
 	} catch (e) {
-		xn(e, t, n);
+		bn(e, t, n);
 	}
 }
-function bn(e, t, n, r) {
+function yn(e, t, n, r) {
 	if (h(e)) {
-		let i = yn(e, t, n, r);
+		let i = vn(e, t, n, r);
 		return i && y(i) && i.catch((e) => {
-			xn(e, t, n);
+			bn(e, t, n);
 		}), i;
 	}
 	if (d(e)) {
 		let i = [];
-		for (let a = 0; a < e.length; a++) i.push(bn(e[a], t, n, r));
+		for (let a = 0; a < e.length; a++) i.push(yn(e[a], t, n, r));
 		return i;
 	}
 }
-function xn(e, n, r, i = !0) {
+function bn(e, n, r, i = !0) {
 	let a = n ? n.vnode : null, { errorHandler: o, throwUnhandledErrorInProduction: s } = n && n.appContext.config || t;
 	if (n) {
 		let t = n.parent, i = n.proxy, a = `https://vuejs.org/error-reference/#runtime-${r}`;
@@ -956,7 +953,7 @@ function xn(e, n, r, i = !0) {
 			t = t.parent;
 		}
 		if (o) {
-			Je(), yn(o, null, 10, [
+			Je(), vn(o, null, 10, [
 				e,
 				i,
 				a
@@ -964,103 +961,103 @@ function xn(e, n, r, i = !0) {
 			return;
 		}
 	}
-	Sn(e, r, a, i, s);
+	xn(e, r, a, i, s);
 }
-function Sn(e, t, n, r = !0, i = !1) {
+function xn(e, t, n, r = !0, i = !1) {
 	if (i) throw e;
 	console.error(e);
 }
-var Cn = [], wn = -1, Tn = [], En = null, Dn = 0, On = /* @__PURE__ */ Promise.resolve(), kn = null;
-function An(e) {
-	let t = kn || On;
+var Sn = [], Cn = -1, wn = [], Tn = null, En = 0, Dn = /* @__PURE__ */ Promise.resolve(), On = null;
+function kn(e) {
+	let t = On || Dn;
 	return e ? t.then(this ? e.bind(this) : e) : t;
 }
-function jn(e) {
-	let t = wn + 1, n = Cn.length;
+function An(e) {
+	let t = Cn + 1, n = Sn.length;
 	for (; t < n;) {
-		let r = t + n >>> 1, i = Cn[r], a = Ln(i);
+		let r = t + n >>> 1, i = Sn[r], a = In(i);
 		a < e || a === e && i.flags & 2 ? t = r + 1 : n = r;
 	}
 	return t;
 }
-function Mn(e) {
+function jn(e) {
 	if (!(e.flags & 1)) {
-		let t = Ln(e), n = Cn[Cn.length - 1];
-		!n || !(e.flags & 2) && t >= Ln(n) ? Cn.push(e) : Cn.splice(jn(t), 0, e), e.flags |= 1, Nn();
+		let t = In(e), n = Sn[Sn.length - 1];
+		!n || !(e.flags & 2) && t >= In(n) ? Sn.push(e) : Sn.splice(An(t), 0, e), e.flags |= 1, Mn();
 	}
 }
-function Nn() {
-	kn ||= On.then(Rn);
+function Mn() {
+	On ||= Dn.then(Ln);
 }
-function Pn(e) {
-	d(e) ? Tn.push(...e) : En && e.id === -1 ? En.splice(Dn + 1, 0, e) : e.flags & 1 || (Tn.push(e), e.flags |= 1), Nn();
+function Nn(e) {
+	d(e) ? wn.push(...e) : Tn && e.id === -1 ? Tn.splice(En + 1, 0, e) : e.flags & 1 || (wn.push(e), e.flags |= 1), Mn();
 }
-function Fn(e, t, n = wn + 1) {
-	for (; n < Cn.length; n++) {
-		let t = Cn[n];
+function Pn(e, t, n = Cn + 1) {
+	for (; n < Sn.length; n++) {
+		let t = Sn[n];
 		if (t && t.flags & 2) {
 			if (e && t.id !== e.uid) continue;
-			Cn.splice(n, 1), n--, t.flags & 4 && (t.flags &= -2), t(), t.flags & 4 || (t.flags &= -2);
+			Sn.splice(n, 1), n--, t.flags & 4 && (t.flags &= -2), t(), t.flags & 4 || (t.flags &= -2);
 		}
 	}
 }
-function In(e) {
-	if (Tn.length) {
-		let e = [...new Set(Tn)].sort((e, t) => Ln(e) - Ln(t));
-		if (Tn.length = 0, En) {
-			En.push(...e);
+function Fn(e) {
+	if (wn.length) {
+		let e = [...new Set(wn)].sort((e, t) => In(e) - In(t));
+		if (wn.length = 0, Tn) {
+			Tn.push(...e);
 			return;
 		}
-		for (En = e, Dn = 0; Dn < En.length; Dn++) {
-			let e = En[Dn];
+		for (Tn = e, En = 0; En < Tn.length; En++) {
+			let e = Tn[En];
 			e.flags & 4 && (e.flags &= -2), e.flags & 8 || e(), e.flags &= -2;
 		}
-		En = null, Dn = 0;
+		Tn = null, En = 0;
 	}
 }
-var Ln = (e) => e.id == null ? e.flags & 2 ? -1 : Infinity : e.id;
-function Rn(e) {
+var In = (e) => e.id == null ? e.flags & 2 ? -1 : Infinity : e.id;
+function Ln(e) {
 	try {
-		for (wn = 0; wn < Cn.length; wn++) {
-			let e = Cn[wn];
-			e && !(e.flags & 8) && (e.flags & 4 && (e.flags &= -2), yn(e, e.i, e.i ? 15 : 14), e.flags & 4 || (e.flags &= -2));
+		for (Cn = 0; Cn < Sn.length; Cn++) {
+			let e = Sn[Cn];
+			e && !(e.flags & 8) && (e.flags & 4 && (e.flags &= -2), vn(e, e.i, e.i ? 15 : 14), e.flags & 4 || (e.flags &= -2));
 		}
 	} finally {
-		for (; wn < Cn.length; wn++) {
-			let e = Cn[wn];
+		for (; Cn < Sn.length; Cn++) {
+			let e = Sn[Cn];
 			e && (e.flags &= -2);
 		}
-		wn = -1, Cn.length = 0, In(e), kn = null, (Cn.length || Tn.length) && Rn(e);
+		Cn = -1, Sn.length = 0, Fn(e), On = null, (Sn.length || wn.length) && Ln(e);
 	}
 }
-var N = null, zn = null;
-function Bn(e) {
+var N = null, Rn = null;
+function zn(e) {
 	let t = N;
-	return N = e, zn = e && e.type.__scopeId || null, t;
+	return N = e, Rn = e && e.type.__scopeId || null, t;
 }
 function P(e, t = N, n) {
 	if (!t || e._n) return e;
 	let r = (...n) => {
-		r._d && Na(-1);
-		let i = Bn(t), a;
+		r._d && Ma(-1);
+		let i = zn(t), a;
 		try {
 			a = e(...n);
 		} finally {
-			Bn(i), r._d && Na(1);
+			zn(i), r._d && Ma(1);
 		}
 		return a;
 	};
 	return r._n = !0, r._c = !0, r._d = !0, r;
 }
-function Vn(e, n) {
+function Bn(e, n) {
 	if (N === null) return e;
-	let r = fo(N), i = e.dirs ||= [];
+	let r = uo(N), i = e.dirs ||= [];
 	for (let e = 0; e < n.length; e++) {
 		let [a, o, s, c = t] = n[e];
 		a && (h(a) && (a = {
 			mounted: a,
 			updated: a
-		}), a.deep && vn(o), i.push({
+		}), a.deep && _n(o), i.push({
 			dir: a,
 			instance: r,
 			value: o,
@@ -1071,13 +1068,13 @@ function Vn(e, n) {
 	}
 	return e;
 }
-function Hn(e, t, n, r) {
+function Vn(e, t, n, r) {
 	let i = e.dirs, a = t && t.dirs;
 	for (let o = 0; o < i.length; o++) {
 		let s = i[o];
 		a && (s.oldValue = a[o].value);
 		let c = s.dir[r];
-		c && (Je(), bn(c, n, 8, [
+		c && (Je(), yn(c, n, 8, [
 			e.el,
 			s,
 			e,
@@ -1085,35 +1082,35 @@ function Hn(e, t, n, r) {
 		]), Ye());
 	}
 }
-function Un(e, t) {
+function Hn(e, t) {
 	if (G) {
 		let n = G.provides, r = G.parent && G.parent.provides;
 		r === n && (n = G.provides = Object.create(r)), n[e] = t;
 	}
 }
-function Wn(e, t, n = !1) {
-	let r = Xa();
-	if (r || Ii) {
-		let i = Ii ? Ii._context.provides : r ? r.parent == null || r.ce ? r.vnode.appContext && r.vnode.appContext.provides : r.parent.provides : void 0;
+function Un(e, t, n = !1) {
+	let r = Ya();
+	if (r || Fi) {
+		let i = Fi ? Fi._context.provides : r ? r.parent == null || r.ce ? r.vnode.appContext && r.vnode.appContext.provides : r.parent.provides : void 0;
 		if (i && e in i) return i[e];
 		if (arguments.length > 1) return n && h(t) ? t.call(r && r.proxy) : t;
 	}
 }
-function Gn() {
-	return !!(Xa() || Ii);
+function Wn() {
+	return !!(Ya() || Fi);
 }
-var Kn = /* @__PURE__ */ Symbol.for("v-scx"), qn = () => Wn(Kn);
-function Jn(e, t) {
-	return Xn(e, null, t);
+var Gn = /* @__PURE__ */ Symbol.for("v-scx"), Kn = () => Un(Gn);
+function qn(e, t) {
+	return Yn(e, null, t);
 }
-function Yn(e, t, n) {
-	return Xn(e, t, n);
+function Jn(e, t, n) {
+	return Yn(e, t, n);
 }
-function Xn(e, n, i = t) {
+function Yn(e, n, i = t) {
 	let { immediate: a, deep: o, flush: c, once: l } = i, u = s({}, i), d = n && a || !n && c !== "post", f;
-	if (no) {
+	if (to) {
 		if (c === "sync") {
-			let e = qn();
+			let e = Kn();
 			f = e.__watcherHandles ||= [];
 		} else if (!d) {
 			let e = () => {};
@@ -1121,25 +1118,25 @@ function Xn(e, n, i = t) {
 		}
 	}
 	let p = G;
-	u.call = (e, t, n) => bn(e, p, t, n);
+	u.call = (e, t, n) => yn(e, p, t, n);
 	let m = !1;
 	c === "post" ? u.scheduler = (e) => {
-		pa(e, p && p.suspense);
+		fa(e, p && p.suspense);
 	} : c !== "sync" && (m = !0, u.scheduler = (e, t) => {
-		t ? e() : Mn(e);
+		t ? e() : jn(e);
 	}), u.augmentJob = (e) => {
 		n && (e.flags |= 4), m && (e.flags |= 2, p && (e.id = p.uid, e.i = p));
 	};
-	let h = _n(e, n, u);
-	return no && (f ? f.push(h) : d && h()), h;
+	let h = gn(e, n, u);
+	return to && (f ? f.push(h) : d && h()), h;
 }
-function Zn(e, t, n) {
-	let r = this.proxy, i = g(e) ? e.includes(".") ? Qn(r, e) : () => r[e] : e.bind(r, r), a;
+function Xn(e, t, n) {
+	let r = this.proxy, i = g(e) ? e.includes(".") ? Zn(r, e) : () => r[e] : e.bind(r, r), a;
 	h(t) ? a = t : (a = t.handler, n = t);
-	let o = $a(this), s = Xn(i, a.bind(r), n);
+	let o = Qa(this), s = Yn(i, a.bind(r), n);
 	return o(), s;
 }
-function Qn(e, t) {
+function Zn(e, t) {
 	let n = t.split(".");
 	return () => {
 		let t = e;
@@ -1147,65 +1144,65 @@ function Qn(e, t) {
 		return t;
 	};
 }
-var $n = /* @__PURE__ */ new WeakMap(), er = /* @__PURE__ */ Symbol("_vte"), tr = (e) => e.__isTeleport, nr = (e) => e && (e.disabled || e.disabled === ""), rr = (e) => e && (e.defer || e.defer === ""), ir = (e) => typeof SVGElement < "u" && e instanceof SVGElement, ar = (e) => typeof MathMLElement == "function" && e instanceof MathMLElement, or = (e, t) => {
+var Qn = /* @__PURE__ */ new WeakMap(), $n = /* @__PURE__ */ Symbol("_vte"), er = (e) => e.__isTeleport, tr = (e) => e && (e.disabled || e.disabled === ""), nr = (e) => e && (e.defer || e.defer === ""), rr = (e) => typeof SVGElement < "u" && e instanceof SVGElement, ir = (e) => typeof MathMLElement == "function" && e instanceof MathMLElement, ar = (e, t) => {
 	let n = e && e.to;
 	return g(n) ? t ? t(n) : null : n;
-}, sr = {
+}, or = {
 	name: "Teleport",
 	__isTeleport: !0,
 	process(e, t, n, r, i, a, o, s, c, l) {
-		let { mc: u, pc: d, pbc: f, o: { insert: p, querySelector: m, createText: h, createComment: g, parentNode: _ } } = l, v = nr(t.props), { dynamicChildren: y } = t, b = (e, t, n) => {
+		let { mc: u, pc: d, pbc: f, o: { insert: p, querySelector: m, createText: h, createComment: g, parentNode: _ } } = l, v = tr(t.props), { dynamicChildren: y } = t, b = (e, t, n) => {
 			e.shapeFlag & 16 && u(e.children, t, n, i, a, o, s, c);
 		}, x = (e = t) => {
-			let n = nr(e.props), r = e.target = or(e.props, m), a = fr(r, e, h, p);
-			r && (o !== "svg" && ir(r) ? o = "svg" : o !== "mathml" && ar(r) && (o = "mathml"), i && i.isCE && (i.ce._teleportTargets || (i.ce._teleportTargets = /* @__PURE__ */ new Set())).add(r), n || (b(e, r, a), dr(e, !1)));
+			let n = tr(e.props), r = e.target = ar(e.props, m), a = dr(r, e, h, p);
+			r && (o !== "svg" && rr(r) ? o = "svg" : o !== "mathml" && ir(r) && (o = "mathml"), i && i.isCE && (i.ce._teleportTargets || (i.ce._teleportTargets = /* @__PURE__ */ new Set())).add(r), n || (b(e, r, a), ur(e, !1)));
 		}, S = (e) => {
 			let t = () => {
-				$n.get(e) === t && ($n.delete(e), nr(e.props) && (b(e, _(e.el) || n, e.anchor), dr(e, !0)), x(e));
+				Qn.get(e) === t && (Qn.delete(e), tr(e.props) && (b(e, _(e.el) || n, e.anchor), ur(e, !0)), x(e));
 			};
-			$n.set(e, t), pa(t, a);
+			Qn.set(e, t), fa(t, a);
 		};
 		if (e == null) {
 			let e = t.el = h(""), i = t.anchor = h("");
-			if (p(e, n, r), p(i, n, r), rr(t.props) || a && a.pendingBranch) {
+			if (p(e, n, r), p(i, n, r), nr(t.props) || a && a.pendingBranch) {
 				S(t);
 				return;
 			}
-			v && (b(t, n, i), dr(t, !0)), x();
+			v && (b(t, n, i), ur(t, !0)), x();
 		} else {
 			t.el = e.el;
-			let r = t.anchor = e.anchor, u = $n.get(e);
+			let r = t.anchor = e.anchor, u = Qn.get(e);
 			if (u) {
-				u.flags |= 8, $n.delete(e), S(t);
+				u.flags |= 8, Qn.delete(e), S(t);
 				return;
 			}
 			t.targetStart = e.targetStart;
-			let p = t.target = e.target, h = t.targetAnchor = e.targetAnchor, g = nr(e.props), _ = g ? n : p, b = g ? r : h;
-			if (o === "svg" || ir(p) ? o = "svg" : (o === "mathml" || ar(p)) && (o = "mathml"), y ? (f(e.dynamicChildren, y, _, i, a, o, s), ya(e, t, !0)) : c || d(e, t, _, b, i, a, o, s, !1), v) g ? t.props && e.props && t.props.to !== e.props.to && (t.props.to = e.props.to) : cr(t, n, r, l, 1);
+			let p = t.target = e.target, h = t.targetAnchor = e.targetAnchor, g = tr(e.props), _ = g ? n : p, b = g ? r : h;
+			if (o === "svg" || rr(p) ? o = "svg" : (o === "mathml" || ir(p)) && (o = "mathml"), y ? (f(e.dynamicChildren, y, _, i, a, o, s), va(e, t, !0)) : c || d(e, t, _, b, i, a, o, s, !1), v) g ? t.props && e.props && t.props.to !== e.props.to && (t.props.to = e.props.to) : sr(t, n, r, l, 1);
 			else if ((t.props && t.props.to) !== (e.props && e.props.to)) {
-				let e = t.target = or(t.props, m);
-				e && cr(t, e, null, l, 0);
-			} else g && cr(t, p, h, l, 1);
-			dr(t, v);
+				let e = t.target = ar(t.props, m);
+				e && sr(t, e, null, l, 0);
+			} else g && sr(t, p, h, l, 1);
+			ur(t, v);
 		}
 	},
 	remove(e, t, n, { um: r, o: { remove: i } }, a) {
-		let { shapeFlag: o, children: s, anchor: c, targetStart: l, targetAnchor: u, target: d, props: f } = e, p = a || !nr(f), m = $n.get(e);
-		if (m && (m.flags |= 8, $n.delete(e), p = !1), d && (i(l), i(u)), a && i(c), o & 16) for (let e = 0; e < s.length; e++) {
+		let { shapeFlag: o, children: s, anchor: c, targetStart: l, targetAnchor: u, target: d, props: f } = e, p = a || !tr(f), m = Qn.get(e);
+		if (m && (m.flags |= 8, Qn.delete(e)), d && (i(l), i(u)), a && i(c), !m && o & 16) for (let e = 0; e < s.length; e++) {
 			let i = s[e];
 			r(i, t, n, p, !!i.dynamicChildren);
 		}
 	},
-	move: cr,
-	hydrate: lr
+	move: sr,
+	hydrate: cr
 };
-function cr(e, t, n, { o: { insert: r }, m: i }, a = 2) {
+function sr(e, t, n, { o: { insert: r }, m: i }, a = 2) {
 	a === 0 && r(e.targetAnchor, t, n);
 	let { el: o, anchor: s, shapeFlag: c, children: l, props: u } = e, d = a === 2;
-	if (d && r(o, t, n), !$n.has(e) && (!d || nr(u)) && c & 16) for (let e = 0; e < l.length; e++) i(l[e], t, n, 2);
+	if (d && r(o, t, n), !Qn.has(e) && (!d || tr(u)) && c & 16) for (let e = 0; e < l.length; e++) i(l[e], t, n, 2);
 	d && r(s, t, n);
 }
-function lr(e, t, n, r, i, a, { o: { nextSibling: o, parentNode: s, querySelector: c, insert: l, createText: u } }, d) {
+function cr(e, t, n, r, i, a, { o: { nextSibling: o, parentNode: s, querySelector: c, insert: l, createText: u } }, d) {
 	function f(e, n) {
 		let r = n;
 		for (; r;) {
@@ -1222,15 +1219,15 @@ function lr(e, t, n, r, i, a, { o: { nextSibling: o, parentNode: s, querySelecto
 	function p(e, t) {
 		t.anchor = d(o(e), t, s(e), n, r, i, a);
 	}
-	let m = t.target = or(t.props, c), h = nr(t.props);
+	let m = t.target = ar(t.props, c), h = tr(t.props);
 	if (m) {
 		let c = m._lpa || m.firstChild;
-		t.shapeFlag & 16 && (h ? (p(e, t), f(m, c), t.targetAnchor || fr(m, t, u, l, s(e) === m ? e : null)) : (t.anchor = o(e), f(m, c), t.targetAnchor || fr(m, t, u, l), d(c && o(c), t, m, n, r, i, a))), dr(t, h);
+		t.shapeFlag & 16 && (h ? (p(e, t), f(m, c), t.targetAnchor || dr(m, t, u, l, s(e) === m ? e : null)) : (t.anchor = o(e), f(m, c), t.targetAnchor || dr(m, t, u, l), d(c && o(c), t, m, n, r, i, a))), ur(t, h);
 	} else h && t.shapeFlag & 16 && (p(e, t), t.targetStart = e, t.targetAnchor = o(e));
 	return t.anchor && o(t.anchor);
 }
-var ur = sr;
-function dr(e, t) {
+var lr = or;
+function ur(e, t) {
 	let n = e.ctx;
 	if (n && n.ut) {
 		let r, i;
@@ -1238,67 +1235,67 @@ function dr(e, t) {
 		n.ut();
 	}
 }
-function fr(e, t, n, r, i = null) {
+function dr(e, t, n, r, i = null) {
 	let a = t.targetStart = n(""), o = t.targetAnchor = n("");
-	return a[er] = o, e && (r(a, e, i), r(o, e, i)), o;
+	return a[$n] = o, e && (r(a, e, i), r(o, e, i)), o;
 }
-var pr = /* @__PURE__ */ Symbol("_leaveCb"), mr = /* @__PURE__ */ Symbol("_enterCb");
-function hr() {
+var fr = /* @__PURE__ */ Symbol("_leaveCb"), pr = /* @__PURE__ */ Symbol("_enterCb");
+function mr() {
 	let e = {
 		isMounted: !1,
 		isLeaving: !1,
 		isUnmounting: !1,
 		leavingVNodes: /* @__PURE__ */ new Map()
 	};
-	return Jr(() => {
+	return qr(() => {
 		e.isMounted = !0;
-	}), Zr(() => {
+	}), Xr(() => {
 		e.isUnmounting = !0;
 	}), e;
 }
-var gr = [Function, Array], _r = {
+var hr = [Function, Array], gr = {
 	mode: String,
 	appear: Boolean,
 	persisted: Boolean,
-	onBeforeEnter: gr,
-	onEnter: gr,
-	onAfterEnter: gr,
-	onEnterCancelled: gr,
-	onBeforeLeave: gr,
-	onLeave: gr,
-	onAfterLeave: gr,
-	onLeaveCancelled: gr,
-	onBeforeAppear: gr,
-	onAppear: gr,
-	onAfterAppear: gr,
-	onAppearCancelled: gr
-}, vr = (e) => {
+	onBeforeEnter: hr,
+	onEnter: hr,
+	onAfterEnter: hr,
+	onEnterCancelled: hr,
+	onBeforeLeave: hr,
+	onLeave: hr,
+	onAfterLeave: hr,
+	onLeaveCancelled: hr,
+	onBeforeAppear: hr,
+	onAppear: hr,
+	onAfterAppear: hr,
+	onAppearCancelled: hr
+}, _r = (e) => {
 	let t = e.subTree;
-	return t.component ? vr(t.component) : t;
-}, yr = {
+	return t.component ? _r(t.component) : t;
+}, vr = {
 	name: "BaseTransition",
-	props: _r,
+	props: gr,
 	setup(e, { slots: t }) {
-		let n = Xa(), r = hr();
+		let n = Ya(), r = mr();
 		return () => {
-			let i = t.default && Dr(t.default(), !0), a = i && i.length ? br(i) : n.subTree ? U() : void 0;
+			let i = t.default && Er(t.default(), !0), a = i && i.length ? yr(i) : n.subTree ? U() : void 0;
 			if (!a) return;
 			let o = /* @__PURE__ */ j(e), { mode: s } = o;
-			if (r.isLeaving) return wr(a);
-			let c = Tr(a);
-			if (!c) return wr(a);
-			let l = Cr(c, o, r, n, (e) => l = e);
-			c.type !== Da && Er(c, l);
-			let u = n.subTree && Tr(n.subTree);
-			if (u && u.type !== Da && !Ia(u, c) && vr(n).type !== Da) {
-				let e = Cr(u, o, r, n);
-				if (Er(u, e), s === "out-in" && c.type !== Da) return r.isLeaving = !0, e.afterLeave = () => {
+			if (r.isLeaving) return Cr(a);
+			let c = wr(a);
+			if (!c) return Cr(a);
+			let l = Sr(c, o, r, n, (e) => l = e);
+			c.type !== Ea && Tr(c, l);
+			let u = n.subTree && wr(n.subTree);
+			if (u && u.type !== Ea && !Fa(u, c) && _r(n).type !== Ea) {
+				let e = Sr(u, o, r, n);
+				if (Tr(u, e), s === "out-in" && c.type !== Ea) return r.isLeaving = !0, e.afterLeave = () => {
 					r.isLeaving = !1, n.job.flags & 8 || n.update(), delete e.afterLeave, u = void 0;
-				}, wr(a);
-				s === "in-out" && c.type !== Da ? e.delayLeave = (e, t, n) => {
-					let i = Sr(r, u);
-					i[String(u.key)] = u, e[pr] = () => {
-						t(), e[pr] = void 0, delete l.delayedLeave, u = void 0;
+				}, Cr(a);
+				s === "in-out" && c.type !== Ea ? e.delayLeave = (e, t, n) => {
+					let i = xr(r, u);
+					i[String(u.key)] = u, e[fr] = () => {
+						t(), e[fr] = void 0, delete l.delayedLeave, u = void 0;
 					}, l.delayedLeave = () => {
 						n(), delete l.delayedLeave, u = void 0;
 					};
@@ -1308,24 +1305,24 @@ var gr = [Function, Array], _r = {
 		};
 	}
 };
-function br(e) {
+function yr(e) {
 	let t = e[0];
 	if (e.length > 1) {
-		for (let n of e) if (n.type !== Da) {
+		for (let n of e) if (n.type !== Ea) {
 			t = n;
 			break;
 		}
 	}
 	return t;
 }
-var xr = yr;
-function Sr(e, t) {
+var br = vr;
+function xr(e, t) {
 	let { leavingVNodes: n } = e, r = n.get(t.type);
 	return r || (r = /* @__PURE__ */ Object.create(null), n.set(t.type, r)), r;
 }
-function Cr(e, t, n, r, i) {
-	let { appear: a, mode: o, persisted: s = !1, onBeforeEnter: c, onEnter: l, onAfterEnter: u, onEnterCancelled: f, onBeforeLeave: p, onLeave: m, onAfterLeave: h, onLeaveCancelled: g, onBeforeAppear: _, onAppear: v, onAfterAppear: y, onAppearCancelled: b } = t, x = String(e.key), S = Sr(n, e), C = (e, t) => {
-		e && bn(e, r, 9, t);
+function Sr(e, t, n, r, i) {
+	let { appear: a, mode: o, persisted: s = !1, onBeforeEnter: c, onEnter: l, onAfterEnter: u, onEnterCancelled: f, onBeforeLeave: p, onLeave: m, onAfterLeave: h, onLeaveCancelled: g, onBeforeAppear: _, onAppear: v, onAfterAppear: y, onAppearCancelled: b } = t, x = String(e.key), S = xr(n, e), C = (e, t) => {
+		e && yn(e, r, 9, t);
 	}, w = (e, t) => {
 		let n = t[1];
 		C(e, t), d(e) ? e.every((e) => e.length <= 1) && n() : e.length <= 1 && n();
@@ -1336,9 +1333,9 @@ function Cr(e, t, n, r, i) {
 			let r = c;
 			if (!n.isMounted) if (a) r = _ || c;
 			else return;
-			t[pr] && t[pr](!0);
+			t[fr] && t[fr](!0);
 			let i = S[x];
-			i && Ia(e, i) && i.el[pr] && i.el[pr](), C(r, [t]);
+			i && Fa(e, i) && i.el[fr] && i.el[fr](), C(r, [t]);
 		},
 		enter(t) {
 			if (S[x] === e) return;
@@ -1346,35 +1343,35 @@ function Cr(e, t, n, r, i) {
 			if (!n.isMounted) if (a) r = v || l, i = y || u, o = b || f;
 			else return;
 			let s = !1;
-			t[mr] = (e) => {
-				s || (s = !0, C(e ? o : i, [t]), ee.delayedLeave && ee.delayedLeave(), t[mr] = void 0);
+			t[pr] = (e) => {
+				s || (s = !0, C(e ? o : i, [t]), ee.delayedLeave && ee.delayedLeave(), t[pr] = void 0);
 			};
-			let c = t[mr].bind(null, !1);
+			let c = t[pr].bind(null, !1);
 			r ? w(r, [t, c]) : c();
 		},
 		leave(t, r) {
 			let i = String(e.key);
-			if (t[mr] && t[mr](!0), n.isUnmounting) return r();
+			if (t[pr] && t[pr](!0), n.isUnmounting) return r();
 			C(p, [t]);
 			let a = !1;
-			t[pr] = (n) => {
-				a || (a = !0, r(), C(n ? g : h, [t]), t[pr] = void 0, S[i] === e && delete S[i]);
+			t[fr] = (n) => {
+				a || (a = !0, r(), C(n ? g : h, [t]), t[fr] = void 0, S[i] === e && delete S[i]);
 			};
-			let o = t[pr].bind(null, !1);
+			let o = t[fr].bind(null, !1);
 			S[i] = e, m ? w(m, [t, o]) : o();
 		},
 		clone(e) {
-			let a = Cr(e, t, n, r, i);
+			let a = Sr(e, t, n, r, i);
 			return i && i(a), a;
 		}
 	};
 	return ee;
 }
-function wr(e) {
-	if (Br(e)) return e = Va(e), e.children = null, e;
+function Cr(e) {
+	if (zr(e)) return e = Ba(e), e.children = null, e;
 }
-function Tr(e) {
-	if (!Br(e)) return tr(e.type) && e.children ? br(e.children) : e;
+function wr(e) {
+	if (!zr(e)) return er(e.type) && e.children ? yr(e.children) : e;
 	if (e.component) return e.component.subTree;
 	let { shapeFlag: t, children: n } = e;
 	if (n) {
@@ -1382,56 +1379,56 @@ function Tr(e) {
 		if (t & 32 && h(n.default)) return n.default();
 	}
 }
-function Er(e, t) {
-	e.shapeFlag & 6 && e.component ? (e.transition = t, Er(e.component.subTree, t)) : e.shapeFlag & 128 ? (e.ssContent.transition = t.clone(e.ssContent), e.ssFallback.transition = t.clone(e.ssFallback)) : e.transition = t;
+function Tr(e, t) {
+	e.shapeFlag & 6 && e.component ? (e.transition = t, Tr(e.component.subTree, t)) : e.shapeFlag & 128 ? (e.ssContent.transition = t.clone(e.ssContent), e.ssFallback.transition = t.clone(e.ssFallback)) : e.transition = t;
 }
-function Dr(e, t = !1, n) {
+function Er(e, t = !1, n) {
 	let r = [], i = 0;
 	for (let a = 0; a < e.length; a++) {
 		let o = e[a], s = n == null ? o.key : String(n) + String(o.key == null ? a : o.key);
-		o.type === L ? (o.patchFlag & 128 && i++, r = r.concat(Dr(o.children, t, s))) : (t || o.type !== Da) && r.push(s == null ? o : Va(o, { key: s }));
+		o.type === L ? (o.patchFlag & 128 && i++, r = r.concat(Er(o.children, t, s))) : (t || o.type !== Ea) && r.push(s == null ? o : Ba(o, { key: s }));
 	}
 	if (i > 1) for (let e = 0; e < r.length; e++) r[e].patchFlag = -2;
 	return r;
 }
-/* @__NO_SIDE_EFFECTS__ */
-function Or(e, t) {
+// @__NO_SIDE_EFFECTS__
+function Dr(e, t) {
 	return h(e) ? /* @__PURE__ */ s({ name: e.name }, t, { setup: e }) : e;
 }
-function kr() {
-	let e = Xa();
+function Or() {
+	let e = Ya();
 	return e ? (e.appContext.config.idPrefix || "v") + "-" + e.ids[0] + e.ids[1]++ : "";
 }
-function Ar(e) {
+function kr(e) {
 	e.ids = [
 		e.ids[0] + e.ids[2]++ + "-",
 		0,
 		0
 	];
 }
-function jr(e, t) {
+function Ar(e, t) {
 	let n;
 	return !!((n = Object.getOwnPropertyDescriptor(e, t)) && !n.configurable);
 }
-var Mr = /* @__PURE__ */ new WeakMap();
-function Nr(e, n, r, a, o = !1) {
+var jr = /* @__PURE__ */ new WeakMap();
+function Mr(e, n, r, a, o = !1) {
 	if (d(e)) {
-		e.forEach((e, t) => Nr(e, n && (d(n) ? n[t] : n), r, a, o));
+		e.forEach((e, t) => Mr(e, n && (d(n) ? n[t] : n), r, a, o));
 		return;
 	}
-	if (Lr(a) && !o) {
-		a.shapeFlag & 512 && a.type.__asyncResolved && a.component.subTree.component && Nr(e, n, r, a.component.subTree);
+	if (Ir(a) && !o) {
+		a.shapeFlag & 512 && a.type.__asyncResolved && a.component.subTree.component && Mr(e, n, r, a.component.subTree);
 		return;
 	}
-	let s = a.shapeFlag & 4 ? fo(a.component) : a.el, l = o ? null : s, { i: f, r: p } = e, m = n && n.r, _ = f.refs === t ? f.refs = {} : f.refs, v = f.setupState, y = /* @__PURE__ */ j(v), b = v === t ? i : (e) => jr(_, e) ? !1 : u(y, e), x = (e, t) => !(t && jr(_, t));
+	let s = a.shapeFlag & 4 ? uo(a.component) : a.el, l = o ? null : s, { i: f, r: p } = e, m = n && n.r, _ = f.refs === t ? f.refs = {} : f.refs, v = f.setupState, y = /* @__PURE__ */ j(v), b = v === t ? i : (e) => Ar(_, e) ? !1 : u(y, e), x = (e, t) => !(t && Ar(_, t));
 	if (m != null && m !== p) {
-		if (Pr(n), g(m)) _[m] = null, b(m) && (v[m] = null);
+		if (Nr(n), g(m)) _[m] = null, b(m) && (v[m] = null);
 		else if (/* @__PURE__ */ M(m)) {
 			let e = n;
 			x(m, e.k) && (m.value = null), e.k && (_[e.k] = null);
 		}
 	}
-	if (h(p)) yn(p, f, 12, [l, _]);
+	if (h(p)) vn(p, f, 12, [l, _]);
 	else {
 		let t = g(p), n = /* @__PURE__ */ M(p);
 		if (t || n) {
@@ -1449,35 +1446,35 @@ function Nr(e, n, r, a, o = !1) {
 			};
 			if (l) {
 				let t = () => {
-					i(), Mr.delete(e);
+					i(), jr.delete(e);
 				};
-				t.id = -1, Mr.set(e, t), pa(t, r);
-			} else Pr(e), i();
+				t.id = -1, jr.set(e, t), fa(t, r);
+			} else Nr(e), i();
 		}
 	}
 }
-function Pr(e) {
-	let t = Mr.get(e);
-	t && (t.flags |= 8, Mr.delete(e));
+function Nr(e) {
+	let t = jr.get(e);
+	t && (t.flags |= 8, jr.delete(e));
 }
-var Fr = (e) => e.nodeType === 8;
+var Pr = (e) => e.nodeType === 8;
 fe().requestIdleCallback, fe().cancelIdleCallback;
-function Ir(e, t) {
-	if (Fr(e) && e.data === "[") {
+function Fr(e, t) {
+	if (Pr(e) && e.data === "[") {
 		let n = 1, r = e.nextSibling;
 		for (; r;) {
 			if (r.nodeType === 1) {
 				if (t(r) === !1) break;
-			} else if (Fr(r)) if (r.data === "]") {
+			} else if (Pr(r)) if (r.data === "]") {
 				if (--n === 0) break;
 			} else r.data === "[" && n++;
 			r = r.nextSibling;
 		}
 	} else t(e);
 }
-var Lr = (e) => !!e.type.__asyncLoader;
-/* @__NO_SIDE_EFFECTS__ */
-function Rr(e) {
+var Ir = (e) => !!e.type.__asyncLoader;
+// @__NO_SIDE_EFFECTS__
+function Lr(e) {
 	h(e) && (e = { loader: e });
 	let { loader: t, loadingComponent: n, errorComponent: r, delay: i = 200, hydrate: a, timeout: o, suspensible: s = !0, onError: c } = e, l = null, u, d = 0, f = () => (d++, l = null, p()), p = () => {
 		let e;
@@ -1488,7 +1485,7 @@ function Rr(e) {
 			throw e;
 		}).then((t) => e !== l && l ? l : (t && (t.__esModule || t[Symbol.toStringTag] === "Module") && (t = t.default), u = t, t)));
 	};
-	return /* @__PURE__ */ Or({
+	return /* @__PURE__ */ Dr({
 		name: "AsyncComponentWrapper",
 		__asyncLoader: p,
 		__asyncHydrate(e, t, n) {
@@ -1497,7 +1494,7 @@ function Rr(e) {
 			let i = () => {
 				r || n();
 			}, o = a ? () => {
-				let n = a(i, (t) => Ir(e, t));
+				let n = a(i, (t) => Fr(e, t));
 				n && (t.bum ||= []).push(n);
 			} : i;
 			u ? o() : p().then(() => !t.isUnmounted && o());
@@ -1507,12 +1504,12 @@ function Rr(e) {
 		},
 		setup() {
 			let e = G;
-			if (Ar(e), u) return () => zr(u, e);
+			if (kr(e), u) return () => Rr(u, e);
 			let t = (t) => {
-				l = null, xn(t, e, 13, !r);
+				l = null, bn(t, e, 13, !r);
 			};
-			if (s && e.suspense || no) return p().then((t) => () => zr(t, e)).catch((e) => (t(e), () => r ? H(r, { error: e }) : null));
-			let a = /* @__PURE__ */ $t(!1), c = /* @__PURE__ */ $t(), d = /* @__PURE__ */ $t(!!i);
+			if (s && e.suspense || to) return p().then((t) => () => Rr(t, e)).catch((e) => (t(e), () => r ? H(r, { error: e }) : null));
+			let a = /* @__PURE__ */ Qt(!1), c = /* @__PURE__ */ Qt(), d = /* @__PURE__ */ Qt(!!i);
 			return i && setTimeout(() => {
 				d.value = !1;
 			}, i), o != null && setTimeout(() => {
@@ -1521,29 +1518,29 @@ function Rr(e) {
 					t(e), c.value = e;
 				}
 			}, o), p().then(() => {
-				a.value = !0, e.parent && Br(e.parent.vnode) && e.parent.update();
+				a.value = !0, e.parent && zr(e.parent.vnode) && e.parent.update();
 			}).catch((e) => {
 				t(e), c.value = e;
 			}), () => {
-				if (a.value && u) return zr(u, e);
+				if (a.value && u) return Rr(u, e);
 				if (c.value && r) return H(r, { error: c.value });
-				if (n && !d.value) return zr(n, e);
+				if (n && !d.value) return Rr(n, e);
 			};
 		}
 	});
 }
-function zr(e, t) {
+function Rr(e, t) {
 	let { ref: n, props: r, children: i, ce: a } = t.vnode, o = H(e, r, i);
 	return o.ref = n, o.ce = a, delete t.vnode.ce, o;
 }
-var Br = (e) => e.type.__isKeepAlive;
+var zr = (e) => e.type.__isKeepAlive;
+function Br(e, t) {
+	Hr(e, "a", t);
+}
 function Vr(e, t) {
-	Ur(e, "a", t);
+	Hr(e, "da", t);
 }
-function Hr(e, t) {
-	Ur(e, "da", t);
-}
-function Ur(e, t, n = G) {
+function Hr(e, t, n = G) {
 	let r = e.__wdc ||= () => {
 		let t = n;
 		for (; t;) {
@@ -1552,65 +1549,65 @@ function Ur(e, t, n = G) {
 		}
 		return e();
 	};
-	if (Gr(t, r, n), n) {
+	if (Wr(t, r, n), n) {
 		let e = n.parent;
-		for (; e && e.parent;) Br(e.parent.vnode) && Wr(r, t, n, e), e = e.parent;
+		for (; e && e.parent;) zr(e.parent.vnode) && Ur(r, t, n, e), e = e.parent;
 	}
 }
-function Wr(e, t, n, r) {
-	let i = Gr(t, e, r, !0);
-	Qr(() => {
+function Ur(e, t, n, r) {
+	let i = Wr(t, e, r, !0);
+	Zr(() => {
 		c(r[t], i);
 	}, n);
 }
-function Gr(e, t, n = G, r = !1) {
+function Wr(e, t, n = G, r = !1) {
 	if (n) {
 		let i = n[e] || (n[e] = []), a = t.__weh ||= (...r) => {
 			Je();
-			let i = $a(n), a = bn(t, n, e, r);
+			let i = Qa(n), a = yn(t, n, e, r);
 			return i(), Ye(), a;
 		};
 		return r ? i.unshift(a) : i.push(a), a;
 	}
 }
-var Kr = (e) => (t, n = G) => {
-	(!no || e === "sp") && Gr(e, (...e) => t(...e), n);
-}, qr = Kr("bm"), Jr = Kr("m"), Yr = Kr("bu"), Xr = Kr("u"), Zr = Kr("bum"), Qr = Kr("um"), $r = Kr("sp"), ei = Kr("rtg"), ti = Kr("rtc");
-function ni(e, t = G) {
-	Gr("ec", e, t);
+var Gr = (e) => (t, n = G) => {
+	(!to || e === "sp") && Wr(e, (...e) => t(...e), n);
+}, Kr = Gr("bm"), qr = Gr("m"), Jr = Gr("bu"), Yr = Gr("u"), Xr = Gr("bum"), Zr = Gr("um"), Qr = Gr("sp"), $r = Gr("rtg"), ei = Gr("rtc");
+function ti(e, t = G) {
+	Wr("ec", e, t);
 }
-var ri = "components", ii = "directives";
+var ni = "components", ri = "directives";
 function F(e, t) {
-	return ci(ri, e, !0, t) || e;
+	return si(ni, e, !0, t) || e;
 }
-var ai = /* @__PURE__ */ Symbol.for("v-ndc");
+var ii = /* @__PURE__ */ Symbol.for("v-ndc");
+function ai(e) {
+	return g(e) ? si(ni, e, !1) || e : e || ii;
+}
 function oi(e) {
-	return g(e) ? ci(ri, e, !1) || e : e || ai;
+	return si(ri, e);
 }
-function si(e) {
-	return ci(ii, e);
-}
-function ci(e, t, n = !0, r = !1) {
+function si(e, t, n = !0, r = !1) {
 	let i = N || G;
 	if (i) {
 		let n = i.type;
-		if (e === ri) {
-			let e = po(n, !1);
+		if (e === ni) {
+			let e = fo(n, !1);
 			if (e && (e === t || e === T(t) || e === ie(T(t)))) return n;
 		}
-		let a = li(i[e] || n[e], t) || li(i.appContext[e], t);
+		let a = ci(i[e] || n[e], t) || ci(i.appContext[e], t);
 		return !a && r ? n : a;
 	}
 }
-function li(e, t) {
+function ci(e, t) {
 	return e && (e[t] || e[T(t)] || e[ie(T(t))]);
 }
-function ui(e, t, n, r) {
+function li(e, t, n, r) {
 	let i, a = n && n[r], o = d(e);
 	if (o || g(e)) {
-		let n = o && /* @__PURE__ */ Kt(e), r = !1, s = !1;
-		n && (r = !/* @__PURE__ */ Jt(e), s = /* @__PURE__ */ qt(e), e = lt(e)), i = Array(e.length);
-		for (let n = 0, o = e.length; n < o; n++) i[n] = t(r ? s ? Qt(Zt(e[n])) : Zt(e[n]) : e[n], n, void 0, a && a[n]);
+		let n = o && /* @__PURE__ */ Gt(e), r = !1, s = !1;
+		n && (r = !/* @__PURE__ */ qt(e), s = /* @__PURE__ */ Kt(e), e = lt(e)), i = Array(e.length);
+		for (let n = 0, o = e.length; n < o; n++) i[n] = t(r ? s ? Zt(Xt(e[n])) : Xt(e[n]) : e[n], n, void 0, a && a[n]);
 	} else if (typeof e == "number") {
 		i = Array(e);
 		for (let n = 0; n < e; n++) i[n] = t(n + 1, n, void 0, a && a[n]);
@@ -1626,7 +1623,7 @@ function ui(e, t, n, r) {
 	else i = [];
 	return n && (n[r] = i), i;
 }
-function di(e, t) {
+function ui(e, t) {
 	for (let n = 0; n < t.length; n++) {
 		let r = t[n];
 		if (d(r)) for (let t = 0; t < r.length; t++) e[r[t].name] = r[t].fn;
@@ -1638,19 +1635,19 @@ function di(e, t) {
 	return e;
 }
 function I(e, t, n = {}, r, i) {
-	if (N.ce || N.parent && Lr(N.parent) && N.parent.ce) {
+	if (N.ce || N.parent && Ir(N.parent) && N.parent.ce) {
 		let e = Object.keys(n).length > 0;
 		return t !== "default" && (n.name = t), R(), B(L, null, [H("slot", n, r && r())], e ? -2 : 64);
 	}
 	let a = e[t];
 	a && a._c && (a._d = !1), R();
-	let o = a && fi(a(n)), s = n.key || o && o.key, c = B(L, { key: (s && !_(s) ? s : `_${t}`) + (!o && r ? "_fb" : "") }, o || (r ? r() : []), o && e._ === 1 ? 64 : -2);
+	let o = a && di(a(n)), s = n.key || o && o.key, c = B(L, { key: (s && !_(s) ? s : `_${t}`) + (!o && r ? "_fb" : "") }, o || (r ? r() : []), o && e._ === 1 ? 64 : -2);
 	return !i && c.scopeId && (c.slotScopeIds = [c.scopeId + "-s"]), a && a._c && (a._d = !0), c;
 }
-function fi(e) {
-	return e.some((e) => Fa(e) ? !(e.type === Da || e.type === L && !fi(e.children)) : !0) ? e : null;
+function di(e) {
+	return e.some((e) => Pa(e) ? !(e.type === Ea || e.type === L && !di(e.children)) : !0) ? e : null;
 }
-var pi = (e) => e ? to(e) ? fo(e) : pi(e.parent) : null, mi = /* @__PURE__ */ s(/* @__PURE__ */ Object.create(null), {
+var fi = (e) => e ? eo(e) ? uo(e) : fi(e.parent) : null, pi = /* @__PURE__ */ s(/* @__PURE__ */ Object.create(null), {
 	$: (e) => e,
 	$el: (e) => e.vnode.el,
 	$data: (e) => e.data,
@@ -1658,17 +1655,17 @@ var pi = (e) => e ? to(e) ? fo(e) : pi(e.parent) : null, mi = /* @__PURE__ */ s(
 	$attrs: (e) => e.attrs,
 	$slots: (e) => e.slots,
 	$refs: (e) => e.refs,
-	$parent: (e) => pi(e.parent),
-	$root: (e) => pi(e.root),
+	$parent: (e) => fi(e.parent),
+	$root: (e) => fi(e.root),
 	$host: (e) => e.ce,
 	$emit: (e) => e.emit,
-	$options: (e) => Ci(e),
+	$options: (e) => Si(e),
 	$forceUpdate: (e) => e.f ||= () => {
-		Mn(e.update);
+		jn(e.update);
 	},
-	$nextTick: (e) => e.n ||= An.bind(e.proxy),
-	$watch: (e) => Zn.bind(e)
-}), hi = (e, n) => e !== t && !e.__isScriptSetup && u(e, n), gi = {
+	$nextTick: (e) => e.n ||= kn.bind(e.proxy),
+	$watch: (e) => Xn.bind(e)
+}), mi = (e, n) => e !== t && !e.__isScriptSetup && u(e, n), hi = {
 	get({ _: e }, n) {
 		if (n === "__v_skip") return !0;
 		let { ctx: r, setupState: i, data: a, props: o, accessCache: s, type: c, appContext: l } = e;
@@ -1680,13 +1677,13 @@ var pi = (e) => e ? to(e) ? fo(e) : pi(e.parent) : null, mi = /* @__PURE__ */ s(
 				case 4: return r[n];
 				case 3: return o[n];
 			}
-			else if (hi(i, n)) return s[n] = 1, i[n];
+			else if (mi(i, n)) return s[n] = 1, i[n];
 			else if (a !== t && u(a, n)) return s[n] = 2, a[n];
 			else if (u(o, n)) return s[n] = 3, o[n];
 			else if (r !== t && u(r, n)) return s[n] = 4, r[n];
-			else vi && (s[n] = 0);
+			else _i && (s[n] = 0);
 		}
-		let d = mi[n], f, p;
+		let d = pi[n], f, p;
 		if (d) return n === "$attrs" && at(e.attrs, "get", ""), d(e);
 		if ((f = c.__cssModules) && (f = f[n])) return f;
 		if (r !== t && u(r, n)) return s[n] = 4, r[n];
@@ -1694,34 +1691,34 @@ var pi = (e) => e ? to(e) ? fo(e) : pi(e.parent) : null, mi = /* @__PURE__ */ s(
 	},
 	set({ _: e }, n, r) {
 		let { data: i, setupState: a, ctx: o } = e;
-		return hi(a, n) ? (a[n] = r, !0) : i !== t && u(i, n) ? (i[n] = r, !0) : u(e.props, n) || n[0] === "$" && n.slice(1) in e ? !1 : (o[n] = r, !0);
+		return mi(a, n) ? (a[n] = r, !0) : i !== t && u(i, n) ? (i[n] = r, !0) : u(e.props, n) || n[0] === "$" && n.slice(1) in e ? !1 : (o[n] = r, !0);
 	},
 	has({ _: { data: e, setupState: n, accessCache: r, ctx: i, appContext: a, props: o, type: s } }, c) {
 		let l;
-		return !!(r[c] || e !== t && c[0] !== "$" && u(e, c) || hi(n, c) || u(o, c) || u(i, c) || u(mi, c) || u(a.config.globalProperties, c) || (l = s.__cssModules) && l[c]);
+		return !!(r[c] || e !== t && c[0] !== "$" && u(e, c) || mi(n, c) || u(o, c) || u(i, c) || u(pi, c) || u(a.config.globalProperties, c) || (l = s.__cssModules) && l[c]);
 	},
 	defineProperty(e, t, n) {
 		return n.get == null ? u(n, "value") && this.set(e, t, n.value, null) : e._.accessCache[t] = 0, Reflect.defineProperty(e, t, n);
 	}
 };
-function _i(e) {
+function gi(e) {
 	return d(e) ? e.reduce((e, t) => (e[t] = null, e), {}) : e;
 }
-var vi = !0;
-function yi(e) {
-	let t = Ci(e), n = e.proxy, i = e.ctx;
-	vi = !1, t.beforeCreate && xi(t.beforeCreate, e, "bc");
+var _i = !0;
+function vi(e) {
+	let t = Si(e), n = e.proxy, i = e.ctx;
+	_i = !1, t.beforeCreate && bi(t.beforeCreate, e, "bc");
 	let { data: a, computed: o, methods: s, watch: c, provide: l, inject: u, created: f, beforeMount: p, mounted: m, beforeUpdate: g, updated: _, activated: y, deactivated: b, beforeDestroy: x, beforeUnmount: S, destroyed: C, unmounted: w, render: ee, renderTracked: te, renderTriggered: ne, errorCaptured: T, serverPrefetch: re, expose: E, inheritAttrs: ie, components: ae, directives: oe, filters: se } = t;
-	if (u && bi(u, i, null), s) for (let e in s) {
+	if (u && yi(u, i, null), s) for (let e in s) {
 		let t = s[e];
 		h(t) && (i[e] = t.bind(n));
 	}
 	if (a) {
 		let t = a.call(n, n);
-		v(t) && (e.data = /* @__PURE__ */ Ht(t));
+		v(t) && (e.data = /* @__PURE__ */ Vt(t));
 	}
-	if (vi = !0, o) for (let e in o) {
-		let t = o[e], a = ho({
+	if (_i = !0, o) for (let e in o) {
+		let t = o[e], a = mo({
 			get: h(t) ? t.bind(n, n) : h(t.get) ? t.get.bind(n, n) : r,
 			set: !h(t) && h(t.set) ? t.set.bind(n) : r
 		});
@@ -1732,18 +1729,18 @@ function yi(e) {
 			set: (e) => a.value = e
 		});
 	}
-	if (c) for (let e in c) Si(c[e], i, n, e);
+	if (c) for (let e in c) xi(c[e], i, n, e);
 	if (l) {
 		let e = h(l) ? l.call(n) : l;
 		Reflect.ownKeys(e).forEach((t) => {
-			Un(t, e[t]);
+			Hn(t, e[t]);
 		});
 	}
-	f && xi(f, e, "c");
+	f && bi(f, e, "c");
 	function ce(e, t) {
 		d(t) ? t.forEach((t) => e(t.bind(n))) : t && e(t.bind(n));
 	}
-	if (ce(qr, p), ce(Jr, m), ce(Yr, g), ce(Xr, _), ce(Vr, y), ce(Hr, b), ce(ni, T), ce(ti, te), ce(ei, ne), ce(Zr, S), ce(Qr, w), ce($r, re), d(E)) if (E.length) {
+	if (ce(Kr, p), ce(qr, m), ce(Jr, g), ce(Yr, _), ce(Br, y), ce(Vr, b), ce(ti, T), ce(ei, te), ce($r, ne), ce(Xr, S), ce(Zr, w), ce(Qr, re), d(E)) if (E.length) {
 		let t = e.exposed ||= {};
 		E.forEach((e) => {
 			Object.defineProperty(t, e, {
@@ -1753,13 +1750,13 @@ function yi(e) {
 			});
 		});
 	} else e.exposed ||= {};
-	ee && e.render === r && (e.render = ee), ie != null && (e.inheritAttrs = ie), ae && (e.components = ae), oe && (e.directives = oe), re && Ar(e);
+	ee && e.render === r && (e.render = ee), ie != null && (e.inheritAttrs = ie), ae && (e.components = ae), oe && (e.directives = oe), re && kr(e);
 }
-function bi(e, t, n = r) {
-	d(e) && (e = Oi(e));
+function yi(e, t, n = r) {
+	d(e) && (e = Di(e));
 	for (let n in e) {
 		let r = e[n], i;
-		i = v(r) ? "default" in r ? Wn(r.from || n, r.default, !0) : Wn(r.from || n) : Wn(r), /* @__PURE__ */ M(i) ? Object.defineProperty(t, n, {
+		i = v(r) ? "default" in r ? Un(r.from || n, r.default, !0) : Un(r.from || n) : Un(r), /* @__PURE__ */ M(i) ? Object.defineProperty(t, n, {
 			enumerable: !0,
 			configurable: !0,
 			get: () => i.value,
@@ -1767,69 +1764,69 @@ function bi(e, t, n = r) {
 		}) : t[n] = i;
 	}
 }
-function xi(e, t, n) {
-	bn(d(e) ? e.map((e) => e.bind(t.proxy)) : e.bind(t.proxy), t, n);
+function bi(e, t, n) {
+	yn(d(e) ? e.map((e) => e.bind(t.proxy)) : e.bind(t.proxy), t, n);
 }
-function Si(e, t, n, r) {
-	let i = r.includes(".") ? Qn(n, r) : () => n[r];
+function xi(e, t, n, r) {
+	let i = r.includes(".") ? Zn(n, r) : () => n[r];
 	if (g(e)) {
 		let n = t[e];
-		h(n) && Yn(i, n);
-	} else if (h(e)) Yn(i, e.bind(n));
-	else if (v(e)) if (d(e)) e.forEach((e) => Si(e, t, n, r));
+		h(n) && Jn(i, n);
+	} else if (h(e)) Jn(i, e.bind(n));
+	else if (v(e)) if (d(e)) e.forEach((e) => xi(e, t, n, r));
 	else {
 		let r = h(e.handler) ? e.handler.bind(n) : t[e.handler];
-		h(r) && Yn(i, r, e);
+		h(r) && Jn(i, r, e);
 	}
 }
-function Ci(e) {
+function Si(e) {
 	let t = e.type, { mixins: n, extends: r } = t, { mixins: i, optionsCache: a, config: { optionMergeStrategies: o } } = e.appContext, s = a.get(t), c;
-	return s ? c = s : !i.length && !n && !r ? c = t : (c = {}, i.length && i.forEach((e) => wi(c, e, o, !0)), wi(c, t, o)), v(t) && a.set(t, c), c;
+	return s ? c = s : !i.length && !n && !r ? c = t : (c = {}, i.length && i.forEach((e) => Ci(c, e, o, !0)), Ci(c, t, o)), v(t) && a.set(t, c), c;
 }
-function wi(e, t, n, r = !1) {
+function Ci(e, t, n, r = !1) {
 	let { mixins: i, extends: a } = t;
-	a && wi(e, a, n, !0), i && i.forEach((t) => wi(e, t, n, !0));
+	a && Ci(e, a, n, !0), i && i.forEach((t) => Ci(e, t, n, !0));
 	for (let i in t) if (!(r && i === "expose")) {
-		let r = Ti[i] || n && n[i];
+		let r = wi[i] || n && n[i];
 		e[i] = r ? r(e[i], t[i]) : t[i];
 	}
 	return e;
 }
-var Ti = {
-	data: Ei,
-	props: ji,
-	emits: ji,
-	methods: Ai,
-	computed: Ai,
-	beforeCreate: ki,
-	created: ki,
-	beforeMount: ki,
-	mounted: ki,
-	beforeUpdate: ki,
-	updated: ki,
-	beforeDestroy: ki,
-	beforeUnmount: ki,
-	destroyed: ki,
-	unmounted: ki,
-	activated: ki,
-	deactivated: ki,
-	errorCaptured: ki,
-	serverPrefetch: ki,
-	components: Ai,
-	directives: Ai,
-	watch: Mi,
-	provide: Ei,
-	inject: Di
+var wi = {
+	data: Ti,
+	props: Ai,
+	emits: Ai,
+	methods: ki,
+	computed: ki,
+	beforeCreate: Oi,
+	created: Oi,
+	beforeMount: Oi,
+	mounted: Oi,
+	beforeUpdate: Oi,
+	updated: Oi,
+	beforeDestroy: Oi,
+	beforeUnmount: Oi,
+	destroyed: Oi,
+	unmounted: Oi,
+	activated: Oi,
+	deactivated: Oi,
+	errorCaptured: Oi,
+	serverPrefetch: Oi,
+	components: ki,
+	directives: ki,
+	watch: ji,
+	provide: Ti,
+	inject: Ei
 };
-function Ei(e, t) {
+function Ti(e, t) {
 	return t ? e ? function() {
 		return s(h(e) ? e.call(this, this) : e, h(t) ? t.call(this, this) : t);
 	} : t : e;
 }
-function Di(e, t) {
-	return Ai(Oi(e), Oi(t));
+function Ei(e, t) {
+	return ki(Di(e), Di(t));
 }
-function Oi(e) {
+function Di(e) {
 	if (d(e)) {
 		let t = {};
 		for (let n = 0; n < e.length; n++) t[e[n]] = e[n];
@@ -1837,23 +1834,23 @@ function Oi(e) {
 	}
 	return e;
 }
-function ki(e, t) {
+function Oi(e, t) {
 	return e ? [...new Set([].concat(e, t))] : t;
 }
-function Ai(e, t) {
+function ki(e, t) {
 	return e ? s(/* @__PURE__ */ Object.create(null), e, t) : t;
 }
-function ji(e, t) {
-	return e ? d(e) && d(t) ? [.../* @__PURE__ */ new Set([...e, ...t])] : s(/* @__PURE__ */ Object.create(null), _i(e), _i(t ?? {})) : t;
+function Ai(e, t) {
+	return e ? d(e) && d(t) ? [.../* @__PURE__ */ new Set([...e, ...t])] : s(/* @__PURE__ */ Object.create(null), gi(e), gi(t ?? {})) : t;
 }
-function Mi(e, t) {
+function ji(e, t) {
 	if (!e) return t;
 	if (!t) return e;
 	let n = s(/* @__PURE__ */ Object.create(null), e);
-	for (let r in t) n[r] = ki(e[r], t[r]);
+	for (let r in t) n[r] = Oi(e[r], t[r]);
 	return n;
 }
-function Ni() {
+function Mi() {
 	return {
 		app: null,
 		config: {
@@ -1874,18 +1871,18 @@ function Ni() {
 		emitsCache: /* @__PURE__ */ new WeakMap()
 	};
 }
-var Pi = 0;
-function Fi(e, t) {
+var Ni = 0;
+function Pi(e, t) {
 	return function(n, r = null) {
 		h(n) || (n = s({}, n)), r != null && !v(r) && (r = null);
-		let i = Ni(), a = /* @__PURE__ */ new WeakSet(), o = [], c = !1, l = i.app = {
-			_uid: Pi++,
+		let i = Mi(), a = /* @__PURE__ */ new WeakSet(), o = [], c = !1, l = i.app = {
+			_uid: Ni++,
 			_component: n,
 			_props: r,
 			_container: null,
 			_context: i,
 			_instance: null,
-			version: _o,
+			version: go,
 			get config() {
 				return i.config;
 			},
@@ -1905,125 +1902,125 @@ function Fi(e, t) {
 			mount(a, o, s) {
 				if (!c) {
 					let u = l._ceVNode || H(n, r);
-					return u.appContext = i, s === !0 ? s = "svg" : s === !1 && (s = void 0), o && t ? t(u, a) : e(u, a, s), c = !0, l._container = a, a.__vue_app__ = l, fo(u.component);
+					return u.appContext = i, s === !0 ? s = "svg" : s === !1 && (s = void 0), o && t ? t(u, a) : e(u, a, s), c = !0, l._container = a, a.__vue_app__ = l, uo(u.component);
 				}
 			},
 			onUnmount(e) {
 				o.push(e);
 			},
 			unmount() {
-				c && (bn(o, l._instance, 16), e(null, l._container), delete l._container.__vue_app__);
+				c && (yn(o, l._instance, 16), e(null, l._container), delete l._container.__vue_app__);
 			},
 			provide(e, t) {
 				return i.provides[e] = t, l;
 			},
 			runWithContext(e) {
-				let t = Ii;
-				Ii = l;
+				let t = Fi;
+				Fi = l;
 				try {
 					return e();
 				} finally {
-					Ii = t;
+					Fi = t;
 				}
 			}
 		};
 		return l;
 	};
 }
-var Ii = null, Li = (e, t) => t === "modelValue" || t === "model-value" ? e.modelModifiers : e[`${t}Modifiers`] || e[`${T(t)}Modifiers`] || e[`${E(t)}Modifiers`];
-function Ri(e, n, ...r) {
+var Fi = null, Ii = (e, t) => t === "modelValue" || t === "model-value" ? e.modelModifiers : e[`${t}Modifiers`] || e[`${T(t)}Modifiers`] || e[`${E(t)}Modifiers`];
+function Li(e, n, ...r) {
 	if (e.isUnmounted) return;
-	let i = e.vnode.props || t, a = r, o = n.startsWith("update:"), s = o && Li(i, n.slice(7));
+	let i = e.vnode.props || t, a = r, o = n.startsWith("update:"), s = o && Ii(i, n.slice(7));
 	s && (s.trim && (a = r.map((e) => g(e) ? e.trim() : e)), s.number && (a = r.map(le)));
 	let c, l = i[c = ae(n)] || i[c = ae(T(n))];
-	!l && o && (l = i[c = ae(E(n))]), l && bn(l, e, 6, a);
+	!l && o && (l = i[c = ae(E(n))]), l && yn(l, e, 6, a);
 	let u = i[c + "Once"];
 	if (u) {
 		if (!e.emitted) e.emitted = {};
 		else if (e.emitted[c]) return;
-		e.emitted[c] = !0, bn(u, e, 6, a);
+		e.emitted[c] = !0, yn(u, e, 6, a);
 	}
 }
-var zi = /* @__PURE__ */ new WeakMap();
-function Bi(e, t, n = !1) {
-	let r = n ? zi : t.emitsCache, i = r.get(e);
+var Ri = /* @__PURE__ */ new WeakMap();
+function zi(e, t, n = !1) {
+	let r = n ? Ri : t.emitsCache, i = r.get(e);
 	if (i !== void 0) return i;
 	let a = e.emits, o = {}, c = !1;
 	if (!h(e)) {
 		let r = (e) => {
-			let n = Bi(e, t, !0);
+			let n = zi(e, t, !0);
 			n && (c = !0, s(o, n));
 		};
 		!n && t.mixins.length && t.mixins.forEach(r), e.extends && r(e.extends), e.mixins && e.mixins.forEach(r);
 	}
 	return !a && !c ? (v(e) && r.set(e, null), null) : (d(a) ? a.forEach((e) => o[e] = null) : s(o, a), v(e) && r.set(e, o), o);
 }
-function Vi(e, t) {
+function Bi(e, t) {
 	return !e || !a(t) ? !1 : (t = t.slice(2).replace(/Once$/, ""), u(e, t[0].toLowerCase() + t.slice(1)) || u(e, E(t)) || u(e, t));
 }
-function Hi(e) {
-	let { type: t, vnode: n, proxy: r, withProxy: i, propsOptions: [a], slots: s, attrs: c, emit: l, render: u, renderCache: d, props: f, data: p, setupState: m, ctx: h, inheritAttrs: g } = e, _ = Bn(e), v, y;
+function Vi(e) {
+	let { type: t, vnode: n, proxy: r, withProxy: i, propsOptions: [a], slots: s, attrs: c, emit: l, render: u, renderCache: d, props: f, data: p, setupState: m, ctx: h, inheritAttrs: g } = e, _ = zn(e), v, y;
 	try {
 		if (n.shapeFlag & 4) {
 			let e = i || r, t = e;
-			v = Ua(u.call(t, e, d, f, m, p, h)), y = c;
+			v = Ha(u.call(t, e, d, f, m, p, h)), y = c;
 		} else {
 			let e = t;
-			v = Ua(e.length > 1 ? e(f, {
+			v = Ha(e.length > 1 ? e(f, {
 				attrs: c,
 				slots: s,
 				emit: l
-			}) : e(f, null)), y = t.props ? c : Ui(c);
+			}) : e(f, null)), y = t.props ? c : Hi(c);
 		}
 	} catch (t) {
-		ka.length = 0, xn(t, e, 1), v = H(Da);
+		Oa.length = 0, bn(t, e, 1), v = H(Ea);
 	}
 	let b = v;
 	if (y && g !== !1) {
 		let e = Object.keys(y), { shapeFlag: t } = b;
-		e.length && t & 7 && (a && e.some(o) && (y = Wi(y, a)), b = Va(b, y, !1, !0));
+		e.length && t & 7 && (a && e.some(o) && (y = Ui(y, a)), b = Ba(b, y, !1, !0));
 	}
-	return n.dirs && (b = Va(b, null, !1, !0), b.dirs = b.dirs ? b.dirs.concat(n.dirs) : n.dirs), n.transition && Er(b, n.transition), v = b, Bn(_), v;
+	return n.dirs && (b = Ba(b, null, !1, !0), b.dirs = b.dirs ? b.dirs.concat(n.dirs) : n.dirs), n.transition && Tr(b, n.transition), v = b, zn(_), v;
 }
-var Ui = (e) => {
+var Hi = (e) => {
 	let t;
 	for (let n in e) (n === "class" || n === "style" || a(n)) && ((t ||= {})[n] = e[n]);
 	return t;
-}, Wi = (e, t) => {
+}, Ui = (e, t) => {
 	let n = {};
 	for (let r in e) (!o(r) || !(r.slice(9) in t)) && (n[r] = e[r]);
 	return n;
 };
-function Gi(e, t, n) {
+function Wi(e, t, n) {
 	let { props: r, children: i, component: a } = e, { props: o, children: s, patchFlag: c } = t, l = a.emitsOptions;
 	if (t.dirs || t.transition) return !0;
 	if (n && c >= 0) {
 		if (c & 1024) return !0;
-		if (c & 16) return r ? Ki(r, o, l) : !!o;
+		if (c & 16) return r ? Gi(r, o, l) : !!o;
 		if (c & 8) {
 			let e = t.dynamicProps;
 			for (let t = 0; t < e.length; t++) {
 				let n = e[t];
-				if (qi(o, r, n) && !Vi(l, n)) return !0;
+				if (Ki(o, r, n) && !Bi(l, n)) return !0;
 			}
 		}
-	} else return (i || s) && (!s || !s.$stable) ? !0 : r === o ? !1 : r ? o ? Ki(r, o, l) : !0 : !!o;
+	} else return (i || s) && (!s || !s.$stable) ? !0 : r === o ? !1 : r ? o ? Gi(r, o, l) : !0 : !!o;
 	return !1;
 }
-function Ki(e, t, n) {
+function Gi(e, t, n) {
 	let r = Object.keys(t);
 	if (r.length !== Object.keys(e).length) return !0;
 	for (let i = 0; i < r.length; i++) {
 		let a = r[i];
-		if (qi(t, e, a) && !Vi(n, a)) return !0;
+		if (Ki(t, e, a) && !Bi(n, a)) return !0;
 	}
 	return !1;
 }
-function qi(e, t, n) {
+function Ki(e, t, n) {
 	let r = e[n], i = t[n];
 	return n === "style" && v(r) && v(i) ? !Ce(r, i) : r !== i;
 }
-function Ji({ vnode: e, parent: t, suspense: n }, r) {
+function qi({ vnode: e, parent: t, suspense: n }, r) {
 	for (; t;) {
 		let n = t.subTree;
 		if (n.suspense && n.suspense.activeBranch === e && (n.suspense.vnode.el = n.el = r, e = n), n === e) (e = t.vnode).el = r, t = t.parent;
@@ -2031,55 +2028,55 @@ function Ji({ vnode: e, parent: t, suspense: n }, r) {
 	}
 	n && n.activeBranch === e && (n.vnode.el = r);
 }
-var Yi = {}, Xi = () => Object.create(Yi), Zi = (e) => Object.getPrototypeOf(e) === Yi;
-function Qi(e, t, n, r = !1) {
-	let i = {}, a = Xi();
-	e.propsDefaults = /* @__PURE__ */ Object.create(null), ea(e, t, i, a);
+var Ji = {}, Yi = () => Object.create(Ji), Xi = (e) => Object.getPrototypeOf(e) === Ji;
+function Zi(e, t, n, r = !1) {
+	let i = {}, a = Yi();
+	e.propsDefaults = /* @__PURE__ */ Object.create(null), $i(e, t, i, a);
 	for (let t in e.propsOptions[0]) t in i || (i[t] = void 0);
-	n ? e.props = r ? i : /* @__PURE__ */ Ut(i) : e.type.props ? e.props = i : e.props = a, e.attrs = a;
+	n ? e.props = r ? i : /* @__PURE__ */ Ht(i) : e.type.props ? e.props = i : e.props = a, e.attrs = a;
 }
-function $i(e, t, n, r) {
+function Qi(e, t, n, r) {
 	let { props: i, attrs: a, vnode: { patchFlag: o } } = e, s = /* @__PURE__ */ j(i), [c] = e.propsOptions, l = !1;
 	if ((r || o > 0) && !(o & 16)) {
 		if (o & 8) {
 			let n = e.vnode.dynamicProps;
 			for (let r = 0; r < n.length; r++) {
 				let o = n[r];
-				if (Vi(e.emitsOptions, o)) continue;
+				if (Bi(e.emitsOptions, o)) continue;
 				let d = t[o];
 				if (c) if (u(a, o)) d !== a[o] && (a[o] = d, l = !0);
 				else {
 					let t = T(o);
-					i[t] = ta(c, s, t, d, e, !1);
+					i[t] = ea(c, s, t, d, e, !1);
 				}
 				else d !== a[o] && (a[o] = d, l = !0);
 			}
 		}
 	} else {
-		ea(e, t, i, a) && (l = !0);
+		$i(e, t, i, a) && (l = !0);
 		let r;
-		for (let a in s) (!t || !u(t, a) && ((r = E(a)) === a || !u(t, r))) && (c ? n && (n[a] !== void 0 || n[r] !== void 0) && (i[a] = ta(c, s, a, void 0, e, !0)) : delete i[a]);
+		for (let a in s) (!t || !u(t, a) && ((r = E(a)) === a || !u(t, r))) && (c ? n && (n[a] !== void 0 || n[r] !== void 0) && (i[a] = ea(c, s, a, void 0, e, !0)) : delete i[a]);
 		if (a !== s) for (let e in a) (!t || !u(t, e)) && (delete a[e], l = !0);
 	}
 	l && ot(e.attrs, "set", "");
 }
-function ea(e, n, r, i) {
+function $i(e, n, r, i) {
 	let [a, o] = e.propsOptions, s = !1, c;
 	if (n) for (let t in n) {
 		if (ee(t)) continue;
 		let l = n[t], d;
-		a && u(a, d = T(t)) ? !o || !o.includes(d) ? r[d] = l : (c ||= {})[d] = l : Vi(e.emitsOptions, t) || (!(t in i) || l !== i[t]) && (i[t] = l, s = !0);
+		a && u(a, d = T(t)) ? !o || !o.includes(d) ? r[d] = l : (c ||= {})[d] = l : Bi(e.emitsOptions, t) || (!(t in i) || l !== i[t]) && (i[t] = l, s = !0);
 	}
 	if (o) {
 		let n = /* @__PURE__ */ j(r), i = c || t;
 		for (let t = 0; t < o.length; t++) {
 			let s = o[t];
-			r[s] = ta(a, n, s, i[s], e, !u(i, s));
+			r[s] = ea(a, n, s, i[s], e, !u(i, s));
 		}
 	}
 	return s;
 }
-function ta(e, t, n, r, i, a) {
+function ea(e, t, n, r, i, a) {
 	let o = e[n];
 	if (o != null) {
 		let e = u(o, "default");
@@ -2089,7 +2086,7 @@ function ta(e, t, n, r, i, a) {
 				let { propsDefaults: a } = i;
 				if (n in a) r = a[n];
 				else {
-					let o = $a(i);
+					let o = Qa(i);
 					r = a[n] = e.call(null, t), o();
 				}
 			} else r = e;
@@ -2099,15 +2096,15 @@ function ta(e, t, n, r, i, a) {
 	}
 	return r;
 }
-var na = /* @__PURE__ */ new WeakMap();
-function ra(e, r, i = !1) {
-	let a = i ? na : r.propsCache, o = a.get(e);
+var ta = /* @__PURE__ */ new WeakMap();
+function na(e, r, i = !1) {
+	let a = i ? ta : r.propsCache, o = a.get(e);
 	if (o) return o;
 	let c = e.props, l = {}, f = [], p = !1;
 	if (!h(e)) {
 		let t = (e) => {
 			p = !0;
-			let [t, n] = ra(e, r, !0);
+			let [t, n] = na(e, r, !0);
 			s(l, t), n && f.push(...n);
 		};
 		!i && r.mixins.length && r.mixins.forEach(t), e.extends && t(e.extends), e.mixins && e.mixins.forEach(t);
@@ -2115,11 +2112,11 @@ function ra(e, r, i = !1) {
 	if (!c && !p) return v(e) && a.set(e, n), n;
 	if (d(c)) for (let e = 0; e < c.length; e++) {
 		let n = T(c[e]);
-		ia(n) && (l[n] = t);
+		ra(n) && (l[n] = t);
 	}
 	else if (c) for (let e in c) {
 		let t = T(e);
-		if (ia(t)) {
+		if (ra(t)) {
 			let n = c[e], r = l[t] = d(n) || h(n) ? { type: n } : s({}, n), i = r.type, a = !1, o = !0;
 			if (d(i)) for (let e = 0; e < i.length; ++e) {
 				let t = i[e], n = h(t) && t.name;
@@ -2135,61 +2132,61 @@ function ra(e, r, i = !1) {
 	let m = [l, f];
 	return v(e) && a.set(e, m), m;
 }
-function ia(e) {
+function ra(e) {
 	return e[0] !== "$" && !ee(e);
 }
-var aa = (e) => e === "_" || e === "_ctx" || e === "$stable", oa = (e) => d(e) ? e.map(Ua) : [Ua(e)], sa = (e, t, n) => {
+var ia = (e) => e === "_" || e === "_ctx" || e === "$stable", aa = (e) => d(e) ? e.map(Ha) : [Ha(e)], oa = (e, t, n) => {
 	if (t._n) return t;
-	let r = P((...e) => oa(t(...e)), n);
+	let r = P((...e) => aa(t(...e)), n);
 	return r._c = !1, r;
-}, ca = (e, t, n) => {
+}, sa = (e, t, n) => {
 	let r = e._ctx;
 	for (let n in e) {
-		if (aa(n)) continue;
+		if (ia(n)) continue;
 		let i = e[n];
-		if (h(i)) t[n] = sa(n, i, r);
+		if (h(i)) t[n] = oa(n, i, r);
 		else if (i != null) {
-			let e = oa(i);
+			let e = aa(i);
 			t[n] = () => e;
 		}
 	}
-}, la = (e, t) => {
-	let n = oa(t);
+}, ca = (e, t) => {
+	let n = aa(t);
 	e.slots.default = () => n;
+}, la = (e, t, n) => {
+	for (let r in t) (n || !ia(r)) && (e[r] = t[r]);
 }, ua = (e, t, n) => {
-	for (let r in t) (n || !aa(r)) && (e[r] = t[r]);
-}, da = (e, t, n) => {
-	let r = e.slots = Xi();
+	let r = e.slots = Yi();
 	if (e.vnode.shapeFlag & 32) {
 		let e = t._;
-		e ? (ua(r, t, n), n && ce(r, "_", e, !0)) : ca(t, r);
-	} else t && la(e, t);
-}, fa = (e, n, r) => {
+		e ? (la(r, t, n), n && ce(r, "_", e, !0)) : sa(t, r);
+	} else t && ca(e, t);
+}, da = (e, n, r) => {
 	let { vnode: i, slots: a } = e, o = !0, s = t;
 	if (i.shapeFlag & 32) {
 		let e = n._;
-		e ? r && e === 1 ? o = !1 : ua(a, n, r) : (o = !n.$stable, ca(n, a)), s = n;
-	} else n && (la(e, n), s = { default: 1 });
-	if (o) for (let e in a) !aa(e) && s[e] == null && delete a[e];
-}, pa = Ta;
-function ma(e) {
-	return ha(e);
+		e ? r && e === 1 ? o = !1 : la(a, n, r) : (o = !n.$stable, sa(n, a)), s = n;
+	} else n && (ca(e, n), s = { default: 1 });
+	if (o) for (let e in a) !ia(e) && s[e] == null && delete a[e];
+}, fa = wa;
+function pa(e) {
+	return ma(e);
 }
-function ha(e, i) {
+function ma(e, i) {
 	let a = fe();
 	a.__VUE__ = !0;
 	let { insert: o, remove: s, patchProp: c, createElement: l, createText: u, createComment: d, setText: f, setElementText: p, parentNode: m, nextSibling: h, setScopeId: g = r, insertStaticContent: _ } = e, v = (e, t, n, r = null, i = null, a = null, o = void 0, s = null, c = !!t.dynamicChildren) => {
 		if (e === t) return;
-		e && !Ia(e, t) && (r = xe(e), _e(e, i, a, !0), e = null), t.patchFlag === -2 && (c = !1, t.dynamicChildren = null);
+		e && !Fa(e, t) && (r = xe(e), _e(e, i, a, !0), e = null), t.patchFlag === -2 && (c = !1, t.dynamicChildren = null);
 		let { type: l, ref: u, shapeFlag: d } = t;
 		switch (l) {
-			case Ea:
+			case Ta:
 				y(e, t, n, r);
 				break;
-			case Da:
+			case Ea:
 				b(e, t, n, r);
 				break;
-			case Oa:
+			case Da:
 				e ?? x(t, n, r, o);
 				break;
 			case L:
@@ -2197,7 +2194,7 @@ function ha(e, i) {
 				break;
 			default: d & 1 ? w(e, t, n, r, i, a, o, s, c) : d & 6 ? oe(e, t, n, r, i, a, o, s, c) : (d & 64 || d & 128) && l.process(e, t, n, r, i, a, o, s, c, we);
 		}
-		u != null && i ? Nr(u, e && e.ref, a, t || e, !t) : u == null && e && e.ref != null && Nr(e.ref, null, a, e, !0);
+		u != null && i ? Mr(u, e && e.ref, a, t || e, !t) : u == null && e && e.ref != null && Mr(e.ref, null, a, e, !0);
 	}, y = (e, t, n, r) => {
 		if (e == null) o(t.el = u(t.children), n, r);
 		else {
@@ -2228,33 +2225,33 @@ function ha(e, i) {
 		}
 	}, te = (e, t, n, r, i, a, s, u) => {
 		let d, f, { props: m, shapeFlag: h, transition: g, dirs: _ } = e;
-		if (d = e.el = l(e.type, a, m && m.is, m), h & 8 ? p(d, e.children) : h & 16 && T(e.children, d, null, r, i, ga(e, a), s, u), _ && Hn(e, null, r, "created"), ne(d, e, e.scopeId, s, r), m) {
+		if (d = e.el = l(e.type, a, m && m.is, m), h & 8 ? p(d, e.children) : h & 16 && T(e.children, d, null, r, i, ha(e, a), s, u), _ && Vn(e, null, r, "created"), ne(d, e, e.scopeId, s, r), m) {
 			for (let e in m) e !== "value" && !ee(e) && c(d, e, null, m[e], a, r);
-			"value" in m && c(d, "value", null, m.value, a), (f = m.onVnodeBeforeMount) && Ka(f, r, e);
+			"value" in m && c(d, "value", null, m.value, a), (f = m.onVnodeBeforeMount) && Ga(f, r, e);
 		}
-		_ && Hn(e, null, r, "beforeMount");
-		let v = va(i, g);
-		v && g.beforeEnter(d), o(d, t, n), ((f = m && m.onVnodeMounted) || v || _) && pa(() => {
+		_ && Vn(e, null, r, "beforeMount");
+		let v = _a(i, g);
+		v && g.beforeEnter(d), o(d, t, n), ((f = m && m.onVnodeMounted) || v || _) && fa(() => {
 			try {
-				f && Ka(f, r, e), v && g.enter(d), _ && Hn(e, null, r, "mounted");
+				f && Ga(f, r, e), v && g.enter(d), _ && Vn(e, null, r, "mounted");
 			} finally {}
 		}, i);
 	}, ne = (e, t, n, r, i) => {
 		if (n && g(e, n), r) for (let t = 0; t < r.length; t++) g(e, r[t]);
 		if (i) {
 			let n = i.subTree;
-			if (t === n || wa(n.type) && (n.ssContent === t || n.ssFallback === t)) {
+			if (t === n || Ca(n.type) && (n.ssContent === t || n.ssFallback === t)) {
 				let t = i.vnode;
 				ne(e, t, t.scopeId, t.slotScopeIds, i.parent);
 			}
 		}
 	}, T = (e, t, n, r, i, a, o, s, c = 0) => {
-		for (let l = c; l < e.length; l++) v(null, e[l] = s ? Wa(e[l]) : Ua(e[l]), t, n, r, i, a, o, s);
+		for (let l = c; l < e.length; l++) v(null, e[l] = s ? Ua(e[l]) : Ha(e[l]), t, n, r, i, a, o, s);
 	}, re = (e, n, r, i, a, o, s) => {
 		let l = n.el = e.el, { patchFlag: u, dynamicChildren: d, dirs: f } = n;
 		u |= e.patchFlag & 16;
 		let m = e.props || t, h = n.props || t, g;
-		if (r && _a(r, !1), (g = h.onVnodeBeforeUpdate) && Ka(g, r, n, e), f && Hn(n, e, r, "beforeUpdate"), r && _a(r, !0), (m.innerHTML && h.innerHTML == null || m.textContent && h.textContent == null) && p(l, ""), d ? E(e.dynamicChildren, d, l, r, i, ga(n, a), o) : s || pe(e, n, l, null, r, i, ga(n, a), o, !1), u > 0) {
+		if (r && ga(r, !1), (g = h.onVnodeBeforeUpdate) && Ga(g, r, n, e), f && Vn(n, e, r, "beforeUpdate"), r && ga(r, !0), (m.innerHTML && h.innerHTML == null || m.textContent && h.textContent == null) && p(l, ""), d ? E(e.dynamicChildren, d, l, r, i, ha(n, a), o) : s || pe(e, n, l, null, r, i, ha(n, a), o, !1), u > 0) {
 			if (u & 16) ie(l, m, h, r, a);
 			else if (u & 2 && m.class !== h.class && c(l, "class", null, h.class, a), u & 4 && c(l, "style", m.style, h.style, a), u & 8) {
 				let e = n.dynamicProps;
@@ -2265,13 +2262,13 @@ function ha(e, i) {
 			}
 			u & 1 && e.children !== n.children && p(l, n.children);
 		} else !s && d == null && ie(l, m, h, r, a);
-		((g = h.onVnodeUpdated) || f) && pa(() => {
-			g && Ka(g, r, n, e), f && Hn(n, e, r, "updated");
+		((g = h.onVnodeUpdated) || f) && fa(() => {
+			g && Ga(g, r, n, e), f && Vn(n, e, r, "updated");
 		}, i);
 	}, E = (e, t, n, r, i, a, o) => {
 		for (let s = 0; s < t.length; s++) {
 			let c = e[s], l = t[s];
-			v(c, l, c.el && (c.type === L || !Ia(c, l) || c.shapeFlag & 198) ? m(c.el) : n, null, r, i, a, o, !0);
+			v(c, l, c.el && (c.type === L || !Fa(c, l) || c.shapeFlag & 198) ? m(c.el) : n, null, r, i, a, o, !0);
 		}
 	}, ie = (e, n, r, i, a) => {
 		if (n !== r) {
@@ -2285,20 +2282,20 @@ function ha(e, i) {
 		}
 	}, ae = (e, t, n, r, i, a, s, c, l) => {
 		let d = t.el = e ? e.el : u(""), f = t.anchor = e ? e.anchor : u(""), { patchFlag: p, dynamicChildren: m, slotScopeIds: h } = t;
-		h && (c = c ? c.concat(h) : h), e == null ? (o(d, n, r), o(f, n, r), T(t.children || [], n, f, i, a, s, c, l)) : p > 0 && p & 64 && m && e.dynamicChildren && e.dynamicChildren.length === m.length ? (E(e.dynamicChildren, m, n, i, a, s, c), (t.key != null || i && t === i.subTree) && ya(e, t, !0)) : pe(e, t, n, f, i, a, s, c, l);
+		h && (c = c ? c.concat(h) : h), e == null ? (o(d, n, r), o(f, n, r), T(t.children || [], n, f, i, a, s, c, l)) : p > 0 && p & 64 && m && e.dynamicChildren && e.dynamicChildren.length === m.length ? (E(e.dynamicChildren, m, n, i, a, s, c), (t.key != null || i && t === i.subTree) && va(e, t, !0)) : pe(e, t, n, f, i, a, s, c, l);
 	}, oe = (e, t, n, r, i, a, o, s, c) => {
 		t.slotScopeIds = s, e == null ? t.shapeFlag & 512 ? i.ctx.activate(t, n, r, o, c) : ce(t, n, r, i, a, o, c) : le(e, t, c);
 	}, ce = (e, t, n, r, i, a, o) => {
-		let s = e.component = Ya(e, r, i);
-		if (Br(e) && (s.ctx.renderer = we), ro(s, !1, o), s.asyncDep) {
+		let s = e.component = Ja(e, r, i);
+		if (zr(e) && (s.ctx.renderer = we), no(s, !1, o), s.asyncDep) {
 			if (i && i.registerDep(s, ue, o), !e.el) {
-				let r = s.subTree = H(Da);
+				let r = s.subTree = H(Ea);
 				b(null, r, t, n), e.placeholder = r.el;
 			}
 		} else ue(s, e, t, n, i, a, o);
 	}, le = (e, t, n) => {
 		let r = t.component = e.component;
-		if (Gi(e, t, n)) if (r.asyncDep && !r.asyncResolved) {
+		if (Wi(e, t, n)) if (r.asyncDep && !r.asyncResolved) {
 			de(r, t, n);
 			return;
 		} else r.next = t, r.update();
@@ -2308,10 +2305,10 @@ function ha(e, i) {
 			if (e.isMounted) {
 				let { next: t, bu: n, u: r, parent: s, vnode: c } = e;
 				{
-					let n = xa(e);
+					let n = ba(e);
 					if (n) {
 						t && (t.el = c.el, de(e, t, o)), n.asyncDep.then(() => {
-							pa(() => {
+							fa(() => {
 								e.isUnmounted || l();
 							}, i);
 						});
@@ -2319,37 +2316,37 @@ function ha(e, i) {
 					}
 				}
 				let u = t, d;
-				_a(e, !1), t ? (t.el = c.el, de(e, t, o)) : t = c, n && se(n), (d = t.props && t.props.onVnodeBeforeUpdate) && Ka(d, s, t, c), _a(e, !0);
-				let f = Hi(e), p = e.subTree;
-				e.subTree = f, v(p, f, m(p.el), xe(p), e, i, a), t.el = f.el, u === null && Ji(e, f.el), r && pa(r, i), (d = t.props && t.props.onVnodeUpdated) && pa(() => Ka(d, s, t, c), i);
+				ga(e, !1), t ? (t.el = c.el, de(e, t, o)) : t = c, n && se(n), (d = t.props && t.props.onVnodeBeforeUpdate) && Ga(d, s, t, c), ga(e, !0);
+				let f = Vi(e), p = e.subTree;
+				e.subTree = f, v(p, f, m(p.el), xe(p), e, i, a), t.el = f.el, u === null && qi(e, f.el), r && fa(r, i), (d = t.props && t.props.onVnodeUpdated) && fa(() => Ga(d, s, t, c), i);
 			} else {
-				let o, { el: s, props: c } = t, { bm: l, m: u, parent: d, root: f, type: p } = e, m = Lr(t);
-				if (_a(e, !1), l && se(l), !m && (o = c && c.onVnodeBeforeMount) && Ka(o, d, t), _a(e, !0), s && O) {
+				let o, { el: s, props: c } = t, { bm: l, m: u, parent: d, root: f, type: p } = e, m = Ir(t);
+				if (ga(e, !1), l && se(l), !m && (o = c && c.onVnodeBeforeMount) && Ga(o, d, t), ga(e, !0), s && O) {
 					let t = () => {
-						e.subTree = Hi(e), O(s, e.subTree, e, i, null);
+						e.subTree = Vi(e), O(s, e.subTree, e, i, null);
 					};
 					m && p.__asyncHydrate ? p.__asyncHydrate(s, e, t) : t();
 				} else {
 					f.ce && f.ce._hasShadowRoot() && f.ce._injectChildStyle(p, e.parent ? e.parent.type : void 0);
-					let o = e.subTree = Hi(e);
+					let o = e.subTree = Vi(e);
 					v(null, o, n, r, e, i, a), t.el = o.el;
 				}
-				if (u && pa(u, i), !m && (o = c && c.onVnodeMounted)) {
+				if (u && fa(u, i), !m && (o = c && c.onVnodeMounted)) {
 					let e = t;
-					pa(() => Ka(o, d, e), i);
+					fa(() => Ga(o, d, e), i);
 				}
-				(t.shapeFlag & 256 || d && Lr(d.vnode) && d.vnode.shapeFlag & 256) && e.a && pa(e.a, i), e.isMounted = !0, t = n = r = null;
+				(t.shapeFlag & 256 || d && Ir(d.vnode) && d.vnode.shapeFlag & 256) && e.a && fa(e.a, i), e.isMounted = !0, t = n = r = null;
 			}
 		};
 		e.scope.on();
 		let c = e.effect = new Ne(s);
 		e.scope.off();
 		let l = e.update = c.run.bind(c), u = e.job = c.runIfDirty.bind(c);
-		u.i = e, u.id = e.uid, c.scheduler = () => Mn(u), _a(e, !0), l();
+		u.i = e, u.id = e.uid, c.scheduler = () => jn(u), ga(e, !0), l();
 	}, de = (e, t, n) => {
 		t.component = e;
 		let r = e.vnode.props;
-		e.vnode = t, e.next = null, $i(e, t.props, r, n), fa(e, t.children, n), Je(), Fn(e), Ye();
+		e.vnode = t, e.next = null, Qi(e, t.props, r, n), da(e, t.children, n), Je(), Pn(e), Ye();
 	}, pe = (e, t, n, r, i, a, o, s, c = !1) => {
 		let l = e && e.children, u = e ? e.shapeFlag : 0, d = t.children, { patchFlag: f, shapeFlag: m } = t;
 		if (f > 0) {
@@ -2366,34 +2363,34 @@ function ha(e, i) {
 		e ||= n, t ||= n;
 		let u = e.length, d = t.length, f = Math.min(u, d), p;
 		for (p = 0; p < f; p++) {
-			let n = t[p] = l ? Wa(t[p]) : Ua(t[p]);
+			let n = t[p] = l ? Ua(t[p]) : Ha(t[p]);
 			v(e[p], n, r, null, a, o, s, c, l);
 		}
 		u > d ? be(e, a, o, !0, !1, f) : T(t, r, i, a, o, s, c, l, f);
 	}, he = (e, t, r, i, a, o, s, c, l) => {
 		let u = 0, d = t.length, f = e.length - 1, p = d - 1;
 		for (; u <= f && u <= p;) {
-			let n = e[u], i = t[u] = l ? Wa(t[u]) : Ua(t[u]);
-			if (Ia(n, i)) v(n, i, r, null, a, o, s, c, l);
+			let n = e[u], i = t[u] = l ? Ua(t[u]) : Ha(t[u]);
+			if (Fa(n, i)) v(n, i, r, null, a, o, s, c, l);
 			else break;
 			u++;
 		}
 		for (; u <= f && u <= p;) {
-			let n = e[f], i = t[p] = l ? Wa(t[p]) : Ua(t[p]);
-			if (Ia(n, i)) v(n, i, r, null, a, o, s, c, l);
+			let n = e[f], i = t[p] = l ? Ua(t[p]) : Ha(t[p]);
+			if (Fa(n, i)) v(n, i, r, null, a, o, s, c, l);
 			else break;
 			f--, p--;
 		}
 		if (u > f) {
 			if (u <= p) {
 				let e = p + 1, n = e < d ? t[e].el : i;
-				for (; u <= p;) v(null, t[u] = l ? Wa(t[u]) : Ua(t[u]), r, n, a, o, s, c, l), u++;
+				for (; u <= p;) v(null, t[u] = l ? Ua(t[u]) : Ha(t[u]), r, n, a, o, s, c, l), u++;
 			}
 		} else if (u > p) for (; u <= f;) _e(e[u], a, o, !0), u++;
 		else {
 			let m = u, h = u, g = /* @__PURE__ */ new Map();
 			for (u = h; u <= p; u++) {
-				let e = t[u] = l ? Wa(t[u]) : Ua(t[u]);
+				let e = t[u] = l ? Ua(t[u]) : Ha(t[u]);
 				e.key != null && g.set(e.key, u);
 			}
 			let _, y = 0, b = p - h + 1, x = !1, S = 0, C = Array(b);
@@ -2406,15 +2403,15 @@ function ha(e, i) {
 				}
 				let i;
 				if (n.key != null) i = g.get(n.key);
-				else for (_ = h; _ <= p; _++) if (C[_ - h] === 0 && Ia(n, t[_])) {
+				else for (_ = h; _ <= p; _++) if (C[_ - h] === 0 && Fa(n, t[_])) {
 					i = _;
 					break;
 				}
 				i === void 0 ? _e(n, a, o, !0) : (C[i - h] = u + 1, i >= S ? S = i : x = !0, v(n, t[i], r, null, a, o, s, c, l), y++);
 			}
-			let w = x ? ba(C) : n;
+			let w = x ? ya(C) : n;
 			for (_ = w.length - 1, u = b - 1; u >= 0; u--) {
-				let e = h + u, n = t[e], f = t[e + 1], p = e + 1 < d ? f.el || Ca(f) : i;
+				let e = h + u, n = t[e], f = t[e + 1], p = e + 1 < d ? f.el || Sa(f) : i;
 				C[u] === 0 ? v(null, n, r, p, a, o, s, c, l) : x && (_ < 0 || u !== w[_] ? ge(n, r, p, 2) : _--);
 			}
 		}
@@ -2438,16 +2435,17 @@ function ha(e, i) {
 			o(e.anchor, t, n);
 			return;
 		}
-		if (c === Oa) {
+		if (c === Da) {
 			S(e, t, n);
 			return;
 		}
-		if (r !== 2 && d & 1 && l) if (r === 0) l.beforeEnter(a), o(a, t, n), pa(() => l.enter(a), i);
+		if (r !== 2 && d & 1 && l) if (r === 0) l.persisted && !a[fr] ? o(a, t, n) : (l.beforeEnter(a), o(a, t, n), fa(() => l.enter(a), i));
 		else {
 			let { leave: r, delayLeave: i, afterLeave: c } = l, u = () => {
 				e.ctx.isUnmounted ? s(a) : o(a, t, n);
 			}, d = () => {
-				a._isLeaving && a[pr](!0), r(a, () => {
+				let e = a._isLeaving || !!a[fr];
+				a._isLeaving && a[fr](!0), l.persisted && !e ? u() : r(a, () => {
 					u(), c && c();
 				});
 			};
@@ -2456,22 +2454,22 @@ function ha(e, i) {
 		else o(a, t, n);
 	}, _e = (e, t, n, r = !1, i = !1) => {
 		let { type: a, props: o, ref: s, children: c, dynamicChildren: l, shapeFlag: u, patchFlag: d, dirs: f, cacheIndex: p, memo: m } = e;
-		if (d === -2 && (i = !1), s != null && (Je(), Nr(s, null, n, e, !0), Ye()), p != null && (t.renderCache[p] = void 0), u & 256) {
+		if (d === -2 && (i = !1), s != null && (Je(), Mr(s, null, n, e, !0), Ye()), p != null && (t.renderCache[p] = void 0), u & 256) {
 			t.ctx.deactivate(e);
 			return;
 		}
-		let h = u & 1 && f, g = !Lr(e), _;
-		if (g && (_ = o && o.onVnodeBeforeUnmount) && Ka(_, t, e), u & 6) ye(e.component, n, r);
+		let h = u & 1 && f, g = !Ir(e), _;
+		if (g && (_ = o && o.onVnodeBeforeUnmount) && Ga(_, t, e), u & 6) ye(e.component, n, r);
 		else {
 			if (u & 128) {
 				e.suspense.unmount(n, r);
 				return;
 			}
-			h && Hn(e, null, t, "beforeUnmount"), u & 64 ? e.type.remove(e, t, n, we, r) : l && !l.hasOnce && (a !== L || d > 0 && d & 64) ? be(l, t, n, !1, !0) : (a === L && d & 384 || !i && u & 16) && be(c, t, n), r && D(e);
+			h && Vn(e, null, t, "beforeUnmount"), u & 64 ? e.type.remove(e, t, n, we, r) : l && !l.hasOnce && (a !== L || d > 0 && d & 64) ? be(l, t, n, !1, !0) : (a === L && d & 384 || !i && u & 16) && be(c, t, n), r && D(e);
 		}
 		let v = m != null && p == null;
-		(g && (_ = o && o.onVnodeUnmounted) || h || v) && pa(() => {
-			_ && Ka(_, t, e), h && Hn(e, null, t, "unmounted"), v && (e.el = null);
+		(g && (_ = o && o.onVnodeUnmounted) || h || v) && fa(() => {
+			_ && Ga(_, t, e), h && Vn(e, null, t, "unmounted"), v && (e.el = null);
 		}, n);
 	}, D = (e) => {
 		let { type: t, el: n, anchor: r, transition: i } = e;
@@ -2479,7 +2477,7 @@ function ha(e, i) {
 			ve(n, r);
 			return;
 		}
-		if (t === Oa) {
+		if (t === Da) {
 			C(e);
 			return;
 		}
@@ -2496,7 +2494,7 @@ function ha(e, i) {
 		s(t);
 	}, ye = (e, t, n) => {
 		let { bum: r, scope: i, job: a, subTree: o, um: s, m: c, a: l } = e;
-		Sa(c), Sa(l), r && se(r), i.stop(), a && (a.flags |= 8, _e(o, e, t, n)), s && pa(s, t), pa(() => {
+		xa(c), xa(l), r && se(r), i.stop(), a && (a.flags |= 8, _e(o, e, t, n)), s && fa(s, t), fa(() => {
 			e.isUnmounted = !0;
 		}, t);
 	}, be = (e, t, n, r = !1, i = !1, a = 0) => {
@@ -2504,11 +2502,11 @@ function ha(e, i) {
 	}, xe = (e) => {
 		if (e.shapeFlag & 6) return xe(e.component.subTree);
 		if (e.shapeFlag & 128) return e.suspense.next();
-		let t = h(e.anchor || e.el), n = t && t[er];
+		let t = h(e.anchor || e.el), n = t && t[$n];
 		return n ? h(n) : t;
 	}, Se = !1, Ce = (e, t, n) => {
 		let r;
-		e == null ? t._vnode && (_e(t._vnode, null, null, !0), r = t._vnode.component) : v(t._vnode || null, e, t, null, null, null, n), t._vnode = e, Se ||= (Se = !0, Fn(r), In(), !1);
+		e == null ? t._vnode && (_e(t._vnode, null, null, !0), r = t._vnode.component) : v(t._vnode || null, e, t, null, null, null, n), t._vnode = e, Se ||= (Se = !0, Pn(r), Fn(), !1);
 	}, we = {
 		p: v,
 		um: _e,
@@ -2524,26 +2522,26 @@ function ha(e, i) {
 	return i && ([Te, O] = i(we)), {
 		render: Ce,
 		hydrate: Te,
-		createApp: Fi(Ce, Te)
+		createApp: Pi(Ce, Te)
 	};
 }
-function ga({ type: e, props: t }, n) {
+function ha({ type: e, props: t }, n) {
 	return n === "svg" && e === "foreignObject" || n === "mathml" && e === "annotation-xml" && t && t.encoding && t.encoding.includes("html") ? void 0 : n;
 }
-function _a({ effect: e, job: t }, n) {
+function ga({ effect: e, job: t }, n) {
 	n ? (e.flags |= 32, t.flags |= 4) : (e.flags &= -33, t.flags &= -5);
 }
-function va(e, t) {
+function _a(e, t) {
 	return (!e || e && !e.pendingBranch) && t && !t.persisted;
 }
-function ya(e, t, n = !1) {
+function va(e, t, n = !1) {
 	let r = e.children, i = t.children;
 	if (d(r) && d(i)) for (let e = 0; e < r.length; e++) {
 		let t = r[e], a = i[e];
-		a.shapeFlag & 1 && !a.dynamicChildren && ((a.patchFlag <= 0 || a.patchFlag === 32) && (a = i[e] = Wa(i[e]), a.el = t.el), !n && a.patchFlag !== -2 && ya(t, a)), a.type === Ea && (a.patchFlag === -1 && (a = i[e] = Wa(a)), a.el = t.el), a.type === Da && !a.el && (a.el = t.el);
+		a.shapeFlag & 1 && !a.dynamicChildren && ((a.patchFlag <= 0 || a.patchFlag === 32) && (a = i[e] = Ua(i[e]), a.el = t.el), !n && a.patchFlag !== -2 && va(t, a)), a.type === Ta && (a.patchFlag === -1 && (a = i[e] = Ua(a)), a.el = t.el), a.type === Ea && !a.el && (a.el = t.el);
 	}
 }
-function ba(e) {
+function ya(e) {
 	let t = e.slice(), n = [0], r, i, a, o, s, c = e.length;
 	for (r = 0; r < c; r++) {
 		let c = e[r];
@@ -2559,49 +2557,49 @@ function ba(e) {
 	for (a = n.length, o = n[a - 1]; a-- > 0;) n[a] = o, o = t[o];
 	return n;
 }
-function xa(e) {
+function ba(e) {
 	let t = e.subTree.component;
-	if (t) return t.asyncDep && !t.asyncResolved ? t : xa(t);
+	if (t) return t.asyncDep && !t.asyncResolved ? t : ba(t);
 }
-function Sa(e) {
+function xa(e) {
 	if (e) for (let t = 0; t < e.length; t++) e[t].flags |= 8;
 }
-function Ca(e) {
+function Sa(e) {
 	if (e.placeholder) return e.placeholder;
 	let t = e.component;
-	return t ? Ca(t.subTree) : null;
+	return t ? Sa(t.subTree) : null;
 }
-var wa = (e) => e.__isSuspense;
-function Ta(e, t) {
-	t && t.pendingBranch ? d(e) ? t.effects.push(...e) : t.effects.push(e) : Pn(e);
+var Ca = (e) => e.__isSuspense;
+function wa(e, t) {
+	t && t.pendingBranch ? d(e) ? t.effects.push(...e) : t.effects.push(e) : Nn(e);
 }
-var L = /* @__PURE__ */ Symbol.for("v-fgt"), Ea = /* @__PURE__ */ Symbol.for("v-txt"), Da = /* @__PURE__ */ Symbol.for("v-cmt"), Oa = /* @__PURE__ */ Symbol.for("v-stc"), ka = [], Aa = null;
+var L = /* @__PURE__ */ Symbol.for("v-fgt"), Ta = /* @__PURE__ */ Symbol.for("v-txt"), Ea = /* @__PURE__ */ Symbol.for("v-cmt"), Da = /* @__PURE__ */ Symbol.for("v-stc"), Oa = [], ka = null;
 function R(e = !1) {
-	ka.push(Aa = e ? null : []);
+	Oa.push(ka = e ? null : []);
 }
-function ja() {
-	ka.pop(), Aa = ka[ka.length - 1] || null;
+function Aa() {
+	Oa.pop(), ka = Oa[Oa.length - 1] || null;
 }
-var Ma = 1;
-function Na(e, t = !1) {
-	Ma += e, e < 0 && Aa && t && (Aa.hasOnce = !0);
+var ja = 1;
+function Ma(e, t = !1) {
+	ja += e, e < 0 && ka && t && (ka.hasOnce = !0);
 }
-function Pa(e) {
-	return e.dynamicChildren = Ma > 0 ? Aa || n : null, ja(), Ma > 0 && Aa && Aa.push(e), e;
+function Na(e) {
+	return e.dynamicChildren = ja > 0 ? ka || n : null, Aa(), ja > 0 && ka && ka.push(e), e;
 }
 function z(e, t, n, r, i, a) {
-	return Pa(V(e, t, n, r, i, a, !0));
+	return Na(V(e, t, n, r, i, a, !0));
 }
 function B(e, t, n, r, i) {
-	return Pa(H(e, t, n, r, i, !0));
+	return Na(H(e, t, n, r, i, !0));
 }
-function Fa(e) {
+function Pa(e) {
 	return e ? e.__v_isVNode === !0 : !1;
 }
-function Ia(e, t) {
+function Fa(e, t) {
 	return e.type === t.type && e.key === t.key;
 }
-var La = ({ key: e }) => e ?? null, Ra = ({ ref: e, ref_key: t, ref_for: n }) => (typeof e == "number" && (e = "" + e), e == null ? null : g(e) || /* @__PURE__ */ M(e) || h(e) ? {
+var Ia = ({ key: e }) => e ?? null, La = ({ ref: e, ref_key: t, ref_for: n }) => (typeof e == "number" && (e = "" + e), e == null ? null : g(e) || /* @__PURE__ */ M(e) || h(e) ? {
 	i: N,
 	r: e,
 	k: t,
@@ -2613,9 +2611,9 @@ function V(e, t = null, n = null, r = 0, i = null, a = e === L ? 0 : 1, o = !1, 
 		__v_skip: !0,
 		type: e,
 		props: t,
-		key: t && La(t),
-		ref: t && Ra(t),
-		scopeId: zn,
+		key: t && Ia(t),
+		ref: t && La(t),
+		scopeId: Rn,
 		slotScopeIds: null,
 		children: n,
 		component: null,
@@ -2637,33 +2635,33 @@ function V(e, t = null, n = null, r = 0, i = null, a = e === L ? 0 : 1, o = !1, 
 		appContext: null,
 		ctx: N
 	};
-	return s ? (Ga(c, n), a & 128 && e.normalize(c)) : n && (c.shapeFlag |= g(n) ? 8 : 16), Ma > 0 && !o && Aa && (c.patchFlag > 0 || a & 6) && c.patchFlag !== 32 && Aa.push(c), c;
+	return s ? (Wa(c, n), a & 128 && e.normalize(c)) : n && (c.shapeFlag |= g(n) ? 8 : 16), ja > 0 && !o && ka && (c.patchFlag > 0 || a & 6) && c.patchFlag !== 32 && ka.push(c), c;
 }
-var H = za;
-function za(e, t = null, n = null, r = 0, i = null, a = !1) {
-	if ((!e || e === ai) && (e = Da), Fa(e)) {
-		let r = Va(e, t, !0);
-		return n && Ga(r, n), Ma > 0 && !a && Aa && (r.shapeFlag & 6 ? Aa[Aa.indexOf(e)] = r : Aa.push(r)), r.patchFlag = -2, r;
+var H = Ra;
+function Ra(e, t = null, n = null, r = 0, i = null, a = !1) {
+	if ((!e || e === ii) && (e = Ea), Pa(e)) {
+		let r = Ba(e, t, !0);
+		return n && Wa(r, n), ja > 0 && !a && ka && (r.shapeFlag & 6 ? ka[ka.indexOf(e)] = r : ka.push(r)), r.patchFlag = -2, r;
 	}
-	if (mo(e) && (e = e.__vccOpts), t) {
-		t = Ba(t);
+	if (po(e) && (e = e.__vccOpts), t) {
+		t = za(t);
 		let { class: e, style: n } = t;
-		e && !g(e) && (t.class = D(e)), v(n) && (/* @__PURE__ */ Yt(n) && !d(n) && (n = s({}, n)), t.style = pe(n));
+		e && !g(e) && (t.class = D(e)), v(n) && (/* @__PURE__ */ Jt(n) && !d(n) && (n = s({}, n)), t.style = pe(n));
 	}
-	let o = g(e) ? 1 : wa(e) ? 128 : tr(e) ? 64 : v(e) ? 4 : h(e) ? 2 : 0;
+	let o = g(e) ? 1 : Ca(e) ? 128 : er(e) ? 64 : v(e) ? 4 : h(e) ? 2 : 0;
 	return V(e, t, n, r, i, o, a, !0);
 }
-function Ba(e) {
-	return e ? /* @__PURE__ */ Yt(e) || Zi(e) ? s({}, e) : e : null;
+function za(e) {
+	return e ? /* @__PURE__ */ Jt(e) || Xi(e) ? s({}, e) : e : null;
 }
-function Va(e, t, n = !1, r = !1) {
+function Ba(e, t, n = !1, r = !1) {
 	let { props: i, ref: a, patchFlag: o, children: s, transition: c } = e, l = t ? W(i || {}, t) : i, u = {
 		__v_isVNode: !0,
 		__v_skip: !0,
 		type: e.type,
 		props: l,
-		key: l && La(l),
-		ref: t && t.ref ? n && a ? d(a) ? a.concat(Ra(t)) : [a, Ra(t)] : Ra(t) : a,
+		key: l && Ia(l),
+		ref: t && t.ref ? n && a ? d(a) ? a.concat(La(t)) : [a, La(t)] : La(t) : a,
 		scopeId: e.scopeId,
 		slotScopeIds: e.slotScopeIds,
 		children: s,
@@ -2680,45 +2678,45 @@ function Va(e, t, n = !1, r = !1) {
 		transition: c,
 		component: e.component,
 		suspense: e.suspense,
-		ssContent: e.ssContent && Va(e.ssContent),
-		ssFallback: e.ssFallback && Va(e.ssFallback),
+		ssContent: e.ssContent && Ba(e.ssContent),
+		ssFallback: e.ssFallback && Ba(e.ssFallback),
 		placeholder: e.placeholder,
 		el: e.el,
 		anchor: e.anchor,
 		ctx: e.ctx,
 		ce: e.ce
 	};
-	return c && r && Er(u, c.clone(u)), u;
+	return c && r && Tr(u, c.clone(u)), u;
 }
-function Ha(e = " ", t = 0) {
-	return H(Ea, null, e, t);
+function Va(e = " ", t = 0) {
+	return H(Ta, null, e, t);
 }
 function U(e = "", t = !1) {
-	return t ? (R(), B(Da, null, e)) : H(Da, null, e);
+	return t ? (R(), B(Ea, null, e)) : H(Ea, null, e);
+}
+function Ha(e) {
+	return e == null || typeof e == "boolean" ? H(Ea) : d(e) ? H(L, null, e.slice()) : Pa(e) ? Ua(e) : H(Ta, null, String(e));
 }
 function Ua(e) {
-	return e == null || typeof e == "boolean" ? H(Da) : d(e) ? H(L, null, e.slice()) : Fa(e) ? Wa(e) : H(Ea, null, String(e));
+	return e.el === null && e.patchFlag !== -1 || e.memo ? e : Ba(e);
 }
-function Wa(e) {
-	return e.el === null && e.patchFlag !== -1 || e.memo ? e : Va(e);
-}
-function Ga(e, t) {
+function Wa(e, t) {
 	let n = 0, { shapeFlag: r } = e;
 	if (t == null) t = null;
 	else if (d(t)) n = 16;
 	else if (typeof t == "object") if (r & 65) {
 		let n = t.default;
-		n && (n._c && (n._d = !1), Ga(e, n()), n._c && (n._d = !0));
+		n && (n._c && (n._d = !1), Wa(e, n()), n._c && (n._d = !0));
 		return;
 	} else {
 		n = 32;
 		let r = t._;
-		!r && !Zi(t) ? t._ctx = N : r === 3 && N && (N.slots._ === 1 ? t._ = 1 : (t._ = 2, e.patchFlag |= 1024));
+		!r && !Xi(t) ? t._ctx = N : r === 3 && N && (N.slots._ === 1 ? t._ = 1 : (t._ = 2, e.patchFlag |= 1024));
 	}
 	else h(t) ? (t = {
 		default: t,
 		_ctx: N
-	}, n = 32) : (t = String(t), r & 64 ? (n = 16, t = [Ha(t)]) : n = 8);
+	}, n = 32) : (t = String(t), r & 64 ? (n = 16, t = [Va(t)]) : n = 8);
 	e.children = t, e.shapeFlag |= n;
 }
 function W(...e) {
@@ -2734,13 +2732,13 @@ function W(...e) {
 	}
 	return t;
 }
-function Ka(e, t, n, r = null) {
-	bn(e, t, 7, [n, r]);
+function Ga(e, t, n, r = null) {
+	yn(e, t, 7, [n, r]);
 }
-var qa = Ni(), Ja = 0;
-function Ya(e, n, r) {
-	let i = e.type, a = (n ? n.appContext : e.appContext) || qa, o = {
-		uid: Ja++,
+var Ka = Mi(), qa = 0;
+function Ja(e, n, r) {
+	let i = e.type, a = (n ? n.appContext : e.appContext) || Ka, o = {
+		uid: qa++,
 		vnode: e,
 		type: i,
 		parent: n,
@@ -2767,8 +2765,8 @@ function Ya(e, n, r) {
 		renderCache: [],
 		components: null,
 		directives: null,
-		propsOptions: ra(i, a),
-		emitsOptions: Bi(i, a),
+		propsOptions: na(i, a),
+		emitsOptions: zi(i, a),
 		emit: null,
 		emitted: null,
 		propsDefaults: t,
@@ -2803,9 +2801,9 @@ function Ya(e, n, r) {
 		ec: null,
 		sp: null
 	};
-	return o.ctx = { _: o }, o.root = n ? n.root : o, o.emit = Ri.bind(null, o), e.ce && e.ce(o), o;
+	return o.ctx = { _: o }, o.root = n ? n.root : o, o.emit = Li.bind(null, o), e.ce && e.ce(o), o;
 }
-var G = null, Xa = () => G || N, Za, Qa;
+var G = null, Ya = () => G || N, Xa, Za;
 {
 	let e = fe(), t = (t, n) => {
 		let r;
@@ -2813,79 +2811,79 @@ var G = null, Xa = () => G || N, Za, Qa;
 			r.length > 1 ? r.forEach((t) => t(e)) : r[0](e);
 		};
 	};
-	Za = t("__VUE_INSTANCE_SETTERS__", (e) => G = e), Qa = t("__VUE_SSR_SETTERS__", (e) => no = e);
+	Xa = t("__VUE_INSTANCE_SETTERS__", (e) => G = e), Za = t("__VUE_SSR_SETTERS__", (e) => to = e);
 }
-var $a = (e) => {
+var Qa = (e) => {
 	let t = G;
-	return Za(e), e.scope.on(), () => {
-		e.scope.off(), Za(t);
+	return Xa(e), e.scope.on(), () => {
+		e.scope.off(), Xa(t);
 	};
-}, eo = () => {
-	G && G.scope.off(), Za(null);
+}, $a = () => {
+	G && G.scope.off(), Xa(null);
 };
-function to(e) {
+function eo(e) {
 	return e.vnode.shapeFlag & 4;
 }
-var no = !1;
-function ro(e, t = !1, n = !1) {
-	t && Qa(t);
-	let { props: r, children: i } = e.vnode, a = to(e);
-	Qi(e, r, a, t), da(e, i, n || t);
-	let o = a ? io(e, t) : void 0;
-	return t && Qa(!1), o;
+var to = !1;
+function no(e, t = !1, n = !1) {
+	t && Za(t);
+	let { props: r, children: i } = e.vnode, a = eo(e);
+	Zi(e, r, a, t), ua(e, i, n || t);
+	let o = a ? ro(e, t) : void 0;
+	return t && Za(!1), o;
 }
-function io(e, t) {
+function ro(e, t) {
 	let n = e.type;
-	e.accessCache = /* @__PURE__ */ Object.create(null), e.proxy = new Proxy(e.ctx, gi);
+	e.accessCache = /* @__PURE__ */ Object.create(null), e.proxy = new Proxy(e.ctx, hi);
 	let { setup: r } = n;
 	if (r) {
 		Je();
-		let n = e.setupContext = r.length > 1 ? uo(e) : null, i = $a(e), a = yn(r, e, 0, [e.props, n]), o = y(a);
-		if (Ye(), i(), (o || e.sp) && !Lr(e) && Ar(e), o) {
-			if (a.then(eo, eo), t) return a.then((n) => {
-				ao(e, n, t);
+		let n = e.setupContext = r.length > 1 ? lo(e) : null, i = Qa(e), a = vn(r, e, 0, [e.props, n]), o = y(a);
+		if (Ye(), i(), (o || e.sp) && !Ir(e) && kr(e), o) {
+			if (a.then($a, $a), t) return a.then((n) => {
+				io(e, n, t);
 			}).catch((t) => {
-				xn(t, e, 0);
+				bn(t, e, 0);
 			});
 			e.asyncDep = a;
-		} else ao(e, a, t);
-	} else co(e, t);
+		} else io(e, a, t);
+	} else so(e, t);
 }
-function ao(e, t, n) {
-	h(t) ? e.type.__ssrInlineRender ? e.ssrRender = t : e.render = t : v(t) && (e.setupState = sn(t)), co(e, n);
+function io(e, t, n) {
+	h(t) ? e.type.__ssrInlineRender ? e.ssrRender = t : e.render = t : v(t) && (e.setupState = on(t)), so(e, n);
 }
-var oo, so;
-function co(e, t, n) {
+var ao, oo;
+function so(e, t, n) {
 	let i = e.type;
 	if (!e.render) {
-		if (!t && oo && !i.render) {
-			let t = i.template || Ci(e).template;
+		if (!t && ao && !i.render) {
+			let t = i.template || Si(e).template;
 			if (t) {
 				let { isCustomElement: n, compilerOptions: r } = e.appContext.config, { delimiters: a, compilerOptions: o } = i;
-				i.render = oo(t, s(s({
+				i.render = ao(t, s(s({
 					isCustomElement: n,
 					delimiters: a
 				}, r), o));
 			}
 		}
-		e.render = i.render || r, so && so(e);
+		e.render = i.render || r, oo && oo(e);
 	}
 	{
-		let t = $a(e);
+		let t = Qa(e);
 		Je();
 		try {
-			yi(e);
+			vi(e);
 		} finally {
 			Ye(), t();
 		}
 	}
 }
-var lo = { get(e, t) {
+var co = { get(e, t) {
 	return at(e, "get", ""), e[t];
 } };
-function uo(e) {
+function lo(e) {
 	return {
-		attrs: new Proxy(e.attrs, lo),
+		attrs: new Proxy(e.attrs, co),
 		slots: e.slots,
 		emit: e.emit,
 		expose: (t) => {
@@ -2893,38 +2891,38 @@ function uo(e) {
 		}
 	};
 }
-function fo(e) {
-	return e.exposed ? e.exposeProxy ||= new Proxy(sn(Xt(e.exposed)), {
+function uo(e) {
+	return e.exposed ? e.exposeProxy ||= new Proxy(on(Yt(e.exposed)), {
 		get(t, n) {
 			if (n in t) return t[n];
-			if (n in mi) return mi[n](e);
+			if (n in pi) return pi[n](e);
 		},
 		has(e, t) {
-			return t in e || t in mi;
+			return t in e || t in pi;
 		}
 	}) : e.proxy;
 }
-function po(e, t = !0) {
+function fo(e, t = !0) {
 	return h(e) ? e.displayName || e.name : e.name || t && e.__name;
 }
-function mo(e) {
+function po(e) {
 	return h(e) && "__vccOpts" in e;
 }
-var ho = (e, t) => /* @__PURE__ */ fn(e, t, no);
-function go(e, t, n) {
+var mo = (e, t) => /* @__PURE__ */ dn(e, t, to);
+function ho(e, t, n) {
 	try {
-		Na(-1);
+		Ma(-1);
 		let r = arguments.length;
-		return r === 2 ? v(t) && !d(t) ? Fa(t) ? H(e, null, [t]) : H(e, t) : H(e, null, t) : (r > 3 ? n = Array.prototype.slice.call(arguments, 2) : r === 3 && Fa(n) && (n = [n]), H(e, t, n));
+		return r === 2 ? v(t) && !d(t) ? Pa(t) ? H(e, null, [t]) : H(e, t) : H(e, null, t) : (r > 3 ? n = Array.prototype.slice.call(arguments, 2) : r === 3 && Pa(n) && (n = [n]), H(e, t, n));
 	} finally {
-		Na(1);
+		Ma(1);
 	}
 }
-var _o = "3.5.34", vo = void 0, yo = typeof window < "u" && window.trustedTypes;
-if (yo) try {
-	vo = /* @__PURE__ */ yo.createPolicy("vue", { createHTML: (e) => e });
+var go = "3.5.35", _o = void 0, vo = typeof window < "u" && window.trustedTypes;
+if (vo) try {
+	_o = /* @__PURE__ */ vo.createPolicy("vue", { createHTML: (e) => e });
 } catch {}
-var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/svg", So = "http://www.w3.org/1998/Math/MathML", Co = typeof document < "u" ? document : null, wo = Co && /* @__PURE__ */ Co.createElement("template"), To = {
+var yo = _o ? (e) => _o.createHTML(e) : (e) => e, bo = "http://www.w3.org/2000/svg", xo = "http://www.w3.org/1998/Math/MathML", So = typeof document < "u" ? document : null, Co = So && /* @__PURE__ */ So.createElement("template"), wo = {
 	insert: (e, t, n) => {
 		t.insertBefore(e, n || null);
 	},
@@ -2933,11 +2931,11 @@ var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/s
 		t && t.removeChild(e);
 	},
 	createElement: (e, t, n, r) => {
-		let i = t === "svg" ? Co.createElementNS(xo, e) : t === "mathml" ? Co.createElementNS(So, e) : n ? Co.createElement(e, { is: n }) : Co.createElement(e);
+		let i = t === "svg" ? So.createElementNS(bo, e) : t === "mathml" ? So.createElementNS(xo, e) : n ? So.createElement(e, { is: n }) : So.createElement(e);
 		return e === "select" && r && r.multiple != null && i.setAttribute("multiple", r.multiple), i;
 	},
-	createText: (e) => Co.createTextNode(e),
-	createComment: (e) => Co.createComment(e),
+	createText: (e) => So.createTextNode(e),
+	createComment: (e) => So.createComment(e),
 	setText: (e, t) => {
 		e.nodeValue = t;
 	},
@@ -2946,7 +2944,7 @@ var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/s
 	},
 	parentNode: (e) => e.parentNode,
 	nextSibling: (e) => e.nextSibling,
-	querySelector: (e) => Co.querySelector(e),
+	querySelector: (e) => So.querySelector(e),
 	setScopeId(e, t) {
 		e.setAttribute(t, "");
 	},
@@ -2954,8 +2952,8 @@ var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/s
 		let o = n ? n.previousSibling : t.lastChild;
 		if (i && (i === a || i.nextSibling)) for (; t.insertBefore(i.cloneNode(!0), n), !(i === a || !(i = i.nextSibling)););
 		else {
-			wo.innerHTML = bo(r === "svg" ? `<svg>${e}</svg>` : r === "mathml" ? `<math>${e}</math>` : e);
-			let i = wo.content;
+			Co.innerHTML = yo(r === "svg" ? `<svg>${e}</svg>` : r === "mathml" ? `<math>${e}</math>` : e);
+			let i = Co.content;
 			if (r === "svg" || r === "mathml") {
 				let e = i.firstChild;
 				for (; e.firstChild;) i.appendChild(e.firstChild);
@@ -2965,7 +2963,7 @@ var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/s
 		}
 		return [o ? o.nextSibling : t.firstChild, n ? n.previousSibling : t.lastChild];
 	}
-}, Eo = "transition", Do = "animation", Oo = /* @__PURE__ */ Symbol("_vtc"), ko = {
+}, To = "transition", Eo = "animation", Do = /* @__PURE__ */ Symbol("_vtc"), Oo = {
 	name: String,
 	type: String,
 	css: {
@@ -2986,81 +2984,81 @@ var bo = vo ? (e) => vo.createHTML(e) : (e) => e, xo = "http://www.w3.org/2000/s
 	leaveFromClass: String,
 	leaveActiveClass: String,
 	leaveToClass: String
-}, Ao = /* @__PURE__ */ s({}, _r, ko), jo = /* @__PURE__ */ ((e) => (e.displayName = "Transition", e.props = Ao, e))((e, { slots: t }) => go(xr, Po(e), t)), Mo = (e, t = []) => {
+}, ko = /* @__PURE__ */ s({}, gr, Oo), Ao = /* @__PURE__ */ ((e) => (e.displayName = "Transition", e.props = ko, e))((e, { slots: t }) => ho(br, No(e), t)), jo = (e, t = []) => {
 	d(e) ? e.forEach((e) => e(...t)) : e && e(...t);
-}, No = (e) => e ? d(e) ? e.some((e) => e.length > 1) : e.length > 1 : !1;
-function Po(e) {
+}, Mo = (e) => e ? d(e) ? e.some((e) => e.length > 1) : e.length > 1 : !1;
+function No(e) {
 	let t = {};
-	for (let n in e) n in ko || (t[n] = e[n]);
+	for (let n in e) n in Oo || (t[n] = e[n]);
 	if (e.css === !1) return t;
-	let { name: n = "v", type: r, duration: i, enterFromClass: a = `${n}-enter-from`, enterActiveClass: o = `${n}-enter-active`, enterToClass: c = `${n}-enter-to`, appearFromClass: l = a, appearActiveClass: u = o, appearToClass: d = c, leaveFromClass: f = `${n}-leave-from`, leaveActiveClass: p = `${n}-leave-active`, leaveToClass: m = `${n}-leave-to` } = e, h = Fo(i), g = h && h[0], _ = h && h[1], { onBeforeEnter: v, onEnter: y, onEnterCancelled: b, onLeave: x, onLeaveCancelled: S, onBeforeAppear: C = v, onAppear: w = y, onAppearCancelled: ee = b } = t, te = (e, t, n, r) => {
-		e._enterCancelled = r, Ro(e, t ? d : c), Ro(e, t ? u : o), n && n();
+	let { name: n = "v", type: r, duration: i, enterFromClass: a = `${n}-enter-from`, enterActiveClass: o = `${n}-enter-active`, enterToClass: c = `${n}-enter-to`, appearFromClass: l = a, appearActiveClass: u = o, appearToClass: d = c, leaveFromClass: f = `${n}-leave-from`, leaveActiveClass: p = `${n}-leave-active`, leaveToClass: m = `${n}-leave-to` } = e, h = Po(i), g = h && h[0], _ = h && h[1], { onBeforeEnter: v, onEnter: y, onEnterCancelled: b, onLeave: x, onLeaveCancelled: S, onBeforeAppear: C = v, onAppear: w = y, onAppearCancelled: ee = b } = t, te = (e, t, n, r) => {
+		e._enterCancelled = r, Lo(e, t ? d : c), Lo(e, t ? u : o), n && n();
 	}, ne = (e, t) => {
-		e._isLeaving = !1, Ro(e, f), Ro(e, m), Ro(e, p), t && t();
+		e._isLeaving = !1, Lo(e, f), Lo(e, m), Lo(e, p), t && t();
 	}, T = (e) => (t, n) => {
 		let i = e ? w : y, o = () => te(t, e, n);
-		Mo(i, [t, o]), zo(() => {
-			Ro(t, e ? l : a), Lo(t, e ? d : c), No(i) || Vo(t, r, g, o);
+		jo(i, [t, o]), Ro(() => {
+			Lo(t, e ? l : a), Io(t, e ? d : c), Mo(i) || Bo(t, r, g, o);
 		});
 	};
 	return s(t, {
 		onBeforeEnter(e) {
-			Mo(v, [e]), Lo(e, a), Lo(e, o);
+			jo(v, [e]), Io(e, a), Io(e, o);
 		},
 		onBeforeAppear(e) {
-			Mo(C, [e]), Lo(e, l), Lo(e, u);
+			jo(C, [e]), Io(e, l), Io(e, u);
 		},
 		onEnter: T(!1),
 		onAppear: T(!0),
 		onLeave(e, t) {
 			e._isLeaving = !0;
 			let n = () => ne(e, t);
-			Lo(e, f), e._enterCancelled ? (Lo(e, p), Go(e)) : (Go(e), Lo(e, p)), zo(() => {
-				e._isLeaving && (Ro(e, f), Lo(e, m), No(x) || Vo(e, r, _, n));
-			}), Mo(x, [e, n]);
+			Io(e, f), e._enterCancelled ? (Io(e, p), Wo(e)) : (Wo(e), Io(e, p)), Ro(() => {
+				e._isLeaving && (Lo(e, f), Io(e, m), Mo(x) || Bo(e, r, _, n));
+			}), jo(x, [e, n]);
 		},
 		onEnterCancelled(e) {
-			te(e, !1, void 0, !0), Mo(b, [e]);
+			te(e, !1, void 0, !0), jo(b, [e]);
 		},
 		onAppearCancelled(e) {
-			te(e, !0, void 0, !0), Mo(ee, [e]);
+			te(e, !0, void 0, !0), jo(ee, [e]);
 		},
 		onLeaveCancelled(e) {
-			ne(e), Mo(S, [e]);
+			ne(e), jo(S, [e]);
 		}
 	});
 }
-function Fo(e) {
+function Po(e) {
 	if (e == null) return null;
-	if (v(e)) return [Io(e.enter), Io(e.leave)];
+	if (v(e)) return [Fo(e.enter), Fo(e.leave)];
 	{
-		let t = Io(e);
+		let t = Fo(e);
 		return [t, t];
 	}
 }
-function Io(e) {
+function Fo(e) {
 	return ue(e);
 }
+function Io(e, t) {
+	t.split(/\s+/).forEach((t) => t && e.classList.add(t)), (e[Do] || (e[Do] = /* @__PURE__ */ new Set())).add(t);
+}
 function Lo(e, t) {
-	t.split(/\s+/).forEach((t) => t && e.classList.add(t)), (e[Oo] || (e[Oo] = /* @__PURE__ */ new Set())).add(t);
-}
-function Ro(e, t) {
 	t.split(/\s+/).forEach((t) => t && e.classList.remove(t));
-	let n = e[Oo];
-	n && (n.delete(t), n.size || (e[Oo] = void 0));
+	let n = e[Do];
+	n && (n.delete(t), n.size || (e[Do] = void 0));
 }
-function zo(e) {
+function Ro(e) {
 	requestAnimationFrame(() => {
 		requestAnimationFrame(e);
 	});
 }
-var Bo = 0;
-function Vo(e, t, n, r) {
-	let i = e._endId = ++Bo, a = () => {
+var zo = 0;
+function Bo(e, t, n, r) {
+	let i = e._endId = ++zo, a = () => {
 		i === e._endId && r();
 	};
 	if (n != null) return setTimeout(a, n);
-	let { type: o, timeout: s, propCount: c } = Ho(e, t);
+	let { type: o, timeout: s, propCount: c } = Vo(e, t);
 	if (!o) return r();
 	let l = o + "end", u = 0, d = () => {
 		e.removeEventListener(l, f), a();
@@ -3071,10 +3069,10 @@ function Vo(e, t, n, r) {
 		u < c && d();
 	}, s + 1), e.addEventListener(l, f);
 }
-function Ho(e, t) {
-	let n = window.getComputedStyle(e), r = (e) => (n[e] || "").split(", "), i = r(`${Eo}Delay`), a = r(`${Eo}Duration`), o = Uo(i, a), s = r(`${Do}Delay`), c = r(`${Do}Duration`), l = Uo(s, c), u = null, d = 0, f = 0;
-	t === Eo ? o > 0 && (u = Eo, d = o, f = a.length) : t === Do ? l > 0 && (u = Do, d = l, f = c.length) : (d = Math.max(o, l), u = d > 0 ? o > l ? Eo : Do : null, f = u ? u === Eo ? a.length : c.length : 0);
-	let p = u === Eo && /\b(?:transform|all)(?:,|$)/.test(r(`${Eo}Property`).toString());
+function Vo(e, t) {
+	let n = window.getComputedStyle(e), r = (e) => (n[e] || "").split(", "), i = r(`${To}Delay`), a = r(`${To}Duration`), o = Ho(i, a), s = r(`${Eo}Delay`), c = r(`${Eo}Duration`), l = Ho(s, c), u = null, d = 0, f = 0;
+	t === To ? o > 0 && (u = To, d = o, f = a.length) : t === Eo ? l > 0 && (u = Eo, d = l, f = c.length) : (d = Math.max(o, l), u = d > 0 ? o > l ? To : Eo : null, f = u ? u === To ? a.length : c.length : 0);
+	let p = u === To && /\b(?:transform|all)(?:,|$)/.test(r(`${To}Property`).toString());
 	return {
 		type: u,
 		timeout: d,
@@ -3082,98 +3080,98 @@ function Ho(e, t) {
 		hasTransform: p
 	};
 }
-function Uo(e, t) {
+function Ho(e, t) {
 	for (; e.length < t.length;) e = e.concat(e);
-	return Math.max(...t.map((t, n) => Wo(t) + Wo(e[n])));
+	return Math.max(...t.map((t, n) => Uo(t) + Uo(e[n])));
 }
-function Wo(e) {
+function Uo(e) {
 	return e === "auto" ? 0 : Number(e.slice(0, -1).replace(",", ".")) * 1e3;
 }
-function Go(e) {
+function Wo(e) {
 	return (e ? e.ownerDocument : document).body.offsetHeight;
 }
-function Ko(e, t, n) {
-	let r = e[Oo];
+function Go(e, t, n) {
+	let r = e[Do];
 	r && (t = (t ? [t, ...r] : [...r]).join(" ")), t == null ? e.removeAttribute("class") : n ? e.setAttribute("class", t) : e.className = t;
 }
-var qo = /* @__PURE__ */ Symbol("_vod"), Jo = /* @__PURE__ */ Symbol("_vsh"), Yo = {
+var Ko = /* @__PURE__ */ Symbol("_vod"), qo = /* @__PURE__ */ Symbol("_vsh"), Jo = {
 	name: "show",
 	beforeMount(e, { value: t }, { transition: n }) {
-		e[qo] = e.style.display === "none" ? "" : e.style.display, n && t ? n.beforeEnter(e) : Xo(e, t);
+		e[Ko] = e.style.display === "none" ? "" : e.style.display, n && t ? n.beforeEnter(e) : Yo(e, t);
 	},
 	mounted(e, { value: t }, { transition: n }) {
 		n && t && n.enter(e);
 	},
 	updated(e, { value: t, oldValue: n }, { transition: r }) {
-		!t != !n && (r ? t ? (r.beforeEnter(e), Xo(e, !0), r.enter(e)) : r.leave(e, () => {
-			Xo(e, !1);
-		}) : Xo(e, t));
+		!t != !n && (r ? t ? (r.beforeEnter(e), Yo(e, !0), r.enter(e)) : r.leave(e, () => {
+			Yo(e, !1);
+		}) : Yo(e, t));
 	},
 	beforeUnmount(e, { value: t }) {
-		Xo(e, t);
+		Yo(e, t);
 	}
 };
-function Xo(e, t) {
-	e.style.display = t ? e[qo] : "none", e[Jo] = !t;
+function Yo(e, t) {
+	e.style.display = t ? e[Ko] : "none", e[qo] = !t;
 }
-var Zo = /* @__PURE__ */ Symbol(""), Qo = /(?:^|;)\s*display\s*:/;
-function $o(e, t, n) {
+var Xo = /* @__PURE__ */ Symbol(""), Zo = /(?:^|;)\s*display\s*:/;
+function Qo(e, t, n) {
 	let r = e.style, i = g(n), a = !1;
 	if (n && !i) {
 		if (t) if (g(t)) for (let e of t.split(";")) {
 			let t = e.slice(0, e.indexOf(":")).trim();
-			n[t] ?? ts(r, t, "");
+			n[t] ?? es(r, t, "");
 		}
-		else for (let e in t) n[e] ?? ts(r, e, "");
+		else for (let e in t) n[e] ?? es(r, e, "");
 		for (let i in n) {
 			i === "display" && (a = !0);
 			let o = n[i];
-			o == null ? ts(r, i, "") : as(e, i, !g(t) && t ? t[i] : void 0, o) || ts(r, i, o);
+			o == null ? es(r, i, "") : is(e, i, !g(t) && t ? t[i] : void 0, o) || es(r, i, o);
 		}
 	} else if (i) {
 		if (t !== n) {
-			let e = r[Zo];
-			e && (n += ";" + e), r.cssText = n, a = Qo.test(n);
+			let e = r[Xo];
+			e && (n += ";" + e), r.cssText = n, a = Zo.test(n);
 		}
 	} else t && e.removeAttribute("style");
-	qo in e && (e[qo] = a ? r.display : "", e[Jo] && (r.display = "none"));
+	Ko in e && (e[Ko] = a ? r.display : "", e[qo] && (r.display = "none"));
 }
-var es = /\s*!important$/;
-function ts(e, t, n) {
-	if (d(n)) n.forEach((n) => ts(e, t, n));
+var $o = /\s*!important$/;
+function es(e, t, n) {
+	if (d(n)) n.forEach((n) => es(e, t, n));
 	else if (n ??= "", t.startsWith("--")) e.setProperty(t, n);
 	else {
-		let r = is(e, t);
-		es.test(n) ? e.setProperty(E(r), n.replace(es, ""), "important") : e[r] = n;
+		let r = rs(e, t);
+		$o.test(n) ? e.setProperty(E(r), n.replace($o, ""), "important") : e[r] = n;
 	}
 }
-var ns = [
+var ts = [
 	"Webkit",
 	"Moz",
 	"ms"
-], rs = {};
-function is(e, t) {
-	let n = rs[t];
+], ns = {};
+function rs(e, t) {
+	let n = ns[t];
 	if (n) return n;
 	let r = T(t);
-	if (r !== "filter" && r in e) return rs[t] = r;
+	if (r !== "filter" && r in e) return ns[t] = r;
 	r = ie(r);
-	for (let n = 0; n < ns.length; n++) {
-		let i = ns[n] + r;
-		if (i in e) return rs[t] = i;
+	for (let n = 0; n < ts.length; n++) {
+		let i = ts[n] + r;
+		if (i in e) return ns[t] = i;
 	}
 	return t;
 }
-function as(e, t, n, r) {
+function is(e, t, n, r) {
 	return e.tagName === "TEXTAREA" && (t === "width" || t === "height") && g(r) && n === r;
 }
-var os = "http://www.w3.org/1999/xlink";
-function ss(e, t, n, r, i, a = be(t)) {
-	r && t.startsWith("xlink:") ? n == null ? e.removeAttributeNS(os, t.slice(6, t.length)) : e.setAttributeNS(os, t, n) : n == null || a && !xe(n) ? e.removeAttribute(t) : e.setAttribute(t, a ? "" : _(n) ? String(n) : n);
+var as = "http://www.w3.org/1999/xlink";
+function os(e, t, n, r, i, a = be(t)) {
+	r && t.startsWith("xlink:") ? n == null ? e.removeAttributeNS(as, t.slice(6, t.length)) : e.setAttributeNS(as, t, n) : n == null || a && !xe(n) ? e.removeAttribute(t) : e.setAttribute(t, a ? "" : _(n) ? String(n) : n);
 }
-function cs(e, t, n, r, i) {
+function ss(e, t, n, r, i) {
 	if (t === "innerHTML" || t === "textContent") {
-		n != null && (e[t] = t === "innerHTML" ? bo(n) : n);
+		n != null && (e[t] = t === "innerHTML" ? yo(n) : n);
 		return;
 	}
 	let a = e.tagName;
@@ -3192,133 +3190,136 @@ function cs(e, t, n, r, i) {
 	} catch {}
 	o && e.removeAttribute(i || t);
 }
-function ls(e, t, n, r) {
+function cs(e, t, n, r) {
 	e.addEventListener(t, n, r);
 }
-function us(e, t, n, r) {
+function ls(e, t, n, r) {
 	e.removeEventListener(t, n, r);
 }
-var ds = /* @__PURE__ */ Symbol("_vei");
-function fs(e, t, n, r, i = null) {
-	let a = e[ds] || (e[ds] = {}), o = a[t];
+var us = /* @__PURE__ */ Symbol("_vei");
+function ds(e, t, n, r, i = null) {
+	let a = e[us] || (e[us] = {}), o = a[t];
 	if (r && o) o.value = r;
 	else {
-		let [n, s] = ms(t);
-		r ? ls(e, n, a[t] = vs(r, i), s) : o && (us(e, n, o, s), a[t] = void 0);
+		let [n, s] = ps(t);
+		r ? cs(e, n, a[t] = _s(r, i), s) : o && (ls(e, n, o, s), a[t] = void 0);
 	}
 }
-var ps = /(?:Once|Passive|Capture)$/;
-function ms(e) {
+var fs = /(?:Once|Passive|Capture)$/;
+function ps(e) {
 	let t;
-	if (ps.test(e)) {
+	if (fs.test(e)) {
 		t = {};
 		let n;
-		for (; n = e.match(ps);) e = e.slice(0, e.length - n[0].length), t[n[0].toLowerCase()] = !0;
+		for (; n = e.match(fs);) e = e.slice(0, e.length - n[0].length), t[n[0].toLowerCase()] = !0;
 	}
 	return [e[2] === ":" ? e.slice(3) : E(e.slice(2)), t];
 }
-var hs = 0, gs = /* @__PURE__ */ Promise.resolve(), _s = () => hs ||= (gs.then(() => hs = 0), Date.now());
-function vs(e, t) {
+var ms = 0, hs = /* @__PURE__ */ Promise.resolve(), gs = () => ms ||= (hs.then(() => ms = 0), Date.now());
+function _s(e, t) {
 	let n = (e) => {
 		if (!e._vts) e._vts = Date.now();
 		else if (e._vts <= n.attached) return;
-		bn(ys(e, n.value), t, 5, [e]);
+		let r = n.value;
+		if (d(r)) {
+			let n = e.stopImmediatePropagation;
+			e.stopImmediatePropagation = () => {
+				n.call(e), e._stopped = !0;
+			};
+			let i = r.slice(), a = [e];
+			for (let n = 0; n < i.length && !e._stopped; n++) {
+				let e = i[n];
+				e && yn(e, t, 5, a);
+			}
+		} else yn(r, t, 5, [e]);
 	};
-	return n.value = e, n.attached = _s(), n;
+	return n.value = e, n.attached = gs(), n;
 }
-function ys(e, t) {
-	if (d(t)) {
-		let n = e.stopImmediatePropagation;
-		return e.stopImmediatePropagation = () => {
-			n.call(e), e._stopped = !0;
-		}, t.map((e) => (t) => !t._stopped && e && e(t));
-	} else return t;
-}
-var bs = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && e.charCodeAt(2) > 96 && e.charCodeAt(2) < 123, xs = (e, t, n, r, i, s) => {
+var vs = (e) => e.charCodeAt(0) === 111 && e.charCodeAt(1) === 110 && e.charCodeAt(2) > 96 && e.charCodeAt(2) < 123, ys = (e, t, n, r, i, s) => {
 	let c = i === "svg";
-	t === "class" ? Ko(e, r, c) : t === "style" ? $o(e, n, r) : a(t) ? o(t) || fs(e, t, n, r, s) : (t[0] === "." ? (t = t.slice(1), !0) : t[0] === "^" ? (t = t.slice(1), !1) : Ss(e, t, r, c)) ? (cs(e, t, r), !e.tagName.includes("-") && (t === "value" || t === "checked" || t === "selected") && ss(e, t, r, c, s, t !== "value")) : e._isVueCE && (Cs(e, t) || e._def.__asyncLoader && (/[A-Z]/.test(t) || !g(r))) ? cs(e, T(t), r, s, t) : (t === "true-value" ? e._trueValue = r : t === "false-value" && (e._falseValue = r), ss(e, t, r, c));
+	t === "class" ? Go(e, r, c) : t === "style" ? Qo(e, n, r) : a(t) ? o(t) || ds(e, t, n, r, s) : (t[0] === "." ? (t = t.slice(1), !0) : t[0] === "^" ? (t = t.slice(1), !1) : bs(e, t, r, c)) ? (ss(e, t, r), !e.tagName.includes("-") && (t === "value" || t === "checked" || t === "selected") && os(e, t, r, c, s, t !== "value")) : e._isVueCE && (xs(e, t) || e._def.__asyncLoader && (/[A-Z]/.test(t) || !g(r))) ? ss(e, T(t), r, s, t) : (t === "true-value" ? e._trueValue = r : t === "false-value" && (e._falseValue = r), os(e, t, r, c));
 };
-function Ss(e, t, n, r) {
-	if (r) return !!(t === "innerHTML" || t === "textContent" || t in e && bs(t) && h(n));
+function bs(e, t, n, r) {
+	if (r) return !!(t === "innerHTML" || t === "textContent" || t in e && vs(t) && h(n));
 	if (t === "spellcheck" || t === "draggable" || t === "translate" || t === "autocorrect" || t === "sandbox" && e.tagName === "IFRAME" || t === "form" || t === "list" && e.tagName === "INPUT" || t === "type" && e.tagName === "TEXTAREA") return !1;
 	if (t === "width" || t === "height") {
 		let t = e.tagName;
 		if (t === "IMG" || t === "VIDEO" || t === "CANVAS" || t === "SOURCE") return !1;
 	}
-	return bs(t) && g(n) ? !1 : t in e;
+	return vs(t) && g(n) ? !1 : t in e;
 }
-function Cs(e, t) {
+function xs(e, t) {
 	let n = e._def.props;
 	if (!n) return !1;
 	let r = T(t);
 	return Array.isArray(n) ? n.some((e) => T(e) === r) : Object.keys(n).some((e) => T(e) === r);
 }
-var ws = (e) => {
+var Ss = (e) => {
 	let t = e.props["onUpdate:modelValue"] || !1;
 	return d(t) ? (e) => se(t, e) : t;
 };
-function Ts(e) {
+function Cs(e) {
 	e.target.composing = !0;
 }
-function Es(e) {
+function ws(e) {
 	let t = e.target;
 	t.composing && (t.composing = !1, t.dispatchEvent(new Event("input")));
 }
-var Ds = /* @__PURE__ */ Symbol("_assign");
-function Os(e, t, n) {
+var Ts = /* @__PURE__ */ Symbol("_assign");
+function Es(e, t, n) {
 	return t && (e = e.trim()), n && (e = le(e)), e;
 }
-var ks = {
+var Ds = {
 	created(e, { modifiers: { lazy: t, trim: n, number: r } }, i) {
-		e[Ds] = ws(i);
+		e[Ts] = Ss(i);
 		let a = r || i.props && i.props.type === "number";
-		ls(e, t ? "change" : "input", (t) => {
-			t.target.composing || e[Ds](Os(e.value, n, a));
-		}), (n || a) && ls(e, "change", () => {
-			e.value = Os(e.value, n, a);
-		}), t || (ls(e, "compositionstart", Ts), ls(e, "compositionend", Es), ls(e, "change", Es));
+		cs(e, t ? "change" : "input", (t) => {
+			t.target.composing || e[Ts](Es(e.value, n, a));
+		}), (n || a) && cs(e, "change", () => {
+			e.value = Es(e.value, n, a);
+		}), t || (cs(e, "compositionstart", Cs), cs(e, "compositionend", ws), cs(e, "change", ws));
 	},
 	mounted(e, { value: t }) {
 		e.value = t ?? "";
 	},
 	beforeUpdate(e, { value: t, oldValue: n, modifiers: { lazy: r, trim: i, number: a } }, o) {
-		if (e[Ds] = ws(o), e.composing) return;
+		if (e[Ts] = Ss(o), e.composing) return;
 		let s = (a || e.type === "number") && !/^0\d/.test(e.value) ? le(e.value) : e.value, c = t ?? "";
 		if (s === c) return;
 		let l = e.getRootNode();
 		(l instanceof Document || l instanceof ShadowRoot) && l.activeElement === e && e.type !== "range" && (r && t === n || i && e.value.trim() === c) || (e.value = c);
 	}
-}, As = {
+}, Os = {
 	deep: !0,
 	created(e, { value: t, modifiers: { number: n } }, r) {
 		let i = p(t);
-		ls(e, "change", () => {
-			let t = Array.prototype.filter.call(e.options, (e) => e.selected).map((e) => n ? le(Ms(e)) : Ms(e));
-			e[Ds](e.multiple ? i ? new Set(t) : t : t[0]), e._assigning = !0, An(() => {
+		cs(e, "change", () => {
+			let t = Array.prototype.filter.call(e.options, (e) => e.selected).map((e) => n ? le(As(e)) : As(e));
+			e[Ts](e.multiple ? i ? new Set(t) : t : t[0]), e._assigning = !0, kn(() => {
 				e._assigning = !1;
 			});
-		}), e[Ds] = ws(r);
+		}), e[Ts] = Ss(r);
 	},
 	mounted(e, { value: t }) {
-		js(e, t);
+		ks(e, t);
 	},
 	beforeUpdate(e, t, n) {
-		e[Ds] = ws(n);
+		e[Ts] = Ss(n);
 	},
 	updated(e, { value: t }) {
-		e._assigning || js(e, t);
+		e._assigning || ks(e, t);
 	}
 };
-function js(e, t) {
+function ks(e, t) {
 	let n = e.multiple, r = d(t);
 	if (!(n && !r && !p(t))) {
 		for (let i = 0, a = e.options.length; i < a; i++) {
-			let a = e.options[i], o = Ms(a);
+			let a = e.options[i], o = As(a);
 			if (n) if (r) {
 				let e = typeof o;
 				e === "string" || e === "number" ? a.selected = t.some((e) => String(e) === String(o)) : a.selected = we(t, o) > -1;
 			} else a.selected = t.has(o);
-			else if (Ce(Ms(a), t)) {
+			else if (Ce(As(a), t)) {
 				e.selectedIndex !== i && (e.selectedIndex = i);
 				return;
 			}
@@ -3326,15 +3327,15 @@ function js(e, t) {
 		!n && e.selectedIndex !== -1 && (e.selectedIndex = -1);
 	}
 }
-function Ms(e) {
+function As(e) {
 	return "_value" in e ? e._value : e.value;
 }
-var Ns = [
+var js = [
 	"ctrl",
 	"shift",
 	"alt",
 	"meta"
-], Ps = {
+], Ms = {
 	stop: (e) => e.stopPropagation(),
 	prevent: (e) => e.preventDefault(),
 	self: (e) => e.target !== e.currentTarget,
@@ -3345,18 +3346,18 @@ var Ns = [
 	left: (e) => "button" in e && e.button !== 0,
 	middle: (e) => "button" in e && e.button !== 1,
 	right: (e) => "button" in e && e.button !== 2,
-	exact: (e, t) => Ns.some((n) => e[`${n}Key`] && !t.includes(n))
-}, Fs = (e, t) => {
+	exact: (e, t) => js.some((n) => e[`${n}Key`] && !t.includes(n))
+}, Ns = (e, t) => {
 	if (!e) return e;
 	let n = e._withMods ||= {}, r = t.join(".");
 	return n[r] || (n[r] = ((n, ...r) => {
 		for (let e = 0; e < t.length; e++) {
-			let r = Ps[t[e]];
+			let r = Ms[t[e]];
 			if (r && r(n, t)) return;
 		}
 		return e(n, ...r);
 	}));
-}, Is = {
+}, Ps = {
 	esc: "escape",
 	space: " ",
 	up: "arrow-up",
@@ -3364,58 +3365,58 @@ var Ns = [
 	right: "arrow-right",
 	down: "arrow-down",
 	delete: "backspace"
-}, Ls = (e, t) => {
+}, Fs = (e, t) => {
 	let n = e._withKeys ||= {}, r = t.join(".");
 	return n[r] || (n[r] = ((n) => {
 		if (!("key" in n)) return;
 		let r = E(n.key);
-		if (t.some((e) => e === r || Is[e] === r)) return e(n);
+		if (t.some((e) => e === r || Ps[e] === r)) return e(n);
 	}));
-}, Rs = /* @__PURE__ */ s({ patchProp: xs }, To), zs;
-function Bs() {
-	return zs ||= ma(Rs);
+}, Is = /* @__PURE__ */ s({ patchProp: ys }, wo), Ls;
+function Rs() {
+	return Ls ||= pa(Is);
 }
-var Vs = ((...e) => {
-	let t = Bs().createApp(...e), { mount: n } = t;
+var zs = ((...e) => {
+	let t = Rs().createApp(...e), { mount: n } = t;
 	return t.mount = (e) => {
-		let r = Us(e);
+		let r = Vs(e);
 		if (!r) return;
 		let i = t._component;
 		!h(i) && !i.render && !i.template && (i.template = r.innerHTML), r.nodeType === 1 && (r.textContent = "");
-		let a = n(r, !1, Hs(r));
+		let a = n(r, !1, Bs(r));
 		return r instanceof Element && (r.removeAttribute("v-cloak"), r.setAttribute("data-v-app", "")), a;
 	}, t;
 });
-function Hs(e) {
+function Bs(e) {
 	if (e instanceof SVGElement) return "svg";
 	if (typeof MathMLElement == "function" && e instanceof MathMLElement) return "mathml";
 }
-function Us(e) {
+function Vs(e) {
 	return g(e) ? document.querySelector(e) : e;
 }
 //#endregion
 //#region node_modules/@primeuix/utils/dist/object/index.mjs
-var Ws = Object.defineProperty, Gs = Object.getOwnPropertySymbols, Ks = Object.prototype.hasOwnProperty, qs = Object.prototype.propertyIsEnumerable, Js = (e, t, n) => t in e ? Ws(e, t, {
+var Hs = Object.defineProperty, Us = Object.getOwnPropertySymbols, Ws = Object.prototype.hasOwnProperty, Gs = Object.prototype.propertyIsEnumerable, Ks = (e, t, n) => t in e ? Hs(e, t, {
 	enumerable: !0,
 	configurable: !0,
 	writable: !0,
 	value: n
-}) : e[t] = n, Ys = (e, t) => {
-	for (var n in t ||= {}) Ks.call(t, n) && Js(e, n, t[n]);
-	if (Gs) for (var n of Gs(t)) qs.call(t, n) && Js(e, n, t[n]);
+}) : e[t] = n, qs = (e, t) => {
+	for (var n in t ||= {}) Ws.call(t, n) && Ks(e, n, t[n]);
+	if (Us) for (var n of Us(t)) Gs.call(t, n) && Ks(e, n, t[n]);
 	return e;
 };
-function Xs(e) {
+function Js(e) {
 	return e == null || e === "" || Array.isArray(e) && e.length === 0 || !(e instanceof Date) && typeof e == "object" && Object.keys(e).length === 0;
 }
-function Zs(e, t, n = /* @__PURE__ */ new WeakSet()) {
+function Ys(e, t, n = /* @__PURE__ */ new WeakSet()) {
 	if (e === t) return !0;
 	if (!e || !t || typeof e != "object" || typeof t != "object" || n.has(e) || n.has(t)) return !1;
 	n.add(e).add(t);
 	let r = Array.isArray(e), i = Array.isArray(t), a, o, s;
 	if (r && i) {
 		if (o = e.length, o != t.length) return !1;
-		for (a = o; a-- !== 0;) if (!Zs(e[a], t[a], n)) return !1;
+		for (a = o; a-- !== 0;) if (!Ys(e[a], t[a], n)) return !1;
 		return !0;
 	}
 	if (r != i) return !1;
@@ -3428,26 +3429,26 @@ function Zs(e, t, n = /* @__PURE__ */ new WeakSet()) {
 	let f = Object.keys(e);
 	if (o = f.length, o !== Object.keys(t).length) return !1;
 	for (a = o; a-- !== 0;) if (!Object.prototype.hasOwnProperty.call(t, f[a])) return !1;
-	for (a = o; a-- !== 0;) if (s = f[a], !Zs(e[s], t[s], n)) return !1;
+	for (a = o; a-- !== 0;) if (s = f[a], !Ys(e[s], t[s], n)) return !1;
 	return !0;
 }
-function Qs(e, t) {
-	return Zs(e, t);
+function Xs(e, t) {
+	return Ys(e, t);
 }
-function $s(e) {
+function Zs(e) {
 	return typeof e == "function" && "call" in e && "apply" in e;
 }
 function K(e) {
-	return !Xs(e);
+	return !Js(e);
 }
-function ec(e, t) {
+function Qs(e, t) {
 	if (!e || !t) return null;
 	try {
 		let n = e[t];
 		if (K(n)) return n;
 	} catch {}
 	if (Object.keys(e).length) {
-		if ($s(t)) return t(e);
+		if (Zs(t)) return t(e);
 		if (t.indexOf(".") === -1) return e[t];
 		{
 			let n = t.split("."), r = e;
@@ -3460,29 +3461,29 @@ function ec(e, t) {
 	}
 	return null;
 }
-function tc(e, t, n) {
-	return n ? ec(e, n) === ec(t, n) : Qs(e, t);
+function $s(e, t, n) {
+	return n ? Qs(e, n) === Qs(t, n) : Xs(e, t);
 }
-function nc(e, t) {
+function ec(e, t) {
 	if (e != null && t && t.length) {
-		for (let n of t) if (tc(e, n)) return !0;
+		for (let n of t) if ($s(e, n)) return !0;
 	}
 	return !1;
 }
-function rc(e, t = !0) {
+function tc(e, t = !0) {
 	return e instanceof Object && e.constructor === Object && (t || Object.keys(e).length !== 0);
 }
-function ic(e = {}, t = {}) {
-	let n = Ys({}, e);
+function nc(e = {}, t = {}) {
+	let n = qs({}, e);
 	return Object.keys(t).forEach((r) => {
 		let i = r;
-		rc(t[i]) && i in e && rc(e[i]) ? n[i] = ic(e[i], t[i]) : n[i] = t[i];
+		tc(t[i]) && i in e && tc(e[i]) ? n[i] = nc(e[i], t[i]) : n[i] = t[i];
 	}), n;
 }
-function ac(...e) {
-	return e.reduce((e, t, n) => n === 0 ? t : ic(e, t), {});
+function rc(...e) {
+	return e.reduce((e, t, n) => n === 0 ? t : nc(e, t), {});
 }
-function oc(e, t) {
+function ic(e, t) {
 	let n = -1;
 	if (K(e)) try {
 		n = e.findLastIndex(t);
@@ -3491,42 +3492,42 @@ function oc(e, t) {
 	}
 	return n;
 }
-function sc(e, ...t) {
-	return $s(e) ? e(...t) : e;
+function ac(e, ...t) {
+	return Zs(e) ? e(...t) : e;
 }
-function cc(e, t = !0) {
+function oc(e, t = !0) {
 	return typeof e == "string" && (t || e !== "");
 }
-function lc(e) {
-	return cc(e) ? e.replace(/(-|_)/g, "").toLowerCase() : e;
+function sc(e) {
+	return oc(e) ? e.replace(/(-|_)/g, "").toLowerCase() : e;
 }
-function uc(e, t = "", n = {}) {
-	let r = lc(t).split("."), i = r.shift();
-	return i ? rc(e) ? uc(sc(e[Object.keys(e).find((e) => lc(e) === i) || ""], n), r.join("."), n) : void 0 : sc(e, n);
+function cc(e, t = "", n = {}) {
+	let r = sc(t).split("."), i = r.shift();
+	return i ? tc(e) ? cc(ac(e[Object.keys(e).find((e) => sc(e) === i) || ""], n), r.join("."), n) : void 0 : ac(e, n);
 }
-function dc(e, t = !0) {
+function lc(e, t = !0) {
 	return Array.isArray(e) && (t || e.length !== 0);
 }
-function fc(e) {
+function uc(e) {
 	return K(e) && !isNaN(e);
 }
-function pc(e = "") {
+function dc(e = "") {
 	return K(e) && e.length === 1 && !!e.match(/\S| /);
 }
-function mc(e, t) {
+function fc(e, t) {
 	if (t) {
 		let n = t.test(e);
 		return t.lastIndex = 0, n;
 	}
 	return !1;
 }
-function hc(...e) {
-	return ac(...e);
+function pc(...e) {
+	return rc(...e);
 }
-function gc(e) {
+function mc(e) {
 	return e && e.replace(/\/\*(?:(?!\*\/)[\s\S])*\*\/|[\r\n\t]+/g, "").replace(/ {2,}/g, " ").replace(/ ([{:}]) /g, "$1").replace(/([;,]) /g, "$1").replace(/ !/g, "!").replace(/: /g, ":").trim();
 }
-function _c(e) {
+function hc(e) {
 	if (e && /[\xC0-\xFF\u0100-\u017E]/.test(e)) {
 		let t = {
 			A: /[\xC0-\xC5\u0100\u0102\u0104]/g,
@@ -3578,15 +3579,15 @@ function _c(e) {
 	}
 	return e;
 }
-function vc(e) {
-	return cc(e, !1) ? e[0].toUpperCase() + e.slice(1) : e;
+function gc(e) {
+	return oc(e, !1) ? e[0].toUpperCase() + e.slice(1) : e;
 }
-function yc(e) {
-	return cc(e) ? e.replace(/(_)/g, "-").replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase() : e;
+function _c(e) {
+	return oc(e) ? e.replace(/(_)/g, "-").replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase() : e;
 }
 //#endregion
 //#region node_modules/@primeuix/utils/dist/eventbus/index.mjs
-function bc() {
+function vc() {
 	let e = /* @__PURE__ */ new Map();
 	return {
 		on(t, n) {
@@ -3628,24 +3629,24 @@ function q(...e) {
 }
 //#endregion
 //#region node_modules/@primeuix/utils/dist/dom/index.mjs
-function xc(e, t) {
+function yc(e, t) {
 	return e ? e.classList ? e.classList.contains(t) : RegExp("(^| )" + t + "( |$)", "gi").test(e.className) : !1;
 }
-function Sc(e, t) {
+function bc(e, t) {
 	if (e && t) {
 		let n = (t) => {
-			xc(e, t) || (e.classList ? e.classList.add(t) : e.className += " " + t);
+			yc(e, t) || (e.classList ? e.classList.add(t) : e.className += " " + t);
 		};
 		[t].flat().filter(Boolean).forEach((e) => e.split(" ").forEach(n));
 	}
 }
-function Cc() {
+function xc() {
 	return window.innerWidth - document.documentElement.offsetWidth;
 }
-function wc(e) {
-	typeof e == "string" ? Sc(document.body, e || "p-overflow-hidden") : (e != null && e.variableName && document.body.style.setProperty(e.variableName, Cc() + "px"), Sc(document.body, e?.className || "p-overflow-hidden"));
+function Sc(e) {
+	typeof e == "string" ? bc(document.body, e || "p-overflow-hidden") : (e != null && e.variableName && document.body.style.setProperty(e.variableName, xc() + "px"), bc(document.body, e?.className || "p-overflow-hidden"));
 }
-function Tc(e, t) {
+function Cc(e, t) {
 	if (e && t) {
 		let n = (t) => {
 			e.classList ? e.classList.remove(t) : e.className = e.className.replace(RegExp("(^|\\b)" + t.split(" ").join("|") + "(\\b|$)", "gi"), " ");
@@ -3653,10 +3654,10 @@ function Tc(e, t) {
 		[t].flat().filter(Boolean).forEach((e) => e.split(" ").forEach(n));
 	}
 }
-function Ec(e) {
-	typeof e == "string" ? Tc(document.body, e || "p-overflow-hidden") : (e != null && e.variableName && document.body.style.removeProperty(e.variableName), Tc(document.body, e?.className || "p-overflow-hidden"));
+function wc(e) {
+	typeof e == "string" ? Cc(document.body, e || "p-overflow-hidden") : (e != null && e.variableName && document.body.style.removeProperty(e.variableName), Cc(document.body, e?.className || "p-overflow-hidden"));
 }
-function Dc(e) {
+function Tc(e) {
 	for (let t of document == null ? void 0 : document.styleSheets) try {
 		for (let n of t?.cssRules) for (let t of n?.style) if (e.test(t)) return {
 			name: t,
@@ -3665,7 +3666,7 @@ function Dc(e) {
 	} catch {}
 	return null;
 }
-function Oc(e) {
+function Ec(e) {
 	let t = {
 		width: 0,
 		height: 0
@@ -3676,40 +3677,40 @@ function Oc(e) {
 	}
 	return t;
 }
-function kc() {
+function Dc() {
 	let e = window, t = document, n = t.documentElement, r = t.getElementsByTagName("body")[0];
 	return {
 		width: e.innerWidth || n.clientWidth || r.clientWidth,
 		height: e.innerHeight || n.clientHeight || r.clientHeight
 	};
 }
-function Ac(e) {
+function Oc(e) {
 	return e ? Math.abs(e.scrollLeft) : 0;
 }
-function jc() {
+function kc() {
 	let e = document.documentElement;
-	return (window.pageXOffset || Ac(e)) - (e.clientLeft || 0);
+	return (window.pageXOffset || Oc(e)) - (e.clientLeft || 0);
 }
-function Mc() {
+function Ac() {
 	let e = document.documentElement;
 	return (window.pageYOffset || e.scrollTop) - (e.clientTop || 0);
 }
-function Nc(e) {
+function jc(e) {
 	return e ? getComputedStyle(e).direction === "rtl" : !1;
 }
-function Pc(e, t, n = !0) {
+function Mc(e, t, n = !0) {
 	if (e) {
 		let r = e.offsetParent ? {
 			width: e.offsetWidth,
 			height: e.offsetHeight
-		} : Oc(e), i = r.height, a = r.width, o = t.offsetHeight, s = t.offsetWidth, c = t.getBoundingClientRect(), l = Mc(), u = jc(), d = kc(), f, p, m = "top";
-		c.top + o + i > d.height ? (f = c.top + l - i, m = "bottom", f < 0 && (f = l)) : f = o + c.top + l, p = c.left + a > d.width ? Math.max(0, c.left + u + s - a) : c.left + u, Nc(e) ? e.style.insetInlineEnd = p + "px" : e.style.insetInlineStart = p + "px", e.style.top = f + "px", e.style.transformOrigin = m, n && (e.style.marginTop = m === "bottom" ? `calc(${Dc(/-anchor-gutter$/)?.value ?? "2px"} * -1)` : Dc(/-anchor-gutter$/)?.value ?? "");
+		} : Ec(e), i = r.height, a = r.width, o = t.offsetHeight, s = t.offsetWidth, c = t.getBoundingClientRect(), l = Ac(), u = kc(), d = Dc(), f, p, m = "top";
+		c.top + o + i > d.height ? (f = c.top + l - i, m = "bottom", f < 0 && (f = l)) : f = o + c.top + l, p = c.left + a > d.width ? Math.max(0, c.left + u + s - a) : c.left + u, jc(e) ? e.style.insetInlineEnd = p + "px" : e.style.insetInlineStart = p + "px", e.style.top = f + "px", e.style.transformOrigin = m, n && (e.style.marginTop = m === "bottom" ? `calc(${Tc(/-anchor-gutter$/)?.value ?? "2px"} * -1)` : Tc(/-anchor-gutter$/)?.value ?? "");
 	}
 }
-function Fc(e, t) {
+function Nc(e, t) {
 	e && (typeof t == "string" ? e.style.cssText = t : Object.entries(t || {}).forEach(([t, n]) => e.style[t] = n));
 }
-function Ic(e, t) {
+function Pc(e, t) {
 	if (e instanceof HTMLElement) {
 		let n = e.offsetWidth;
 		if (t) {
@@ -3720,33 +3721,33 @@ function Ic(e, t) {
 	}
 	return 0;
 }
-function Lc(e, t, n = !0, r = void 0) {
+function Fc(e, t, n = !0, r = void 0) {
 	if (e) {
 		let i = e.offsetParent ? {
 			width: e.offsetWidth,
 			height: e.offsetHeight
-		} : Oc(e), a = t.offsetHeight, o = t.getBoundingClientRect(), s = kc(), c, l, u = r ?? "top";
+		} : Ec(e), a = t.offsetHeight, o = t.getBoundingClientRect(), s = Dc(), c, l, u = r ?? "top";
 		if (!r && o.top + a + i.height > s.height ? (c = -1 * i.height, u = "bottom", o.top + c < 0 && (c = -1 * o.top)) : c = a, l = i.width > s.width ? o.left * -1 : o.left + i.width > s.width ? (o.left + i.width - s.width) * -1 : 0, e.style.top = c + "px", e.style.insetInlineStart = l + "px", e.style.transformOrigin = u, n) {
-			let t = Dc(/-anchor-gutter$/)?.value;
+			let t = Tc(/-anchor-gutter$/)?.value;
 			e.style.marginTop = u === "bottom" ? `calc(${t ?? "2px"} * -1)` : t ?? "";
 		}
 	}
 }
-function Rc(e) {
+function Ic(e) {
 	if (e) {
 		let t = e.parentNode;
 		return t && t instanceof ShadowRoot && t.host && (t = t.host), t;
 	}
 	return null;
 }
-function zc(e) {
-	return !!(e != null && e.nodeName && Rc(e));
+function Lc(e) {
+	return !!(e != null && e.nodeName && Ic(e));
 }
-function Bc(e) {
+function Rc(e) {
 	return typeof Element < "u" ? e instanceof Element : typeof e == "object" && !!e && e.nodeType === 1 && typeof e.nodeName == "string";
 }
-function Vc(e, t = {}) {
-	if (Bc(e)) {
+function zc(e, t = {}) {
+	if (Rc(e)) {
 		let n = (t, r) => {
 			var i;
 			let a = (i = e?.$attrs) != null && i[t] ? [e?.$attrs?.[t]] : [];
@@ -3765,34 +3766,34 @@ function Vc(e, t = {}) {
 		Object.entries(t).forEach(([t, r]) => {
 			if (r != null) {
 				let i = t.match(/^on(.+)/);
-				i ? e.addEventListener(i[1].toLowerCase(), r) : t === "p-bind" || t === "pBind" ? Vc(e, r) : (r = t === "class" ? [...new Set(n("class", r))].join(" ").trim() : t === "style" ? n("style", r).join(";").trim() : r, (e.$attrs = e.$attrs || {}) && (e.$attrs[t] = r), e.setAttribute(t, r));
+				i ? e.addEventListener(i[1].toLowerCase(), r) : t === "p-bind" || t === "pBind" ? zc(e, r) : (r = t === "class" ? [...new Set(n("class", r))].join(" ").trim() : t === "style" ? n("style", r).join(";").trim() : r, (e.$attrs = e.$attrs || {}) && (e.$attrs[t] = r), e.setAttribute(t, r));
 			}
 		});
 	}
 }
-function Hc(e, t = {}, ...n) {
+function Bc(e, t = {}, ...n) {
 	if (e) {
 		let r = document.createElement(e);
-		return Vc(r, t), r.append(...n), r;
+		return zc(r, t), r.append(...n), r;
 	}
 }
-function Uc(e, t) {
-	return Bc(e) ? Array.from(e.querySelectorAll(t)) : [];
+function Vc(e, t) {
+	return Rc(e) ? Array.from(e.querySelectorAll(t)) : [];
 }
-function Wc(e, t) {
-	return Bc(e) ? e.matches(t) ? e : e.querySelector(t) : null;
+function Hc(e, t) {
+	return Rc(e) ? e.matches(t) ? e : e.querySelector(t) : null;
 }
 function J(e, t) {
 	e && document.activeElement !== e && e.focus(t);
 }
-function Gc(e, t) {
-	if (Bc(e)) {
+function Uc(e, t) {
+	if (Rc(e)) {
 		let n = e.getAttribute(t);
 		return isNaN(n) ? n === "true" || n === "false" ? n === "true" : n : +n;
 	}
 }
-function Kc(e, t = "") {
-	let n = Uc(e, `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
+function Wc(e, t = "") {
+	let n = Vc(e, `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             [href]:not([tabindex = "-1"]):not([style*="display:none"]):not([hidden])${t},
             input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             select:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
@@ -3802,27 +3803,27 @@ function Kc(e, t = "") {
 	for (let e of n) getComputedStyle(e).display != "none" && getComputedStyle(e).visibility != "hidden" && r.push(e);
 	return r;
 }
-function qc(e, t) {
-	let n = Kc(e, t);
+function Gc(e, t) {
+	let n = Wc(e, t);
 	return n.length > 0 ? n[0] : null;
 }
-function Jc(e) {
+function Kc(e) {
 	if (e) {
 		let t = e.offsetHeight, n = getComputedStyle(e);
 		return t -= parseFloat(n.paddingTop) + parseFloat(n.paddingBottom) + parseFloat(n.borderTopWidth) + parseFloat(n.borderBottomWidth), t;
 	}
 	return 0;
 }
-function Yc(e, t) {
-	let n = Kc(e, t);
+function qc(e, t) {
+	let n = Wc(e, t);
 	return n.length > 0 ? n[n.length - 1] : null;
 }
-function Xc(e) {
+function Jc(e) {
 	if (e) {
 		let t = e.getBoundingClientRect();
 		return {
 			top: t.top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0),
-			left: t.left + (window.pageXOffset || Ac(document.documentElement) || Ac(document.body) || 0)
+			left: t.left + (window.pageXOffset || Oc(document.documentElement) || Oc(document.body) || 0)
 		};
 	}
 	return {
@@ -3830,7 +3831,7 @@ function Xc(e) {
 		left: "auto"
 	};
 }
-function Zc(e, t) {
+function Yc(e, t) {
 	if (e) {
 		let n = e.offsetHeight;
 		if (t) {
@@ -3841,14 +3842,14 @@ function Zc(e, t) {
 	}
 	return 0;
 }
-function Qc(e, t = []) {
-	let n = Rc(e);
-	return n === null ? t : Qc(n, t.concat([n]));
+function Xc(e, t = []) {
+	let n = Ic(e);
+	return n === null ? t : Xc(n, t.concat([n]));
 }
-function $c(e) {
+function Zc(e) {
 	let t = [];
 	if (e) {
-		let n = Qc(e), r = /(auto|scroll)/, i = (e) => {
+		let n = Xc(e), r = /(auto|scroll)/, i = (e) => {
 			try {
 				let t = window.getComputedStyle(e, null);
 				return r.test(t.getPropertyValue("overflow")) || r.test(t.getPropertyValue("overflowX")) || r.test(t.getPropertyValue("overflowY"));
@@ -3861,7 +3862,7 @@ function $c(e) {
 			if (n) {
 				let r = n.split(",");
 				for (let n of r) {
-					let r = Wc(e, n);
+					let r = Hc(e, n);
 					r && i(r) && t.push(r);
 				}
 			}
@@ -3870,21 +3871,21 @@ function $c(e) {
 	}
 	return t;
 }
-function el(e) {
+function Qc(e) {
 	if (e) {
 		let t = e.offsetWidth, n = getComputedStyle(e);
 		return t -= parseFloat(n.paddingLeft) + parseFloat(n.paddingRight) + parseFloat(n.borderLeftWidth) + parseFloat(n.borderRightWidth), t;
 	}
 	return 0;
 }
-function tl() {
+function $c() {
 	return /(android)/i.test(navigator.userAgent);
 }
-function nl() {
+function el() {
 	return !!(typeof window < "u" && window.document && window.document.createElement);
 }
-function rl(e, t = "") {
-	return Bc(e) ? e.matches(`button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
+function tl(e, t = "") {
+	return Rc(e) ? e.matches(`button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             select:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
@@ -3892,24 +3893,24 @@ function rl(e, t = "") {
             [tabIndex]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t},
             [contenteditable]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${t}`) : !1;
 }
-function il(e) {
+function nl(e) {
 	return !!(e && e.offsetParent != null);
 }
-function al() {
+function rl() {
 	return "ontouchstart" in window || navigator.maxTouchPoints > 0 || navigator.msMaxTouchPoints > 0;
 }
-function ol(e, t = "", n) {
-	Bc(e) && n != null && e.setAttribute(t, n);
+function il(e, t = "", n) {
+	Rc(e) && n != null && e.setAttribute(t, n);
 }
 //#endregion
 //#region node_modules/@primeuix/utils/dist/uuid/index.mjs
-var sl = {};
-function cl(e = "pui_id_") {
-	return Object.hasOwn(sl, e) || (sl[e] = 0), sl[e]++, `${e}${sl[e]}`;
+var al = {};
+function ol(e = "pui_id_") {
+	return Object.hasOwn(al, e) || (al[e] = 0), al[e]++, `${e}${al[e]}`;
 }
 //#endregion
 //#region node_modules/@primeuix/utils/dist/zindex/index.mjs
-function ll() {
+function sl() {
 	let e = [], t = (t, n, r = 999) => {
 		let a = i(t, n, r), o = a.value + (a.key === t ? 0 : r) + 1;
 		return e.push({
@@ -3933,57 +3934,57 @@ function ll() {
 		getCurrent: (e) => r(e, !0)
 	};
 }
-var ul = ll(), dl = Object.defineProperty, fl = Object.defineProperties, pl = Object.getOwnPropertyDescriptors, ml = Object.getOwnPropertySymbols, hl = Object.prototype.hasOwnProperty, gl = Object.prototype.propertyIsEnumerable, _l = (e, t, n) => t in e ? dl(e, t, {
+var cl = sl(), ll = Object.defineProperty, ul = Object.defineProperties, dl = Object.getOwnPropertyDescriptors, fl = Object.getOwnPropertySymbols, pl = Object.prototype.hasOwnProperty, ml = Object.prototype.propertyIsEnumerable, hl = (e, t, n) => t in e ? ll(e, t, {
 	enumerable: !0,
 	configurable: !0,
 	writable: !0,
 	value: n
-}) : e[t] = n, vl = (e, t) => {
-	for (var n in t ||= {}) hl.call(t, n) && _l(e, n, t[n]);
-	if (ml) for (var n of ml(t)) gl.call(t, n) && _l(e, n, t[n]);
+}) : e[t] = n, gl = (e, t) => {
+	for (var n in t ||= {}) pl.call(t, n) && hl(e, n, t[n]);
+	if (fl) for (var n of fl(t)) ml.call(t, n) && hl(e, n, t[n]);
 	return e;
-}, yl = (e, t) => fl(e, pl(t)), bl = (e, t) => {
+}, _l = (e, t) => ul(e, dl(t)), vl = (e, t) => {
 	var n = {};
-	for (var r in e) hl.call(e, r) && t.indexOf(r) < 0 && (n[r] = e[r]);
-	if (e != null && ml) for (var r of ml(e)) t.indexOf(r) < 0 && gl.call(e, r) && (n[r] = e[r]);
+	for (var r in e) pl.call(e, r) && t.indexOf(r) < 0 && (n[r] = e[r]);
+	if (e != null && fl) for (var r of fl(e)) t.indexOf(r) < 0 && ml.call(e, r) && (n[r] = e[r]);
 	return n;
-}, xl = bc(), Sl = /{([^}]*)}/g, Cl = /(\d+\s+[\+\-\*\/]\s+\d+)/g, wl = /var\([^)]+\)/g;
+}, yl = vc(), bl = /{([^}]*)}/g, xl = /(\d+\s+[\+\-\*\/]\s+\d+)/g, Sl = /var\([^)]+\)/g;
+function Cl(e) {
+	return oc(e) ? e.replace(/[A-Z]/g, (e, t) => t === 0 ? e : "." + e.toLowerCase()).toLowerCase() : e;
+}
+function wl(e) {
+	return tc(e) && e.hasOwnProperty("$value") && e.hasOwnProperty("$type") ? e.$value : e;
+}
 function Tl(e) {
-	return cc(e) ? e.replace(/[A-Z]/g, (e, t) => t === 0 ? e : "." + e.toLowerCase()).toLowerCase() : e;
-}
-function El(e) {
-	return rc(e) && e.hasOwnProperty("$value") && e.hasOwnProperty("$type") ? e.$value : e;
-}
-function Dl(e) {
 	return e.replaceAll(/ /g, "").replace(/[^\w]/g, "-");
 }
-function Ol(e = "", t = "") {
-	return Dl(`${cc(e, !1) && cc(t, !1) ? `${e}-` : e}${t}`);
+function El(e = "", t = "") {
+	return Tl(`${oc(e, !1) && oc(t, !1) ? `${e}-` : e}${t}`);
 }
-function kl(e = "", t = "") {
-	return `--${Ol(e, t)}`;
+function Dl(e = "", t = "") {
+	return `--${El(e, t)}`;
 }
-function Al(e = "") {
+function Ol(e = "") {
 	return ((e.match(/{/g) || []).length + (e.match(/}/g) || []).length) % 2 != 0;
 }
-function jl(e, t = "", n = "", r = [], i) {
-	if (cc(e)) {
+function kl(e, t = "", n = "", r = [], i) {
+	if (oc(e)) {
 		let t = e.trim();
-		if (Al(t)) return;
-		if (mc(t, Sl)) {
-			let e = t.replaceAll(Sl, (e) => `var(${kl(n, yc(e.replace(/{|}/g, "").split(".").filter((e) => !r.some((t) => mc(e, t))).join("-")))}${K(i) ? `, ${i}` : ""})`);
-			return mc(e.replace(wl, "0"), Cl) ? `calc(${e})` : e;
+		if (Ol(t)) return;
+		if (fc(t, bl)) {
+			let e = t.replaceAll(bl, (e) => `var(${Dl(n, _c(e.replace(/{|}/g, "").split(".").filter((e) => !r.some((t) => fc(e, t))).join("-")))}${K(i) ? `, ${i}` : ""})`);
+			return fc(e.replace(Sl, "0"), xl) ? `calc(${e})` : e;
 		}
 		return t;
-	} else if (fc(e)) return e;
+	} else if (uc(e)) return e;
 }
-function Ml(e, t, n) {
-	cc(t, !1) && e.push(`${t}:${n};`);
+function Al(e, t, n) {
+	oc(t, !1) && e.push(`${t}:${n};`);
 }
-function Nl(e, t) {
+function jl(e, t) {
 	return e ? `${e}{${t}}` : "";
 }
-function Pl(e, t) {
+function Ml(e, t) {
 	if (e.indexOf("dt(") === -1) return e;
 	function n(e, t) {
 		let n = [], i = 0, a = "", o = null, s = 0;
@@ -3991,7 +3992,7 @@ function Pl(e, t) {
 			let c = e[i];
 			if ((c === "\"" || c === "'" || c === "`") && e[i - 1] !== "\\" && (o = o === c ? null : c), !o && (c === "(" && s++, c === ")" && s--, (c === "," || i === e.length) && s === 0)) {
 				let e = a.trim();
-				e.startsWith("dt(") ? n.push(Pl(e, t)) : n.push(r(e)), a = "", i++;
+				e.startsWith("dt(") ? n.push(Ml(e, t)) : n.push(r(e)), a = "", i++;
 				continue;
 			}
 			c !== void 0 && (a += c), i++;
@@ -4017,24 +4018,24 @@ function Pl(e, t) {
 	}
 	return e;
 }
-var Fl = (e) => {
-	let t = Y.getTheme(), n = Ll(t, e, void 0, "variable");
+var Nl = (e) => {
+	let t = Y.getTheme(), n = Fl(t, e, void 0, "variable");
 	return {
 		name: n?.match(/--[\w-]+/g)?.[0],
 		variable: n,
-		value: Ll(t, e, void 0, "value")
+		value: Fl(t, e, void 0, "value")
 	};
-}, Il = (...e) => Ll(Y.getTheme(), ...e), Ll = (e = {}, t, n, r) => {
+}, Pl = (...e) => Fl(Y.getTheme(), ...e), Fl = (e = {}, t, n, r) => {
 	if (t) {
-		let { variable: i, options: a } = Y.defaults || {}, { prefix: o, transform: s } = e?.options || a || {}, c = mc(t, Sl) ? t : `{${t}}`;
-		return r === "value" || Xs(r) && s === "strict" ? Y.getTokenValue(t) : jl(c, void 0, o, [i.excludedKeyRegex], n);
+		let { variable: i, options: a } = Y.defaults || {}, { prefix: o, transform: s } = e?.options || a || {}, c = fc(t, bl) ? t : `{${t}}`;
+		return r === "value" || Js(r) && s === "strict" ? Y.getTokenValue(t) : kl(c, void 0, o, [i.excludedKeyRegex], n);
 	}
 	return "";
 };
-function Rl(e, ...t) {
-	return e instanceof Array ? Pl(e.reduce((e, n, r) => e + n + (sc(t[r], { dt: Il }) ?? ""), ""), Il) : sc(e, { dt: Il });
+function Il(e, ...t) {
+	return e instanceof Array ? Ml(e.reduce((e, n, r) => e + n + (ac(t[r], { dt: Pl }) ?? ""), ""), Pl) : ac(e, { dt: Pl });
 }
-function zl(e, t = {}) {
+function Ll(e, t = {}) {
 	let n = Y.defaults.variable, { prefix: r = n.prefix, selector: i = n.selector, excludedKeyRegex: a = n.excludedKeyRegex } = t, o = [], s = [], c = [{
 		node: e,
 		path: r
@@ -4042,13 +4043,13 @@ function zl(e, t = {}) {
 	for (; c.length;) {
 		let { node: e, path: t } = c.pop();
 		for (let n in e) {
-			let i = e[n], l = El(i), u = mc(n, a) ? Ol(t) : Ol(t, yc(n));
-			if (rc(l)) c.push({
+			let i = e[n], l = wl(i), u = fc(n, a) ? El(t) : El(t, _c(n));
+			if (tc(l)) c.push({
 				node: l,
 				path: u
 			});
 			else {
-				Ml(s, kl(u), jl(l, u, r, [a]));
+				Al(s, Dl(u), kl(l, u, r, [a]));
 				let e = u;
 				r && e.startsWith(r + "-") && (e = e.slice(r.length + 1)), o.push(e.replace(/-/g, "."));
 			}
@@ -4059,10 +4060,10 @@ function zl(e, t = {}) {
 		value: s,
 		tokens: o,
 		declarations: l,
-		css: Nl(i, l)
+		css: jl(i, l)
 	};
 }
-var Bl = {
+var Rl = {
 	regex: {
 		rules: {
 			class: {
@@ -4119,12 +4120,12 @@ var Bl = {
 		}
 	},
 	_toVariables(e, t) {
-		return zl(e, { prefix: t?.prefix });
+		return Ll(e, { prefix: t?.prefix });
 	},
 	getCommon({ name: e = "", theme: t = {}, params: n, set: r, defaults: i }) {
 		let { preset: a, options: o } = t, s, c, l, u, d, f, p;
 		if (K(a) && o.transform !== "strict") {
-			let { primitive: t, semantic: n, extend: m } = a, h = n || {}, { colorScheme: g } = h, _ = bl(h, ["colorScheme"]), v = m || {}, { colorScheme: y } = v, b = bl(v, ["colorScheme"]), x = g || {}, { dark: S } = x, C = bl(x, ["dark"]), w = y || {}, { dark: ee } = w, te = bl(w, ["dark"]), ne = K(t) ? this._toVariables({ primitive: t }, o) : {}, T = K(_) ? this._toVariables({ semantic: _ }, o) : {}, re = K(C) ? this._toVariables({ light: C }, o) : {}, E = K(S) ? this._toVariables({ dark: S }, o) : {}, ie = K(b) ? this._toVariables({ semantic: b }, o) : {}, ae = K(te) ? this._toVariables({ light: te }, o) : {}, oe = K(ee) ? this._toVariables({ dark: ee }, o) : {}, [se, ce] = [ne.declarations ?? "", ne.tokens], [le, ue] = [T.declarations ?? "", T.tokens || []], [de, fe] = [re.declarations ?? "", re.tokens || []], [pe, me] = [E.declarations ?? "", E.tokens || []], [he, ge] = [ie.declarations ?? "", ie.tokens || []], [_e, D] = [ae.declarations ?? "", ae.tokens || []], [ve, ye] = [oe.declarations ?? "", oe.tokens || []];
+			let { primitive: t, semantic: n, extend: m } = a, h = n || {}, { colorScheme: g } = h, _ = vl(h, ["colorScheme"]), v = m || {}, { colorScheme: y } = v, b = vl(v, ["colorScheme"]), x = g || {}, { dark: S } = x, C = vl(x, ["dark"]), w = y || {}, { dark: ee } = w, te = vl(w, ["dark"]), ne = K(t) ? this._toVariables({ primitive: t }, o) : {}, T = K(_) ? this._toVariables({ semantic: _ }, o) : {}, re = K(C) ? this._toVariables({ light: C }, o) : {}, E = K(S) ? this._toVariables({ dark: S }, o) : {}, ie = K(b) ? this._toVariables({ semantic: b }, o) : {}, ae = K(te) ? this._toVariables({ light: te }, o) : {}, oe = K(ee) ? this._toVariables({ dark: ee }, o) : {}, [se, ce] = [ne.declarations ?? "", ne.tokens], [le, ue] = [T.declarations ?? "", T.tokens || []], [de, fe] = [re.declarations ?? "", re.tokens || []], [pe, me] = [E.declarations ?? "", E.tokens || []], [he, ge] = [ie.declarations ?? "", ie.tokens || []], [_e, D] = [ae.declarations ?? "", ae.tokens || []], [ve, ye] = [oe.declarations ?? "", oe.tokens || []];
 			s = this.transformCSS(e, se, "light", "variable", o, r, i), c = ce, l = `${this.transformCSS(e, `${le}${de}`, "light", "variable", o, r, i)}${this.transformCSS(e, `${pe}`, "dark", "variable", o, r, i)}`, u = [...new Set([
 				...ue,
 				...fe,
@@ -4133,7 +4134,7 @@ var Bl = {
 				...ge,
 				...D,
 				...ye
-			])], p = sc(a.css, { dt: Il });
+			])], p = ac(a.css, { dt: Pl });
 		}
 		return {
 			primitive: {
@@ -4154,16 +4155,16 @@ var Bl = {
 	getPreset({ name: e = "", preset: t = {}, options: n, params: r, set: i, defaults: a, selector: o }) {
 		let s, c, l;
 		if (K(t) && n.transform !== "strict") {
-			let r = e.replace("-directive", ""), u = t, { colorScheme: d, extend: f, css: p } = u, m = bl(u, [
+			let r = e.replace("-directive", ""), u = t, { colorScheme: d, extend: f, css: p } = u, m = vl(u, [
 				"colorScheme",
 				"extend",
 				"css"
-			]), h = f || {}, { colorScheme: g } = h, _ = bl(h, ["colorScheme"]), v = d || {}, { dark: y } = v, b = bl(v, ["dark"]), x = g || {}, { dark: S } = x, C = bl(x, ["dark"]), w = K(m) ? this._toVariables({ [r]: vl(vl({}, m), _) }, n) : {}, ee = K(b) ? this._toVariables({ [r]: vl(vl({}, b), C) }, n) : {}, te = K(y) ? this._toVariables({ [r]: vl(vl({}, y), S) }, n) : {}, [ne, T] = [w.declarations ?? "", w.tokens || []], [re, E] = [ee.declarations ?? "", ee.tokens || []], [ie, ae] = [te.declarations ?? "", te.tokens || []];
+			]), h = f || {}, { colorScheme: g } = h, _ = vl(h, ["colorScheme"]), v = d || {}, { dark: y } = v, b = vl(v, ["dark"]), x = g || {}, { dark: S } = x, C = vl(x, ["dark"]), w = K(m) ? this._toVariables({ [r]: gl(gl({}, m), _) }, n) : {}, ee = K(b) ? this._toVariables({ [r]: gl(gl({}, b), C) }, n) : {}, te = K(y) ? this._toVariables({ [r]: gl(gl({}, y), S) }, n) : {}, [ne, T] = [w.declarations ?? "", w.tokens || []], [re, E] = [ee.declarations ?? "", ee.tokens || []], [ie, ae] = [te.declarations ?? "", te.tokens || []];
 			s = `${this.transformCSS(r, `${ne}${re}`, "light", "variable", n, i, a, o)}${this.transformCSS(r, ie, "dark", "variable", n, i, a, o)}`, c = [...new Set([
 				...T,
 				...E,
 				...ae
-			])], l = sc(p, { dt: Il });
+			])], l = ac(p, { dt: Pl });
 		}
 		return {
 			css: s,
@@ -4201,7 +4202,7 @@ var Bl = {
 	},
 	getLayerOrder(e, t = {}, n, r) {
 		let { cssLayer: i } = t;
-		return i ? `@layer ${sc(i.order || i.name || "primeui", n)}` : "";
+		return i ? `@layer ${ac(i.order || i.name || "primeui", n)}` : "";
 	},
 	getCommonStyleSheet({ name: e = "", theme: t = {}, params: n, props: r = {}, set: i, defaults: a }) {
 		let o = this.getCommon({
@@ -4212,8 +4213,8 @@ var Bl = {
 			defaults: a
 		}), s = Object.entries(r).reduce((e, [t, n]) => e.push(`${t}="${n}"`) && e, []).join(" ");
 		return Object.entries(o || {}).reduce((e, [t, n]) => {
-			if (rc(n) && Object.hasOwn(n, "css")) {
-				let r = gc(n.css), i = `${t}-variables`;
+			if (tc(n) && Object.hasOwn(n, "css")) {
+				let r = mc(n.css), i = `${t}-variables`;
 				e.push(`<style type="text/css" data-primevue-style-id="${i}" ${s}>${r}</style>`);
 			}
 			return e;
@@ -4227,7 +4228,7 @@ var Bl = {
 			set: i,
 			defaults: a
 		}, s = (e.includes("-directive") ? this.getPresetD(o) : this.getPresetC(o))?.css, c = Object.entries(r).reduce((e, [t, n]) => e.push(`${t}="${n}"`) && e, []).join(" ");
-		return s ? `<style type="text/css" data-primevue-style-id="${e}-variables" ${c}>${gc(s)}</style>` : "";
+		return s ? `<style type="text/css" data-primevue-style-id="${e}-variables" ${c}>${mc(s)}</style>` : "";
 	},
 	createTokens(e = {}, t, n = "", r = "", i = {}) {
 		let a = function(e, t = {}, n = []) {
@@ -4239,16 +4240,16 @@ var Bl = {
 			};
 			n.push(this.path), t.name = this.path, t.binding ||= {};
 			let r = this.value;
-			if (typeof this.value == "string" && Sl.test(this.value)) {
-				let i = this.value.trim().replace(Sl, (r) => {
+			if (typeof this.value == "string" && bl.test(this.value)) {
+				let i = this.value.trim().replace(bl, (r) => {
 					let i = r.slice(1, -1), a = this.tokens[i];
 					if (!a) return console.warn(`Token not found for path: ${i}`), "__UNRESOLVED__";
 					let o = a.computed(e, t, n);
 					return Array.isArray(o) && o.length === 2 ? `light-dark(${o[0].value},${o[1].value})` : o?.value ?? "__UNRESOLVED__";
 				});
-				r = Cl.test(i.replace(wl, "0")) ? `calc(${i})` : i;
+				r = xl.test(i.replace(Sl, "0")) ? `calc(${i})` : i;
 			}
-			return Xs(t.binding) && delete t.binding, n.pop(), {
+			return Js(t.binding) && delete t.binding, n.pop(), {
 				colorScheme: e,
 				path: this.path,
 				paths: t,
@@ -4256,8 +4257,8 @@ var Bl = {
 			};
 		}, o = (e, n, r) => {
 			Object.entries(e).forEach(([e, s]) => {
-				let c = mc(e, t.variable.excludedKeyRegex) ? n : n ? `${n}.${Tl(e)}` : Tl(e), l = r ? `${r}.${e}` : e;
-				rc(s) ? o(s, c, l) : (i[c] || (i[c] = {
+				let c = fc(e, t.variable.excludedKeyRegex) ? n : n ? `${n}.${Cl(e)}` : Cl(e), l = r ? `${r}.${e}` : e;
+				tc(s) ? o(s, c, l) : (i[c] || (i[c] = {
 					paths: [],
 					computed: (e, t = {}, n = []) => {
 						if (i[c].paths.length === 1) return i[c].paths[0].computed(i[c].paths[0].scheme, t.binding, n);
@@ -4279,31 +4280,31 @@ var Bl = {
 		return o(e, n, r), i;
 	},
 	getTokenValue(e, t, n) {
-		let r = ((e) => e.split(".").filter((e) => !mc(e.toLowerCase(), n.variable.excludedKeyRegex)).join("."))(t), i = t.includes("colorScheme.light") ? "light" : t.includes("colorScheme.dark") ? "dark" : void 0, a = [e[r]?.computed(i)].flat().filter((e) => e);
+		let r = ((e) => e.split(".").filter((e) => !fc(e.toLowerCase(), n.variable.excludedKeyRegex)).join("."))(t), i = t.includes("colorScheme.light") ? "light" : t.includes("colorScheme.dark") ? "dark" : void 0, a = [e[r]?.computed(i)].flat().filter((e) => e);
 		return a.length === 1 ? a[0].value : a.reduce((e = {}, t) => {
 			let n = t, { colorScheme: r } = n;
-			return e[r] = bl(n, ["colorScheme"]), e;
+			return e[r] = vl(n, ["colorScheme"]), e;
 		}, void 0);
 	},
 	getSelectorRule(e, t, n, r) {
-		return n === "class" || n === "attr" ? Nl(K(t) ? `${e}${t},${e} ${t}` : e, r) : Nl(e, Nl(t ?? ":root,:host", r));
+		return n === "class" || n === "attr" ? jl(K(t) ? `${e}${t},${e} ${t}` : e, r) : jl(e, jl(t ?? ":root,:host", r));
 	},
 	transformCSS(e, t, n, r, i = {}, a, o, s) {
 		if (K(t)) {
 			let { cssLayer: c } = i;
 			if (r !== "style") {
 				let e = this.getColorSchemeOption(i, o);
-				t = n === "dark" ? e.reduce((e, { type: n, selector: r }) => (K(r) && (e += r.includes("[CSS]") ? r.replace("[CSS]", t) : this.getSelectorRule(r, s, n, t)), e), "") : Nl(s ?? ":root,:host", t);
+				t = n === "dark" ? e.reduce((e, { type: n, selector: r }) => (K(r) && (e += r.includes("[CSS]") ? r.replace("[CSS]", t) : this.getSelectorRule(r, s, n, t)), e), "") : jl(s ?? ":root,:host", t);
 			}
 			if (c) {
 				let n = {
 					name: "primeui",
 					order: "primeui"
 				};
-				rc(c) && (n.name = sc(c.name, {
+				tc(c) && (n.name = ac(c.name, {
 					name: e,
 					type: r
-				})), K(n.name) && (t = Nl(`@layer ${n.name}`, t), a?.layerNames(n.name));
+				})), K(n.name) && (t = jl(`@layer ${n.name}`, t), a?.layerNames(n.name));
 			}
 			return t;
 		}
@@ -4329,7 +4330,7 @@ var Bl = {
 	_tokens: {},
 	update(e = {}) {
 		let { theme: t } = e;
-		t && (this._theme = yl(vl({}, t), { options: vl(vl({}, this.defaults.options), t.options) }), this._tokens = Bl.createTokens(this.preset, this.defaults), this.clearLoadedStyleNames());
+		t && (this._theme = _l(gl({}, t), { options: gl(gl({}, this.defaults.options), t.options) }), this._tokens = Rl.createTokens(this.preset, this.defaults), this.clearLoadedStyleNames());
 	},
 	get theme() {
 		return this._theme;
@@ -4347,19 +4348,19 @@ var Bl = {
 		return this.theme;
 	},
 	setTheme(e) {
-		this.update({ theme: e }), xl.emit("theme:change", e);
+		this.update({ theme: e }), yl.emit("theme:change", e);
 	},
 	getPreset() {
 		return this.preset;
 	},
 	setPreset(e) {
-		this._theme = yl(vl({}, this.theme), { preset: e }), this._tokens = Bl.createTokens(e, this.defaults), this.clearLoadedStyleNames(), xl.emit("preset:change", e), xl.emit("theme:change", this.theme);
+		this._theme = _l(gl({}, this.theme), { preset: e }), this._tokens = Rl.createTokens(e, this.defaults), this.clearLoadedStyleNames(), yl.emit("preset:change", e), yl.emit("theme:change", this.theme);
 	},
 	getOptions() {
 		return this.options;
 	},
 	setOptions(e) {
-		this._theme = yl(vl({}, this.theme), { options: e }), this.clearLoadedStyleNames(), xl.emit("options:change", e), xl.emit("theme:change", this.theme);
+		this._theme = _l(gl({}, this.theme), { options: e }), this.clearLoadedStyleNames(), yl.emit("options:change", e), yl.emit("theme:change", this.theme);
 	},
 	getLayerNames() {
 		return [...this._layerNames];
@@ -4383,10 +4384,10 @@ var Bl = {
 		this._loadedStyleNames.clear();
 	},
 	getTokenValue(e) {
-		return Bl.getTokenValue(this.tokens, e, this.defaults);
+		return Rl.getTokenValue(this.tokens, e, this.defaults);
 	},
 	getCommon(e = "", t) {
-		return Bl.getCommon({
+		return Rl.getCommon({
 			name: e,
 			theme: this.theme,
 			params: t,
@@ -4402,7 +4403,7 @@ var Bl = {
 			defaults: this.defaults,
 			set: { layerNames: this.setLayerNames.bind(this) }
 		};
-		return Bl.getPresetC(n);
+		return Rl.getPresetC(n);
 	},
 	getDirective(e = "", t) {
 		let n = {
@@ -4412,7 +4413,7 @@ var Bl = {
 			defaults: this.defaults,
 			set: { layerNames: this.setLayerNames.bind(this) }
 		};
-		return Bl.getPresetD(n);
+		return Rl.getPresetD(n);
 	},
 	getCustomPreset(e = "", t, n, r) {
 		let i = {
@@ -4424,16 +4425,16 @@ var Bl = {
 			defaults: this.defaults,
 			set: { layerNames: this.setLayerNames.bind(this) }
 		};
-		return Bl.getPreset(i);
+		return Rl.getPreset(i);
 	},
 	getLayerOrderCSS(e = "") {
-		return Bl.getLayerOrder(e, this.options, { names: this.getLayerNames() }, this.defaults);
+		return Rl.getLayerOrder(e, this.options, { names: this.getLayerNames() }, this.defaults);
 	},
 	transformCSS(e = "", t, n = "style", r) {
-		return Bl.transformCSS(e, t, r, n, this.options, { layerNames: this.setLayerNames.bind(this) }, this.defaults);
+		return Rl.transformCSS(e, t, r, n, this.options, { layerNames: this.setLayerNames.bind(this) }, this.defaults);
 	},
 	getCommonStyleSheet(e = "", t, n = {}) {
-		return Bl.getCommonStyleSheet({
+		return Rl.getCommonStyleSheet({
 			name: e,
 			theme: this.theme,
 			params: t,
@@ -4443,7 +4444,7 @@ var Bl = {
 		});
 	},
 	getStyleSheet(e, t, n = {}) {
-		return Bl.getStyleSheet({
+		return Rl.getStyleSheet({
 			name: e,
 			theme: this.theme,
 			params: t,
@@ -4459,9 +4460,9 @@ var Bl = {
 		this._loadingStyles.add(e);
 	},
 	onStyleLoaded(e, { name: t }) {
-		this._loadingStyles.size && (this._loadingStyles.delete(t), xl.emit(`theme:${t}:load`, e), !this._loadingStyles.size && xl.emit("theme:load"));
+		this._loadingStyles.size && (this._loadingStyles.delete(t), yl.emit(`theme:${t}:load`, e), !this._loadingStyles.size && yl.emit("theme:load"));
 	}
-}, Vl = {
+}, zl = {
 	STARTS_WITH: "startsWith",
 	CONTAINS: "contains",
 	NOT_CONTAINS: "notContains",
@@ -4479,10 +4480,10 @@ var Bl = {
 	DATE_BEFORE: "dateBefore",
 	DATE_AFTER: "dateAfter"
 };
-function Hl(e, t) {
+function Bl(e, t) {
 	var n = typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (!n) {
-		if (Array.isArray(e) || (n = Ul(e)) || t) {
+		if (Array.isArray(e) || (n = Vl(e)) || t) {
 			n && (e = n);
 			var r = 0, i = function() {};
 			return {
@@ -4522,23 +4523,23 @@ function Hl(e, t) {
 		}
 	};
 }
-function Ul(e, t) {
+function Vl(e, t) {
 	if (e) {
-		if (typeof e == "string") return Wl(e, t);
+		if (typeof e == "string") return Hl(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Wl(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Hl(e, t) : void 0;
 	}
 }
-function Wl(e, t) {
+function Hl(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-var Gl = {
+var Ul = {
 	filter: function(e, t, n, r, i) {
 		var a = [];
 		if (!e) return a;
-		var o = Hl(e), s;
+		var o = Bl(e), s;
 		try {
 			for (o.s(); !(s = o.n()).done;) {
 				var c = s.value;
@@ -4548,10 +4549,10 @@ var Gl = {
 						continue;
 					}
 				} else {
-					var l = Hl(t), u;
+					var l = Bl(t), u;
 					try {
 						for (l.s(); !(u = l.n()).done;) {
-							var d = u.value, f = ec(c, d);
+							var d = u.value, f = Qs(c, d);
 							if (this.filters[r](f, n, i)) {
 								a.push(c);
 								break;
@@ -4575,36 +4576,36 @@ var Gl = {
 		startsWith: function(e, t, n) {
 			if (t == null || t === "") return !0;
 			if (e == null) return !1;
-			var r = _c(t.toString()).toLocaleLowerCase(n);
-			return _c(e.toString()).toLocaleLowerCase(n).slice(0, r.length) === r;
+			var r = hc(t.toString()).toLocaleLowerCase(n);
+			return hc(e.toString()).toLocaleLowerCase(n).slice(0, r.length) === r;
 		},
 		contains: function(e, t, n) {
 			if (t == null || t === "") return !0;
 			if (e == null) return !1;
-			var r = _c(t.toString()).toLocaleLowerCase(n);
-			return _c(e.toString()).toLocaleLowerCase(n).indexOf(r) !== -1;
+			var r = hc(t.toString()).toLocaleLowerCase(n);
+			return hc(e.toString()).toLocaleLowerCase(n).indexOf(r) !== -1;
 		},
 		notContains: function(e, t, n) {
 			if (t == null || t === "") return !0;
 			if (e == null) return !1;
-			var r = _c(t.toString()).toLocaleLowerCase(n);
-			return _c(e.toString()).toLocaleLowerCase(n).indexOf(r) === -1;
+			var r = hc(t.toString()).toLocaleLowerCase(n);
+			return hc(e.toString()).toLocaleLowerCase(n).indexOf(r) === -1;
 		},
 		endsWith: function(e, t, n) {
 			if (t == null || t === "") return !0;
 			if (e == null) return !1;
-			var r = _c(t.toString()).toLocaleLowerCase(n), i = _c(e.toString()).toLocaleLowerCase(n);
+			var r = hc(t.toString()).toLocaleLowerCase(n), i = hc(e.toString()).toLocaleLowerCase(n);
 			return i.indexOf(r, i.length - r.length) !== -1;
 		},
 		equals: function(e, t, n) {
-			return t == null || t === "" ? !0 : e == null ? !1 : e.getTime && t.getTime ? e.getTime() === t.getTime() : _c(e.toString()).toLocaleLowerCase(n) == _c(t.toString()).toLocaleLowerCase(n);
+			return t == null || t === "" ? !0 : e == null ? !1 : e.getTime && t.getTime ? e.getTime() === t.getTime() : hc(e.toString()).toLocaleLowerCase(n) == hc(t.toString()).toLocaleLowerCase(n);
 		},
 		notEquals: function(e, t, n) {
-			return t == null || t === "" ? !1 : e == null ? !0 : e.getTime && t.getTime ? e.getTime() !== t.getTime() : _c(e.toString()).toLocaleLowerCase(n) != _c(t.toString()).toLocaleLowerCase(n);
+			return t == null || t === "" ? !1 : e == null ? !0 : e.getTime && t.getTime ? e.getTime() !== t.getTime() : hc(e.toString()).toLocaleLowerCase(n) != hc(t.toString()).toLocaleLowerCase(n);
 		},
 		in: function(e, t) {
 			if (t == null || t.length === 0) return !0;
-			for (var n = 0; n < t.length; n++) if (tc(e, t[n])) return !0;
+			for (var n = 0; n < t.length; n++) if ($s(e, t[n])) return !0;
 			return !1;
 		},
 		between: function(e, t) {
@@ -4638,18 +4639,18 @@ var Gl = {
 	register: function(e, t) {
 		this.filters[e] = t;
 	}
-}, Kl = "\n    *,\n    ::before,\n    ::after {\n        box-sizing: border-box;\n    }\n\n    .p-collapsible-enter-active {\n        animation: p-animate-collapsible-expand 0.2s ease-out;\n        overflow: hidden;\n    }\n\n    .p-collapsible-leave-active {\n        animation: p-animate-collapsible-collapse 0.2s ease-out;\n        overflow: hidden;\n    }\n\n    @keyframes p-animate-collapsible-expand {\n        from {\n            grid-template-rows: 0fr;\n        }\n        to {\n            grid-template-rows: 1fr;\n        }\n    }\n\n    @keyframes p-animate-collapsible-collapse {\n        from {\n            grid-template-rows: 1fr;\n        }\n        to {\n            grid-template-rows: 0fr;\n        }\n    }\n\n    .p-disabled,\n    .p-disabled * {\n        cursor: default;\n        pointer-events: none;\n        user-select: none;\n    }\n\n    .p-disabled,\n    .p-component:disabled {\n        opacity: dt('disabled.opacity');\n    }\n\n    .pi {\n        font-size: dt('icon.size');\n    }\n\n    .p-icon {\n        width: dt('icon.size');\n        height: dt('icon.size');\n    }\n\n    .p-overlay-mask {\n        background: var(--px-mask-background, dt('mask.background'));\n        color: dt('mask.color');\n        position: fixed;\n        top: 0;\n        left: 0;\n        width: 100%;\n        height: 100%;\n    }\n\n    .p-overlay-mask-enter-active {\n        animation: p-animate-overlay-mask-enter dt('mask.transition.duration') forwards;\n    }\n\n    .p-overlay-mask-leave-active {\n        animation: p-animate-overlay-mask-leave dt('mask.transition.duration') forwards;\n    }\n\n    @keyframes p-animate-overlay-mask-enter {\n        from {\n            background: transparent;\n        }\n        to {\n            background: var(--px-mask-background, dt('mask.background'));\n        }\n    }\n    @keyframes p-animate-overlay-mask-leave {\n        from {\n            background: var(--px-mask-background, dt('mask.background'));\n        }\n        to {\n            background: transparent;\n        }\n    }\n\n    .p-anchored-overlay-enter-active {\n        animation: p-animate-anchored-overlay-enter 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    .p-anchored-overlay-leave-active {\n        animation: p-animate-anchored-overlay-leave 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    @keyframes p-animate-anchored-overlay-enter {\n        from {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n\n    @keyframes p-animate-anchored-overlay-leave {\n        to {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n";
+}, Wl = "\n    *,\n    ::before,\n    ::after {\n        box-sizing: border-box;\n    }\n\n    .p-collapsible-enter-active {\n        animation: p-animate-collapsible-expand 0.2s ease-out;\n        overflow: hidden;\n    }\n\n    .p-collapsible-leave-active {\n        animation: p-animate-collapsible-collapse 0.2s ease-out;\n        overflow: hidden;\n    }\n\n    @keyframes p-animate-collapsible-expand {\n        from {\n            grid-template-rows: 0fr;\n        }\n        to {\n            grid-template-rows: 1fr;\n        }\n    }\n\n    @keyframes p-animate-collapsible-collapse {\n        from {\n            grid-template-rows: 1fr;\n        }\n        to {\n            grid-template-rows: 0fr;\n        }\n    }\n\n    .p-disabled,\n    .p-disabled * {\n        cursor: default;\n        pointer-events: none;\n        user-select: none;\n    }\n\n    .p-disabled,\n    .p-component:disabled {\n        opacity: dt('disabled.opacity');\n    }\n\n    .pi {\n        font-size: dt('icon.size');\n    }\n\n    .p-icon {\n        width: dt('icon.size');\n        height: dt('icon.size');\n    }\n\n    .p-overlay-mask {\n        background: var(--px-mask-background, dt('mask.background'));\n        color: dt('mask.color');\n        position: fixed;\n        top: 0;\n        left: 0;\n        width: 100%;\n        height: 100%;\n    }\n\n    .p-overlay-mask-enter-active {\n        animation: p-animate-overlay-mask-enter dt('mask.transition.duration') forwards;\n    }\n\n    .p-overlay-mask-leave-active {\n        animation: p-animate-overlay-mask-leave dt('mask.transition.duration') forwards;\n    }\n\n    @keyframes p-animate-overlay-mask-enter {\n        from {\n            background: transparent;\n        }\n        to {\n            background: var(--px-mask-background, dt('mask.background'));\n        }\n    }\n    @keyframes p-animate-overlay-mask-leave {\n        from {\n            background: var(--px-mask-background, dt('mask.background'));\n        }\n        to {\n            background: transparent;\n        }\n    }\n\n    .p-anchored-overlay-enter-active {\n        animation: p-animate-anchored-overlay-enter 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    .p-anchored-overlay-leave-active {\n        animation: p-animate-anchored-overlay-leave 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    @keyframes p-animate-anchored-overlay-enter {\n        from {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n\n    @keyframes p-animate-anchored-overlay-leave {\n        to {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n";
 //#endregion
 //#region node_modules/@primevue/core/usestyle/index.mjs
-function ql(e) {
+function Gl(e) {
 	"@babel/helpers - typeof";
-	return ql = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Gl = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, ql(e);
+	}, Gl(e);
 }
-function Jl(e, t) {
+function Kl(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -4659,103 +4660,103 @@ function Jl(e, t) {
 	}
 	return n;
 }
-function Yl(e) {
+function ql(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Jl(Object(n), !0).forEach(function(t) {
-			Xl(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Jl(Object(n)).forEach(function(t) {
+		t % 2 ? Kl(Object(n), !0).forEach(function(t) {
+			Jl(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Kl(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Xl(e, t, n) {
-	return (t = Zl(t)) in e ? Object.defineProperty(e, t, {
+function Jl(e, t, n) {
+	return (t = Yl(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Zl(e) {
-	var t = Ql(e, "string");
-	return ql(t) == "symbol" ? t : t + "";
+function Yl(e) {
+	var t = Xl(e, "string");
+	return Gl(t) == "symbol" ? t : t + "";
 }
-function Ql(e, t) {
-	if (ql(e) != "object" || !e) return e;
+function Xl(e, t) {
+	if (Gl(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (ql(r) != "object") return r;
+		if (Gl(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-function $l(e) {
+function Zl(e) {
 	var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : !0;
-	Xa() && Xa().components ? Jr(e) : t ? e() : An(e);
+	Ya() && Ya().components ? qr(e) : t ? e() : kn(e);
 }
-var eu = 0;
-function tu(e) {
-	var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, n = /* @__PURE__ */ $t(!1), r = /* @__PURE__ */ $t(e), i = /* @__PURE__ */ $t(null), a = nl() ? window.document : void 0, o = t.document, s = o === void 0 ? a : o, c = t.immediate, l = c === void 0 ? !0 : c, u = t.manual, d = u === void 0 ? !1 : u, f = t.name, p = f === void 0 ? `style_${++eu}` : f, m = t.id, h = m === void 0 ? void 0 : m, g = t.media, _ = g === void 0 ? void 0 : g, v = t.nonce, y = v === void 0 ? void 0 : v, b = t.first, x = b === void 0 ? !1 : b, S = t.onMounted, C = S === void 0 ? void 0 : S, w = t.onUpdated, ee = w === void 0 ? void 0 : w, te = t.onLoad, ne = te === void 0 ? void 0 : te, T = t.props, re = T === void 0 ? {} : T, E = function() {}, ie = function(t) {
+var Ql = 0;
+function $l(e) {
+	var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, n = /* @__PURE__ */ Qt(!1), r = /* @__PURE__ */ Qt(e), i = /* @__PURE__ */ Qt(null), a = el() ? window.document : void 0, o = t.document, s = o === void 0 ? a : o, c = t.immediate, l = c === void 0 ? !0 : c, u = t.manual, d = u === void 0 ? !1 : u, f = t.name, p = f === void 0 ? `style_${++Ql}` : f, m = t.id, h = m === void 0 ? void 0 : m, g = t.media, _ = g === void 0 ? void 0 : g, v = t.nonce, y = v === void 0 ? void 0 : v, b = t.first, x = b === void 0 ? !1 : b, S = t.onMounted, C = S === void 0 ? void 0 : S, w = t.onUpdated, ee = w === void 0 ? void 0 : w, te = t.onLoad, ne = te === void 0 ? void 0 : te, T = t.props, re = T === void 0 ? {} : T, E = function() {}, ie = function(t) {
 		var a = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
 		if (s) {
-			var o = Yl(Yl({}, re), a), c = o.name || p, l = o.id || h, u = o.nonce || y;
-			i.value = s.querySelector(`style[data-primevue-style-id="${c}"]`) || s.getElementById(l) || s.createElement("style"), i.value.isConnected || (r.value = t || e, Vc(i.value, {
+			var o = ql(ql({}, re), a), c = o.name || p, l = o.id || h, u = o.nonce || y;
+			i.value = s.querySelector(`style[data-primevue-style-id="${c}"]`) || s.getElementById(l) || s.createElement("style"), i.value.isConnected || (r.value = t || e, zc(i.value, {
 				type: "text/css",
 				id: l,
 				media: _,
 				nonce: u
-			}), x ? s.head.prepend(i.value) : s.head.appendChild(i.value), ol(i.value, "data-primevue-style-id", c), Vc(i.value, o), i.value.onload = function(e) {
+			}), x ? s.head.prepend(i.value) : s.head.appendChild(i.value), il(i.value, "data-primevue-style-id", c), zc(i.value, o), i.value.onload = function(e) {
 				return ne?.(e, { name: c });
-			}, C?.(c)), !n.value && (E = Yn(r, function(e) {
+			}, C?.(c)), !n.value && (E = Jn(r, function(e) {
 				i.value.textContent = e, ee?.(c);
 			}, { immediate: !0 }), n.value = !0);
 		}
 	};
-	return l && !d && $l(ie), {
+	return l && !d && Zl(ie), {
 		id: h,
 		name: p,
 		el: i,
 		css: r,
 		unload: function() {
-			!s || !n.value || (E(), zc(i.value) && s.head.removeChild(i.value), n.value = !1, i.value = null);
+			!s || !n.value || (E(), Lc(i.value) && s.head.removeChild(i.value), n.value = !1, i.value = null);
 		},
 		load: ie,
-		isLoaded: /* @__PURE__ */ Wt(n)
+		isLoaded: /* @__PURE__ */ Ut(n)
 	};
 }
 //#endregion
 //#region node_modules/@primevue/core/base/style/index.mjs
-function nu(e) {
+function eu(e) {
 	"@babel/helpers - typeof";
-	return nu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return eu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, nu(e);
+	}, eu(e);
 }
-var ru, iu, au, ou;
-function su(e, t) {
-	return fu(e) || du(e, t) || lu(e, t) || cu();
+var tu, nu, ru, iu;
+function au(e, t) {
+	return uu(e) || lu(e, t) || su(e, t) || ou();
 }
-function cu() {
+function ou() {
 	throw TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function lu(e, t) {
+function su(e, t) {
 	if (e) {
-		if (typeof e == "string") return uu(e, t);
+		if (typeof e == "string") return cu(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? uu(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? cu(e, t) : void 0;
 	}
 }
-function uu(e, t) {
+function cu(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function du(e, t) {
+function lu(e, t) {
 	var n = e == null ? null : typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (n != null) {
 		var r, i, a, o, s = [], c = !0, l = !1;
@@ -4773,10 +4774,10 @@ function du(e, t) {
 		return s;
 	}
 }
-function fu(e) {
+function uu(e) {
 	if (Array.isArray(e)) return e;
 }
-function pu(e, t) {
+function du(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -4786,40 +4787,40 @@ function pu(e, t) {
 	}
 	return n;
 }
-function mu(e) {
+function fu(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? pu(Object(n), !0).forEach(function(t) {
-			hu(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : pu(Object(n)).forEach(function(t) {
+		t % 2 ? du(Object(n), !0).forEach(function(t) {
+			pu(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : du(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function hu(e, t, n) {
-	return (t = gu(t)) in e ? Object.defineProperty(e, t, {
+function pu(e, t, n) {
+	return (t = mu(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function gu(e) {
-	var t = _u(e, "string");
-	return nu(t) == "symbol" ? t : t + "";
+function mu(e) {
+	var t = hu(e, "string");
+	return eu(t) == "symbol" ? t : t + "";
 }
-function _u(e, t) {
-	if (nu(e) != "object" || !e) return e;
+function hu(e, t) {
+	if (eu(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (nu(r) != "object") return r;
+		if (eu(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-function vu(e, t) {
+function gu(e, t) {
 	return t ||= e.slice(0), Object.freeze(Object.defineProperties(e, { raw: { value: Object.freeze(t) } }));
 }
 var X = {
@@ -4847,14 +4848,14 @@ var X = {
 }
 `;
 	},
-	style: Kl,
+	style: Wl,
 	classes: {},
 	inlineStyles: {},
 	load: function(e) {
 		var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, n = (arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : function(e) {
 			return e;
-		})(Rl(ru ||= vu(["", ""]), e));
-		return K(n) ? tu(gc(n), mu({ name: this.name }, t)) : {};
+		})(Il(tu ||= gu(["", ""]), e));
+		return K(n) ? $l(mc(n), fu({ name: this.name }, t)) : {};
 	},
 	loadCSS: function() {
 		var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
@@ -4864,7 +4865,7 @@ var X = {
 		var e = this, t = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, n = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "";
 		return this.load(this.style, t, function() {
 			var r = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "";
-			return Y.transformCSS(t.name || e.name, `${r}${Rl(iu ||= vu(["", ""]), n)}`);
+			return Y.transformCSS(t.name || e.name, `${r}${Il(nu ||= gu(["", ""]), n)}`);
 		});
 	},
 	getCommonTheme: function(e) {
@@ -4885,12 +4886,12 @@ var X = {
 	getStyleSheet: function() {
 		var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "", t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {};
 		if (this.css) {
-			var n = sc(this.css, { dt: Il }) || "", r = gc(Rl(au ||= vu([
+			var n = ac(this.css, { dt: Pl }) || "", r = mc(Il(ru ||= gu([
 				"",
 				"",
 				""
 			]), n, e)), i = Object.entries(t).reduce(function(e, t) {
-				var n = su(t, 2), r = n[0], i = n[1];
+				var n = au(t, 2), r = n[0], i = n[1];
 				return e.push(`${r}="${i}"`) && e;
 			}, []).join(" ");
 			return K(r) ? `<style type="text/css" data-primevue-style-id="${this.name}" ${i}>${r}</style>` : "";
@@ -4904,8 +4905,8 @@ var X = {
 	getThemeStyleSheet: function(e) {
 		var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, n = [Y.getStyleSheet(this.name, e, t)];
 		if (this.style) {
-			var r = this.name === "base" ? "global-style" : `${this.name}-style`, i = Rl(ou ||= vu(["", ""]), sc(this.style, { dt: Il })), a = gc(Y.transformCSS(r, i)), o = Object.entries(t).reduce(function(e, t) {
-				var n = su(t, 2), r = n[0], i = n[1];
+			var r = this.name === "base" ? "global-style" : `${this.name}-style`, i = Il(iu ||= gu(["", ""]), ac(this.style, { dt: Pl })), a = mc(Y.transformCSS(r, i)), o = Object.entries(t).reduce(function(e, t) {
+				var n = au(t, 2), r = n[0], i = n[1];
 				return e.push(`${r}="${i}"`) && e;
 			}, []).join(" ");
 			K(a) && n.push(`<style type="text/css" data-primevue-style-id="${r}" ${o}>${a}</style>`);
@@ -4913,23 +4914,23 @@ var X = {
 		return n.join("");
 	},
 	extend: function(e) {
-		return mu(mu({}, this), {}, {
+		return fu(fu({}, this), {}, {
 			css: void 0,
 			style: void 0
 		}, e);
 	}
-}, yu = bc();
+}, _u = vc();
 //#endregion
 //#region node_modules/@primevue/core/config/index.mjs
-function bu(e) {
+function vu(e) {
 	"@babel/helpers - typeof";
-	return bu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return vu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, bu(e);
+	}, vu(e);
 }
-function xu(e, t) {
+function yu(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -4939,40 +4940,40 @@ function xu(e, t) {
 	}
 	return n;
 }
-function Su(e) {
+function bu(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? xu(Object(n), !0).forEach(function(t) {
-			Cu(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : xu(Object(n)).forEach(function(t) {
+		t % 2 ? yu(Object(n), !0).forEach(function(t) {
+			xu(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : yu(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Cu(e, t, n) {
-	return (t = wu(t)) in e ? Object.defineProperty(e, t, {
+function xu(e, t, n) {
+	return (t = Su(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function wu(e) {
-	var t = Tu(e, "string");
-	return bu(t) == "symbol" ? t : t + "";
+function Su(e) {
+	var t = Cu(e, "string");
+	return vu(t) == "symbol" ? t : t + "";
 }
-function Tu(e, t) {
-	if (bu(e) != "object" || !e) return e;
+function Cu(e, t) {
+	if (vu(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (bu(r) != "object") return r;
+		if (vu(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Eu = {
+var wu = {
 	ripple: !1,
 	inputStyle: null,
 	inputVariant: null,
@@ -5159,26 +5160,26 @@ var Eu = {
 	},
 	filterMatchModeOptions: {
 		text: [
-			Vl.STARTS_WITH,
-			Vl.CONTAINS,
-			Vl.NOT_CONTAINS,
-			Vl.ENDS_WITH,
-			Vl.EQUALS,
-			Vl.NOT_EQUALS
+			zl.STARTS_WITH,
+			zl.CONTAINS,
+			zl.NOT_CONTAINS,
+			zl.ENDS_WITH,
+			zl.EQUALS,
+			zl.NOT_EQUALS
 		],
 		numeric: [
-			Vl.EQUALS,
-			Vl.NOT_EQUALS,
-			Vl.LESS_THAN,
-			Vl.LESS_THAN_OR_EQUAL_TO,
-			Vl.GREATER_THAN,
-			Vl.GREATER_THAN_OR_EQUAL_TO
+			zl.EQUALS,
+			zl.NOT_EQUALS,
+			zl.LESS_THAN,
+			zl.LESS_THAN_OR_EQUAL_TO,
+			zl.GREATER_THAN,
+			zl.GREATER_THAN_OR_EQUAL_TO
 		],
 		date: [
-			Vl.DATE_IS,
-			Vl.DATE_IS_NOT,
-			Vl.DATE_BEFORE,
-			Vl.DATE_AFTER
+			zl.DATE_IS,
+			zl.DATE_IS_NOT,
+			zl.DATE_BEFORE,
+			zl.DATE_AFTER
 		]
 	},
 	zIndex: {
@@ -5195,59 +5196,59 @@ var Eu = {
 		mergeProps: !1
 	},
 	csp: { nonce: void 0 }
-}, Du = Symbol();
-function Ou(e, t) {
-	var n = { config: /* @__PURE__ */ Ht(t) };
-	return e.config.globalProperties.$primevue = n, e.provide(Du, n), Au(), ju(e, n), n;
+}, Tu = Symbol();
+function Eu(e, t) {
+	var n = { config: /* @__PURE__ */ Vt(t) };
+	return e.config.globalProperties.$primevue = n, e.provide(Tu, n), Ou(), ku(e, n), n;
 }
-var ku = [];
-function Au() {
-	xl.clear(), ku.forEach(function(e) {
+var Du = [];
+function Ou() {
+	yl.clear(), Du.forEach(function(e) {
 		return e?.();
-	}), ku = [];
+	}), Du = [];
 }
-function ju(e, t) {
-	var n = /* @__PURE__ */ $t(!1), r = function() {
+function ku(e, t) {
+	var n = /* @__PURE__ */ Qt(!1), r = function() {
 		if (t.config?.theme !== "none" && !Y.isStyleNameLoaded("common")) {
 			var e, n = X.getCommonTheme?.call(X) || {}, r = n.primitive, i = n.semantic, a = n.global, o = n.style, s = { nonce: (e = t.config) == null || (e = e.csp) == null ? void 0 : e.nonce };
-			X.load(r?.css, Su({ name: "primitive-variables" }, s)), X.load(i?.css, Su({ name: "semantic-variables" }, s)), X.load(a?.css, Su({ name: "global-variables" }, s)), X.loadStyle(Su({ name: "global-style" }, s), o), Y.setLoadedStyleName("common");
+			X.load(r?.css, bu({ name: "primitive-variables" }, s)), X.load(i?.css, bu({ name: "semantic-variables" }, s)), X.load(a?.css, bu({ name: "global-variables" }, s)), X.loadStyle(bu({ name: "global-style" }, s), o), Y.setLoadedStyleName("common");
 		}
 	};
-	xl.on("theme:change", function(t) {
+	yl.on("theme:change", function(t) {
 		n.value ||= (e.config.globalProperties.$primevue.config.theme = t, !0);
 	});
-	var i = Yn(t.config, function(e, t) {
-		yu.emit("config:change", {
+	var i = Jn(t.config, function(e, t) {
+		_u.emit("config:change", {
 			newValue: e,
 			oldValue: t
 		});
 	}, {
 		immediate: !0,
 		deep: !0
-	}), a = Yn(function() {
+	}), a = Jn(function() {
 		return t.config.ripple;
 	}, function(e, t) {
-		yu.emit("config:ripple:change", {
+		_u.emit("config:ripple:change", {
 			newValue: e,
 			oldValue: t
 		});
 	}, {
 		immediate: !0,
 		deep: !0
-	}), o = Yn(function() {
+	}), o = Jn(function() {
 		return t.config.theme;
 	}, function(e, i) {
-		n.value || Y.setTheme(e), t.config.unstyled || r(), n.value = !1, yu.emit("config:theme:change", {
+		n.value || Y.setTheme(e), t.config.unstyled || r(), n.value = !1, _u.emit("config:theme:change", {
 			newValue: e,
 			oldValue: i
 		});
 	}, {
 		immediate: !0,
 		deep: !1
-	}), s = Yn(function() {
+	}), s = Jn(function() {
 		return t.config.unstyled;
 	}, function(e, n) {
-		!e && t.config.theme && r(), yu.emit("config:unstyled:change", {
+		!e && t.config.theme && r(), _u.emit("config:unstyled:change", {
 			newValue: e,
 			oldValue: n
 		});
@@ -5255,37 +5256,37 @@ function ju(e, t) {
 		immediate: !0,
 		deep: !0
 	});
-	ku.push(i), ku.push(a), ku.push(o), ku.push(s);
+	Du.push(i), Du.push(a), Du.push(o), Du.push(s);
 }
-var Mu = { install: function(e, t) {
-	Ou(e, hc(Eu, t));
-} }, Nu = bc(), Pu = Symbol(), Fu = { install: function(e) {
+var Au = { install: function(e, t) {
+	Eu(e, pc(wu, t));
+} }, ju = vc(), Mu = Symbol(), Nu = { install: function(e) {
 	var t = {
 		add: function(e) {
-			Nu.emit("add", e);
+			ju.emit("add", e);
 		},
 		remove: function(e) {
-			Nu.emit("remove", e);
+			ju.emit("remove", e);
 		},
 		removeGroup: function(e) {
-			Nu.emit("remove-group", e);
+			ju.emit("remove-group", e);
 		},
 		removeAllGroups: function() {
-			Nu.emit("remove-all-groups");
+			ju.emit("remove-all-groups");
 		}
 	};
-	e.config.globalProperties.$toast = t, e.provide(Pu, t);
-} }, Iu = bc(), Lu = Symbol(), Ru = { install: function(e) {
+	e.config.globalProperties.$toast = t, e.provide(Mu, t);
+} }, Pu = vc(), Fu = Symbol(), Iu = { install: function(e) {
 	var t = {
 		require: function(e) {
-			Iu.emit("confirm", e);
+			Pu.emit("confirm", e);
 		},
 		close: function() {
-			Iu.emit("close");
+			Pu.emit("close");
 		}
 	};
-	e.config.globalProperties.$confirm = t, e.provide(Lu, t);
-} }, zu = {
+	e.config.globalProperties.$confirm = t, e.provide(Fu, t);
+} }, Lu = {
 	_loadedStyleNames: /* @__PURE__ */ new Set(),
 	getLoadedStyleNames: function() {
 		return this._loadedStyleNames;
@@ -5305,45 +5306,45 @@ var Mu = { install: function(e, t) {
 };
 //#endregion
 //#region node_modules/@primevue/core/useattrselector/index.mjs
-function Bu() {
-	return `${arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "pc"}${kr().replace("v-", "").replaceAll("-", "_")}`;
+function Ru() {
+	return `${arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "pc"}${Or().replace("v-", "").replaceAll("-", "_")}`;
 }
 //#endregion
 //#region node_modules/@primevue/core/basecomponent/index.mjs
-var Vu = X.extend({ name: "common" });
-function Hu(e) {
+var zu = X.extend({ name: "common" });
+function Bu(e) {
 	"@babel/helpers - typeof";
-	return Hu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Bu = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Hu(e);
+	}, Bu(e);
 }
-function Uu(e) {
-	return Xu(e) || Wu(e) || qu(e) || Ku();
+function Vu(e) {
+	return Ju(e) || Hu(e) || Gu(e) || Wu();
 }
-function Wu(e) {
+function Hu(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Gu(e, t) {
-	return Xu(e) || Yu(e, t) || qu(e, t) || Ku();
+function Uu(e, t) {
+	return Ju(e) || qu(e, t) || Gu(e, t) || Wu();
 }
-function Ku() {
+function Wu() {
 	throw TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function qu(e, t) {
+function Gu(e, t) {
 	if (e) {
-		if (typeof e == "string") return Ju(e, t);
+		if (typeof e == "string") return Ku(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Ju(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Ku(e, t) : void 0;
 	}
 }
-function Ju(e, t) {
+function Ku(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Yu(e, t) {
+function qu(e, t) {
 	var n = e == null ? null : typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (n != null) {
 		var r, i, a, o, s = [], c = !0, l = !1;
@@ -5364,10 +5365,10 @@ function Yu(e, t) {
 		return s;
 	}
 }
-function Xu(e) {
+function Ju(e) {
 	if (Array.isArray(e)) return e;
 }
-function Zu(e, t) {
+function Yu(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -5380,37 +5381,37 @@ function Zu(e, t) {
 function Z(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Zu(Object(n), !0).forEach(function(t) {
-			Qu(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Zu(Object(n)).forEach(function(t) {
+		t % 2 ? Yu(Object(n), !0).forEach(function(t) {
+			Xu(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Yu(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Qu(e, t, n) {
-	return (t = $u(t)) in e ? Object.defineProperty(e, t, {
+function Xu(e, t, n) {
+	return (t = Zu(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function $u(e) {
-	var t = ed(e, "string");
-	return Hu(t) == "symbol" ? t : t + "";
+function Zu(e) {
+	var t = Qu(e, "string");
+	return Bu(t) == "symbol" ? t : t + "";
 }
-function ed(e, t) {
-	if (Hu(e) != "object" || !e) return e;
+function Qu(e, t) {
+	if (Bu(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Hu(r) != "object") return r;
+		if (Bu(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var td = {
+var $u = {
 	name: "BaseComponent",
 	props: {
 		pt: {
@@ -5435,14 +5436,14 @@ var td = {
 		isUnstyled: {
 			immediate: !0,
 			handler: function(e) {
-				xl.off("theme:change", this._loadCoreStyles), e || (this._loadCoreStyles(), this._themeChangeListener(this._loadCoreStyles));
+				yl.off("theme:change", this._loadCoreStyles), e || (this._loadCoreStyles(), this._themeChangeListener(this._loadCoreStyles));
 			}
 		},
 		dt: {
 			immediate: !0,
 			handler: function(e, t) {
 				var n = this;
-				xl.off("theme:change", this._themeScopedListener), e ? (this._loadScopedThemeStyles(e), this._themeScopedListener = function() {
+				yl.off("theme:change", this._themeScopedListener), e ? (this._loadScopedThemeStyles(e), this._themeScopedListener = function() {
 					return n._loadScopedThemeStyles(e);
 				}, this._themeChangeListener(this._themeScopedListener)) : this._unloadScopedThemeStyles();
 			}
@@ -5456,13 +5457,13 @@ var td = {
 		var e, t, n, r, i, a, o, s, c, l, u = this.pt?._usept, d = u ? (e = this.pt) == null || (e = e.originalValue) == null ? void 0 : e[this.$.type.name] : void 0;
 		(n = (u ? (t = this.pt) == null || (t = t.value) == null ? void 0 : t[this.$.type.name] : this.pt) || d) == null || (n = n.hooks) == null || (r = n.onBeforeCreate) == null || r.call(n);
 		var f = (i = this.$primevueConfig) == null || (i = i.pt) == null ? void 0 : i._usept, p = f ? (a = this.$primevue) == null || (a = a.config) == null || (a = a.pt) == null ? void 0 : a.originalValue : void 0;
-		(c = (f ? (o = this.$primevue) == null || (o = o.config) == null || (o = o.pt) == null ? void 0 : o.value : (s = this.$primevue) == null || (s = s.config) == null ? void 0 : s.pt) || p) == null || (c = c[this.$.type.name]) == null || (c = c.hooks) == null || (l = c.onBeforeCreate) == null || l.call(c), this.$attrSelector = Bu(), this.uid = this.$attrs.id || this.$attrSelector.replace("pc", "pv_id_");
+		(c = (f ? (o = this.$primevue) == null || (o = o.config) == null || (o = o.pt) == null ? void 0 : o.value : (s = this.$primevue) == null || (s = s.config) == null ? void 0 : s.pt) || p) == null || (c = c[this.$.type.name]) == null || (c = c.hooks) == null || (l = c.onBeforeCreate) == null || l.call(c), this.$attrSelector = Ru(), this.uid = this.$attrs.id || this.$attrSelector.replace("pc", "pv_id_");
 	},
 	created: function() {
 		this._hook("onCreated");
 	},
 	beforeMount: function() {
-		this.rootEl = Wc(Bc(this.$el) ? this.$el : this.$el?.parentElement, `[${this.$attrSelector}]`), this.rootEl && (this.rootEl.$pc = Z({
+		this.rootEl = Hc(Rc(this.$el) ? this.$el : this.$el?.parentElement, `[${this.$attrSelector}]`), this.rootEl && (this.rootEl.$pc = Z({
 			name: this.$.type.name,
 			attrSelector: this.$attrSelector
 		}, this.$params)), this._loadStyles(), this._hook("onBeforeMount");
@@ -5491,17 +5492,17 @@ var td = {
 		},
 		_mergeProps: function(e) {
 			var t = [...arguments].slice(1);
-			return $s(e) ? e.apply(void 0, t) : W.apply(void 0, t);
+			return Zs(e) ? e.apply(void 0, t) : W.apply(void 0, t);
 		},
 		_load: function() {
-			zu.isStyleNameLoaded("base") || (X.loadCSS(this.$styleOptions), this._loadGlobalStyles(), zu.setLoadedStyleName("base")), this._loadThemeStyles();
+			Lu.isStyleNameLoaded("base") || (X.loadCSS(this.$styleOptions), this._loadGlobalStyles(), Lu.setLoadedStyleName("base")), this._loadThemeStyles();
 		},
 		_loadStyles: function() {
 			this._load(), this._themeChangeListener(this._load);
 		},
 		_loadCoreStyles: function() {
 			var e;
-			!zu.isStyleNameLoaded(this.$style?.name) && (e = this.$style) != null && e.name && (Vu.loadCSS(this.$styleOptions), this.$options.style && this.$style.loadCSS(this.$styleOptions), zu.setLoadedStyleName(this.$style.name));
+			!Lu.isStyleNameLoaded(this.$style?.name) && (e = this.$style) != null && e.name && (zu.loadCSS(this.$styleOptions), this.$options.style && this.$style.loadCSS(this.$styleOptions), Lu.setLoadedStyleName(this.$style.name));
 		},
 		_loadGlobalStyles: function() {
 			var e = this._useGlobalPT(this._getOptionValue, "global.css", this.$params);
@@ -5537,10 +5538,10 @@ var td = {
 		},
 		_themeChangeListener: function() {
 			var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : function() {};
-			zu.clearLoadedStyleNames(), xl.on("theme:change", e);
+			Lu.clearLoadedStyleNames(), yl.on("theme:change", e);
 		},
 		_removeThemeListeners: function() {
-			xl.off("theme:change", this._loadCoreStyles), xl.off("theme:change", this._load), xl.off("theme:change", this._themeScopedListener);
+			yl.off("theme:change", this._loadCoreStyles), yl.off("theme:change", this._load), yl.off("theme:change", this._themeScopedListener);
 		},
 		_getHostInstance: function(e) {
 			return e ? this.$options.hostName ? e.$.type.name === this.$options.hostName ? e : this._getHostInstance(e.$parentInstance) : e.$parentInstance : void 0;
@@ -5549,7 +5550,7 @@ var td = {
 			return this[e] || this._getHostInstance(this)?.[e];
 		},
 		_getOptionValue: function(e) {
-			return uc(e, arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {});
+			return cc(e, arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {});
 		},
 		_getPTValue: function() {
 			var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", n = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {}, r = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : !0, i = /./g.test(t) && !!n[t.split(".")[0]], a = this._getPropValue("ptOptions") || this.$primevueConfig?.ptOptions || {}, o = a.mergeSections, s = o === void 0 ? !0 : o, c = a.mergeProps, l = c === void 0 ? !1 : c, u = r ? i ? this._useGlobalPT(this._getPTClassValue, t, n) : this._useDefaultPT(this._getPTClassValue, t, n) : void 0, d = i ? void 0 : this._getPTSelf(e, this._getPTClassValue, t, Z(Z({}, n), {}, { global: u || {} })), f = this._getPTDatasets(t);
@@ -5561,15 +5562,15 @@ var td = {
 		},
 		_getPTDatasets: function() {
 			var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "", t = "data-pc-", n = e === "root" && K(this.pt?.["data-pc-section"]);
-			return e !== "transition" && Z(Z({}, e === "root" && Z(Z(Qu({}, `${t}name`, lc(n ? this.pt?.["data-pc-section"] : this.$.type.name)), n && Qu({}, `${t}extend`, lc(this.$.type.name))), {}, Qu({}, `${this.$attrSelector}`, ""))), {}, Qu({}, `${t}section`, lc(e)));
+			return e !== "transition" && Z(Z({}, e === "root" && Z(Z(Xu({}, `${t}name`, sc(n ? this.pt?.["data-pc-section"] : this.$.type.name)), n && Xu({}, `${t}extend`, sc(this.$.type.name))), {}, Xu({}, `${this.$attrSelector}`, ""))), {}, Xu({}, `${t}section`, sc(e)));
 		},
 		_getPTClassValue: function() {
 			var e = this._getOptionValue.apply(this, arguments);
-			return cc(e) || dc(e) ? { class: e } : e;
+			return oc(e) || lc(e) ? { class: e } : e;
 		},
 		_getPT: function(e) {
 			var t = this, n = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", r = arguments.length > 2 ? arguments[2] : void 0, i = function(e) {
-				var i = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : !1, a = r ? r(e) : e, o = lc(n), s = lc(t.$name);
+				var i = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : !1, a = r ? r(e) : e, o = sc(n), s = sc(t.$name);
 				return (i && o === s ? void 0 : a?.[o]) ?? a;
 			};
 			return e != null && e.hasOwnProperty("_usept") ? {
@@ -5584,7 +5585,7 @@ var td = {
 			};
 			if (e != null && e.hasOwnProperty("_usept")) {
 				var a = e._usept || this.$primevueConfig?.ptOptions || {}, o = a.mergeSections, s = o === void 0 ? !0 : o, c = a.mergeProps, l = c === void 0 ? !1 : c, u = i(e.originalValue), d = i(e.value);
-				return u === void 0 && d === void 0 ? void 0 : cc(d) ? d : cc(u) ? u : s || !s && d ? l ? this._mergeProps(l, u, d) : Z(Z({}, u), d) : d;
+				return u === void 0 && d === void 0 ? void 0 : oc(d) ? d : oc(u) ? u : s || !s && d ? l ? this._mergeProps(l, u, d) : Z(Z({}, u), d) : d;
 			}
 			return i(e);
 		},
@@ -5614,7 +5615,7 @@ var td = {
 			var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : "", t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : !0, n = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : {};
 			if (t) {
 				var r = this._getOptionValue(this.$style.inlineStyles, e, Z(Z({}, this.$params), n));
-				return [this._getOptionValue(Vu.inlineStyles, e, Z(Z({}, this.$params), n)), r];
+				return [this._getOptionValue(zu.inlineStyles, e, Z(Z({}, this.$params), n)), r];
 			}
 		}
 	},
@@ -5622,13 +5623,13 @@ var td = {
 		globalPT: function() {
 			var e = this;
 			return this._getPT(this.$primevueConfig?.pt, void 0, function(t) {
-				return sc(t, { instance: e });
+				return ac(t, { instance: e });
 			});
 		},
 		defaultPT: function() {
 			var e = this;
 			return this._getPT(this.$primevueConfig?.pt, void 0, function(t) {
-				return e._getOptionValue(t, e.$name, Z({}, e.$params)) || sc(t, Z({}, e.$params));
+				return e._getOptionValue(t, e.$name, Z({}, e.$params)) || ac(t, Z({}, e.$params));
 			});
 		},
 		isUnstyled: function() {
@@ -5640,7 +5641,7 @@ var td = {
 		$inProps: function() {
 			var e = Object.keys(this.$.vnode?.props || {});
 			return Object.fromEntries(Object.entries(this.$props).filter(function(t) {
-				var n = Gu(t, 1)[0];
+				var n = Uu(t, 1)[0];
 				return e?.includes(n);
 			}));
 		},
@@ -5683,39 +5684,39 @@ var td = {
 		},
 		$_attrsPT: function() {
 			return Object.entries(this.$attrs || {}).filter(function(e) {
-				return Gu(e, 1)[0]?.startsWith("pt:");
+				return Uu(e, 1)[0]?.startsWith("pt:");
 			}).reduce(function(e, t) {
-				var n = Gu(t, 2), r = n[0], i = n[1];
-				return Ju(Uu(r.split(":"))).slice(1)?.reduce(function(e, t, n, r) {
+				var n = Uu(t, 2), r = n[0], i = n[1];
+				return Ku(Vu(r.split(":"))).slice(1)?.reduce(function(e, t, n, r) {
 					return !e[t] && (e[t] = n === r.length - 1 ? i : {}), e[t];
 				}, e), e;
 			}, {});
 		},
 		$_attrsWithoutPT: function() {
 			return Object.entries(this.$attrs || {}).filter(function(e) {
-				var t = Gu(e, 1)[0];
+				var t = Uu(e, 1)[0];
 				return !(t != null && t.startsWith("pt:"));
 			}).reduce(function(e, t) {
-				var n = Gu(t, 2), r = n[0];
+				var n = Uu(t, 2), r = n[0];
 				return e[r] = n[1], e;
 			}, {});
 		}
 	}
-}, nd = X.extend({
+}, ed = X.extend({
 	name: "baseicon",
 	css: "\n.p-icon {\n    display: inline-block;\n    vertical-align: baseline;\n    flex-shrink: 0;\n}\n\n.p-icon-spin {\n    -webkit-animation: p-icon-spin 2s infinite linear;\n    animation: p-icon-spin 2s infinite linear;\n}\n\n@-webkit-keyframes p-icon-spin {\n    0% {\n        -webkit-transform: rotate(0deg);\n        transform: rotate(0deg);\n    }\n    100% {\n        -webkit-transform: rotate(359deg);\n        transform: rotate(359deg);\n    }\n}\n\n@keyframes p-icon-spin {\n    0% {\n        -webkit-transform: rotate(0deg);\n        transform: rotate(0deg);\n    }\n    100% {\n        -webkit-transform: rotate(359deg);\n        transform: rotate(359deg);\n    }\n}\n"
 });
 //#endregion
 //#region node_modules/@primevue/icons/baseicon/index.mjs
-function rd(e) {
+function td(e) {
 	"@babel/helpers - typeof";
-	return rd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return td = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, rd(e);
+	}, td(e);
 }
-function id(e, t) {
+function nd(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -5725,42 +5726,42 @@ function id(e, t) {
 	}
 	return n;
 }
-function ad(e) {
+function rd(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? id(Object(n), !0).forEach(function(t) {
-			od(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : id(Object(n)).forEach(function(t) {
+		t % 2 ? nd(Object(n), !0).forEach(function(t) {
+			id(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : nd(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function od(e, t, n) {
-	return (t = sd(t)) in e ? Object.defineProperty(e, t, {
+function id(e, t, n) {
+	return (t = ad(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function sd(e) {
-	var t = cd(e, "string");
-	return rd(t) == "symbol" ? t : t + "";
+function ad(e) {
+	var t = od(e, "string");
+	return td(t) == "symbol" ? t : t + "";
 }
-function cd(e, t) {
-	if (rd(e) != "object" || !e) return e;
+function od(e, t) {
+	if (td(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (rd(r) != "object") return r;
+		if (td(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var ld = {
+var sd = {
 	name: "BaseIcon",
-	extends: td,
+	extends: $u,
 	props: {
 		label: {
 			type: String,
@@ -5771,7 +5772,7 @@ var ld = {
 			default: !1
 		}
 	},
-	style: nd,
+	style: ed,
 	provide: function() {
 		return {
 			$pcIcon: this,
@@ -5779,64 +5780,64 @@ var ld = {
 		};
 	},
 	methods: { pti: function() {
-		var e = Xs(this.label);
-		return ad(ad({}, !this.isUnstyled && { class: ["p-icon", { "p-icon-spin": this.spin }] }), {}, {
+		var e = Js(this.label);
+		return rd(rd({}, !this.isUnstyled && { class: ["p-icon", { "p-icon-spin": this.spin }] }), {}, {
 			role: e ? void 0 : "img",
 			"aria-label": e ? void 0 : this.label,
 			"aria-hidden": e
 		});
 	} }
-}, ud = {
+}, cd = {
 	name: "SpinnerIcon",
-	extends: ld
+	extends: sd
 };
-function dd(e) {
-	return hd(e) || md(e) || pd(e) || fd();
+function ld(e) {
+	return pd(e) || fd(e) || dd(e) || ud();
 }
-function fd() {
+function ud() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function pd(e, t) {
+function dd(e, t) {
 	if (e) {
-		if (typeof e == "string") return gd(e, t);
+		if (typeof e == "string") return md(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? gd(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? md(e, t) : void 0;
 	}
 }
-function md(e) {
+function fd(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function hd(e) {
-	if (Array.isArray(e)) return gd(e);
+function pd(e) {
+	if (Array.isArray(e)) return md(e);
 }
-function gd(e, t) {
+function md(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function _d(e, t, n, r, i, a) {
+function hd(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), dd(t[0] ||= [V("path", {
+	}, e.pti()), ld(t[0] ||= [V("path", {
 		d: "M6.99701 14C5.85441 13.999 4.72939 13.7186 3.72012 13.1832C2.71084 12.6478 1.84795 11.8737 1.20673 10.9284C0.565504 9.98305 0.165424 8.89526 0.041387 7.75989C-0.0826496 6.62453 0.073125 5.47607 0.495122 4.4147C0.917119 3.35333 1.59252 2.4113 2.46241 1.67077C3.33229 0.930247 4.37024 0.413729 5.4857 0.166275C6.60117 -0.0811796 7.76026 -0.0520535 8.86188 0.251112C9.9635 0.554278 10.9742 1.12227 11.8057 1.90555C11.915 2.01493 11.9764 2.16319 11.9764 2.31778C11.9764 2.47236 11.915 2.62062 11.8057 2.73C11.7521 2.78503 11.688 2.82877 11.6171 2.85864C11.5463 2.8885 11.4702 2.90389 11.3933 2.90389C11.3165 2.90389 11.2404 2.8885 11.1695 2.85864C11.0987 2.82877 11.0346 2.78503 10.9809 2.73C9.9998 1.81273 8.73246 1.26138 7.39226 1.16876C6.05206 1.07615 4.72086 1.44794 3.62279 2.22152C2.52471 2.99511 1.72683 4.12325 1.36345 5.41602C1.00008 6.70879 1.09342 8.08723 1.62775 9.31926C2.16209 10.5513 3.10478 11.5617 4.29713 12.1803C5.48947 12.7989 6.85865 12.988 8.17414 12.7157C9.48963 12.4435 10.6711 11.7264 11.5196 10.6854C12.3681 9.64432 12.8319 8.34282 12.8328 7C12.8328 6.84529 12.8943 6.69692 13.0038 6.58752C13.1132 6.47812 13.2616 6.41667 13.4164 6.41667C13.5712 6.41667 13.7196 6.47812 13.8291 6.58752C13.9385 6.69692 14 6.84529 14 7C14 8.85651 13.2622 10.637 11.9489 11.9497C10.6356 13.2625 8.85432 14 6.99701 14Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-ud.render = _d;
+cd.render = hd;
 //#endregion
 //#region node_modules/primevue/badge/style/index.mjs
-var vd = X.extend({
+var gd = X.extend({
 	name: "badge",
 	style: "\n    .p-badge {\n        display: inline-flex;\n        border-radius: dt('badge.border.radius');\n        align-items: center;\n        justify-content: center;\n        padding: dt('badge.padding');\n        background: dt('badge.primary.background');\n        color: dt('badge.primary.color');\n        font-size: dt('badge.font.size');\n        font-weight: dt('badge.font.weight');\n        min-width: dt('badge.min.width');\n        height: dt('badge.height');\n    }\n\n    .p-badge-dot {\n        width: dt('badge.dot.size');\n        min-width: dt('badge.dot.size');\n        height: dt('badge.dot.size');\n        border-radius: 50%;\n        padding: 0;\n    }\n\n    .p-badge-circle {\n        padding: 0;\n        border-radius: 50%;\n    }\n\n    .p-badge-secondary {\n        background: dt('badge.secondary.background');\n        color: dt('badge.secondary.color');\n    }\n\n    .p-badge-success {\n        background: dt('badge.success.background');\n        color: dt('badge.success.color');\n    }\n\n    .p-badge-info {\n        background: dt('badge.info.background');\n        color: dt('badge.info.color');\n    }\n\n    .p-badge-warn {\n        background: dt('badge.warn.background');\n        color: dt('badge.warn.color');\n    }\n\n    .p-badge-danger {\n        background: dt('badge.danger.background');\n        color: dt('badge.danger.color');\n    }\n\n    .p-badge-contrast {\n        background: dt('badge.contrast.background');\n        color: dt('badge.contrast.color');\n    }\n\n    .p-badge-sm {\n        font-size: dt('badge.sm.font.size');\n        min-width: dt('badge.sm.min.width');\n        height: dt('badge.sm.height');\n    }\n\n    .p-badge-lg {\n        font-size: dt('badge.lg.font.size');\n        min-width: dt('badge.lg.min.width');\n        height: dt('badge.lg.height');\n    }\n\n    .p-badge-xl {\n        font-size: dt('badge.xl.font.size');\n        min-width: dt('badge.xl.min.width');\n        height: dt('badge.xl.height');\n    }\n",
 	classes: { root: function(e) {
 		var t = e.props, n = e.instance;
 		return ["p-badge p-component", {
 			"p-badge-circle": K(t.value) && String(t.value).length === 1,
-			"p-badge-dot": Xs(t.value) && !n.$slots.default,
+			"p-badge-dot": Js(t.value) && !n.$slots.default,
 			"p-badge-sm": t.size === "small",
 			"p-badge-lg": t.size === "large",
 			"p-badge-xl": t.size === "xlarge",
@@ -5848,9 +5849,9 @@ var vd = X.extend({
 			"p-badge-contrast": t.severity === "contrast"
 		}];
 	} }
-}), yd = {
+}), _d = {
 	name: "BaseBadge",
-	extends: td,
+	extends: $u,
 	props: {
 		value: {
 			type: [String, Number],
@@ -5865,7 +5866,7 @@ var vd = X.extend({
 			default: null
 		}
 	},
-	style: vd,
+	style: gd,
 	provide: function() {
 		return {
 			$pcBadge: this,
@@ -5873,85 +5874,85 @@ var vd = X.extend({
 		};
 	}
 };
-function bd(e) {
+function vd(e) {
 	"@babel/helpers - typeof";
-	return bd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return vd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, bd(e);
+	}, vd(e);
 }
-function xd(e, t, n) {
-	return (t = Sd(t)) in e ? Object.defineProperty(e, t, {
+function yd(e, t, n) {
+	return (t = bd(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Sd(e) {
-	var t = Cd(e, "string");
-	return bd(t) == "symbol" ? t : t + "";
+function bd(e) {
+	var t = xd(e, "string");
+	return vd(t) == "symbol" ? t : t + "";
 }
-function Cd(e, t) {
-	if (bd(e) != "object" || !e) return e;
+function xd(e, t) {
+	if (vd(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (bd(r) != "object") return r;
+		if (vd(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var wd = {
+var Sd = {
 	name: "Badge",
-	extends: yd,
+	extends: _d,
 	inheritAttrs: !1,
 	computed: { dataP: function() {
-		return q(xd(xd({
+		return q(yd(yd({
 			circle: this.value != null && String(this.value).length === 1,
 			empty: this.value == null && !this.$slots.default
 		}, this.severity, this.severity), this.size, this.size));
 	} }
-}, Td = ["data-p"];
-function Ed(e, t, n, r, i, a) {
+}, Cd = ["data-p"];
+function wd(e, t, n, r, i, a) {
 	return R(), z("span", W({
 		class: e.cx("root"),
 		"data-p": a.dataP
 	}, e.ptmi("root")), [I(e.$slots, "default", {}, function() {
-		return [Ha(O(e.value), 1)];
-	})], 16, Td);
+		return [Va(O(e.value), 1)];
+	})], 16, Cd);
 }
-wd.render = Ed;
+Sd.render = wd;
 //#endregion
 //#region node_modules/@primevue/core/basedirective/index.mjs
-function Dd(e) {
+function Td(e) {
 	"@babel/helpers - typeof";
-	return Dd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Td = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Dd(e);
+	}, Td(e);
 }
-function Od(e, t) {
-	return Nd(e) || Md(e, t) || Ad(e, t) || kd();
+function Ed(e, t) {
+	return jd(e) || Ad(e, t) || Od(e, t) || Dd();
 }
-function kd() {
+function Dd() {
 	throw TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Ad(e, t) {
+function Od(e, t) {
 	if (e) {
-		if (typeof e == "string") return jd(e, t);
+		if (typeof e == "string") return kd(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? jd(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? kd(e, t) : void 0;
 	}
 }
-function jd(e, t) {
+function kd(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Md(e, t) {
+function Ad(e, t) {
 	var n = e == null ? null : typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (n != null) {
 		var r, i, a, o, s = [], c = !0, l = !1;
@@ -5969,10 +5970,10 @@ function Md(e, t) {
 		return s;
 	}
 }
-function Nd(e) {
+function jd(e) {
 	if (Array.isArray(e)) return e;
 }
-function Pd(e, t) {
+function Md(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -5985,59 +5986,59 @@ function Pd(e, t) {
 function Q(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Pd(Object(n), !0).forEach(function(t) {
-			Fd(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Pd(Object(n)).forEach(function(t) {
+		t % 2 ? Md(Object(n), !0).forEach(function(t) {
+			Nd(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Md(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Fd(e, t, n) {
-	return (t = Id(t)) in e ? Object.defineProperty(e, t, {
+function Nd(e, t, n) {
+	return (t = Pd(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Id(e) {
-	var t = Ld(e, "string");
-	return Dd(t) == "symbol" ? t : t + "";
+function Pd(e) {
+	var t = Fd(e, "string");
+	return Td(t) == "symbol" ? t : t + "";
 }
-function Ld(e, t) {
-	if (Dd(e) != "object" || !e) return e;
+function Fd(e, t) {
+	if (Td(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Dd(r) != "object") return r;
+		if (Td(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
 var $ = {
 	_getMeta: function() {
-		return [rc(arguments.length <= 0 ? void 0 : arguments[0]) || arguments.length <= 0 ? void 0 : arguments[0], sc(rc(arguments.length <= 0 ? void 0 : arguments[0]) ? arguments.length <= 0 ? void 0 : arguments[0] : arguments.length <= 1 ? void 0 : arguments[1])];
+		return [tc(arguments.length <= 0 ? void 0 : arguments[0]) || arguments.length <= 0 ? void 0 : arguments[0], ac(tc(arguments.length <= 0 ? void 0 : arguments[0]) ? arguments.length <= 0 ? void 0 : arguments[0] : arguments.length <= 1 ? void 0 : arguments[1])];
 	},
 	_getConfig: function(e, t) {
 		var n, r;
 		return ((e == null || (n = e.instance) == null ? void 0 : n.$primevue) || (t == null || (r = t.ctx) == null || (r = r.appContext) == null || (r = r.config) == null || (r = r.globalProperties) == null ? void 0 : r.$primevue))?.config;
 	},
-	_getOptionValue: uc,
+	_getOptionValue: cc,
 	_getPTValue: function() {
 		var e, t = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, n = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, r = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : "", i = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : {}, a = arguments.length > 4 && arguments[4] !== void 0 ? arguments[4] : !0, o = function() {
 			var e = $._getOptionValue.apply($, arguments);
-			return cc(e) || dc(e) ? { class: e } : e;
+			return oc(e) || lc(e) ? { class: e } : e;
 		}, s = ((e = t.binding) == null || (e = e.value) == null ? void 0 : e.ptOptions) || t.$primevueConfig?.ptOptions || {}, c = s.mergeSections, l = c === void 0 ? !0 : c, u = s.mergeProps, d = u === void 0 ? !1 : u, f = a ? $._useDefaultPT(t, t.defaultPT(), o, r, i) : void 0, p = $._usePT(t, $._getPT(n, t.$name), o, r, Q(Q({}, i), {}, { global: f || {} })), m = $._getPTDatasets(t, r);
 		return l || !l && p ? d ? $._mergeProps(t, d, f, p, m) : Q(Q(Q({}, f), p), m) : Q(Q({}, p), m);
 	},
 	_getPTDatasets: function() {
 		var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", n = "data-pc-";
-		return Q(Q({}, t === "root" && Fd({}, `${n}name`, lc(e.$name))), {}, Fd({}, `${n}section`, lc(t)));
+		return Q(Q({}, t === "root" && Nd({}, `${n}name`, sc(e.$name))), {}, Nd({}, `${n}section`, sc(t)));
 	},
 	_getPT: function(e) {
 		var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : "", n = arguments.length > 2 ? arguments[2] : void 0, r = function(e) {
-			var r = n ? n(e) : e, i = lc(t);
+			var r = n ? n(e) : e, i = sc(t);
 			return r?.[i] ?? r;
 		};
 		return e && Object.hasOwn(e, "_usept") ? {
@@ -6052,7 +6053,7 @@ var $ = {
 		};
 		if (t && Object.hasOwn(t, "_usept")) {
 			var o = t._usept || e.$primevueConfig?.ptOptions || {}, s = o.mergeSections, c = s === void 0 ? !0 : s, l = o.mergeProps, u = l === void 0 ? !1 : l, d = a(t.originalValue), f = a(t.value);
-			return d === void 0 && f === void 0 ? void 0 : cc(f) ? f : cc(d) ? d : c || !c && f ? u ? $._mergeProps(e, u, d, f) : Q(Q({}, d), f) : f;
+			return d === void 0 && f === void 0 ? void 0 : oc(f) ? f : oc(d) ? d : c || !c && f ? u ? $._mergeProps(e, u, d, f) : Q(Q({}, d), f) : f;
 		}
 		return a(t);
 	},
@@ -6068,9 +6069,9 @@ var $ = {
 	},
 	_loadCoreStyles: function() {
 		var e, t = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {}, n = arguments.length > 1 ? arguments[1] : void 0;
-		if (!zu.isStyleNameLoaded(t.$style?.name) && (e = t.$style) != null && e.name) {
+		if (!Lu.isStyleNameLoaded(t.$style?.name) && (e = t.$style) != null && e.name) {
 			var r;
-			X.loadCSS(n), (r = t.$style) == null || r.loadCSS(n), zu.setLoadedStyleName(t.$style.name);
+			X.loadCSS(n), (r = t.$style) == null || r.loadCSS(n), Lu.setLoadedStyleName(t.$style.name);
 		}
 	},
 	_loadThemeStyles: function() {
@@ -6102,14 +6103,14 @@ var $ = {
 	},
 	_themeChangeListener: function() {
 		var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : function() {};
-		zu.clearLoadedStyleNames(), xl.on("theme:change", e);
+		Lu.clearLoadedStyleNames(), yl.on("theme:change", e);
 	},
 	_removeThemeListeners: function() {
 		var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : {};
-		xl.off("theme:change", e.$loadStyles), e.$loadStyles = void 0;
+		yl.off("theme:change", e.$loadStyles), e.$loadStyles = void 0;
 	},
 	_hook: function(e, t, n, r, i, a) {
-		var o, s, c = `on${vc(t)}`, l = $._getConfig(r, i), u = n?.$instance, d = $._usePT(u, $._getPT(r == null || (o = r.value) == null ? void 0 : o.pt, e), $._getOptionValue, `hooks.${c}`), f = $._useDefaultPT(u, l == null || (s = l.pt) == null || (s = s.directives) == null ? void 0 : s[e], $._getOptionValue, `hooks.${c}`), p = {
+		var o, s, c = `on${gc(t)}`, l = $._getConfig(r, i), u = n?.$instance, d = $._usePT(u, $._getPT(r == null || (o = r.value) == null ? void 0 : o.pt, e), $._getOptionValue, `hooks.${c}`), f = $._useDefaultPT(u, l == null || (s = l.pt) == null || (s = s.directives) == null ? void 0 : s[e], $._getOptionValue, `hooks.${c}`), p = {
 			el: n,
 			binding: r,
 			vnode: i,
@@ -6119,13 +6120,13 @@ var $ = {
 	},
 	_mergeProps: function() {
 		var e = arguments.length > 1 ? arguments[1] : void 0, t = [...arguments].slice(2);
-		return $s(e) ? e.apply(void 0, t) : W.apply(void 0, t);
+		return Zs(e) ? e.apply(void 0, t) : W.apply(void 0, t);
 	},
 	_extend: function(e) {
 		var t = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : {}, n = function(n, r, i, a, o) {
 			var s, c, l;
 			r._$instances = r._$instances || {};
-			var u = $._getConfig(i, a), d = r._$instances[e] || {}, f = Xs(d) ? Q(Q({}, t), t?.methods) : {};
+			var u = $._getConfig(i, a), d = r._$instances[e] || {}, f = Js(d) ? Q(Q({}, t), t?.methods) : {};
 			r._$instances[e] = Q(Q({}, d), {}, {
 				$name: e,
 				$host: r,
@@ -6191,16 +6192,16 @@ var $ = {
 			a.$watchersCallback = {
 				config: s,
 				"config.ripple": c
-			}, o == null || (n = o.config) == null || n.call(a, a?.$primevueConfig), yu.on("config:change", s), o == null || (r = o["config.ripple"]) == null || r.call(a, a == null || (i = a.$primevueConfig) == null ? void 0 : i.ripple), yu.on("config:ripple:change", c);
+			}, o == null || (n = o.config) == null || n.call(a, a?.$primevueConfig), _u.on("config:change", s), o == null || (r = o["config.ripple"]) == null || r.call(a, a == null || (i = a.$primevueConfig) == null ? void 0 : i.ripple), _u.on("config:ripple:change", c);
 		}, i = function(t) {
 			var n = t._$instances[e].$watchersCallback;
-			n && (yu.off("config:change", n.config), yu.off("config:ripple:change", n["config.ripple"]), t._$instances[e].$watchersCallback = void 0);
+			n && (_u.off("config:change", n.config), _u.off("config:ripple:change", n["config.ripple"]), t._$instances[e].$watchersCallback = void 0);
 		};
 		return {
 			created: function(t, r, i, a) {
 				t.$pd ||= {}, t.$pd[e] = {
 					name: e,
-					attrSelector: cl("pd")
+					attrSelector: ol("pd")
 				}, n("created", t, r, i, a);
 			},
 			beforeMount: function(t, i, a, o) {
@@ -6225,72 +6226,72 @@ var $ = {
 		};
 	},
 	extend: function() {
-		var e = Od($._getMeta.apply($, arguments), 2), t = e[0], n = e[1];
+		var e = Ed($._getMeta.apply($, arguments), 2), t = e[0], n = e[1];
 		return Q({ extend: function() {
-			var e = Od($._getMeta.apply($, arguments), 2), t = e[0], r = e[1];
+			var e = Ed($._getMeta.apply($, arguments), 2), t = e[0], r = e[1];
 			return $.extend(t, Q(Q(Q({}, n), n?.methods), r));
 		} }, $._extend(t, n));
 	}
-}, Rd = X.extend({
+}, Id = X.extend({
 	name: "ripple-directive",
 	style: "\n    .p-ink {\n        display: block;\n        position: absolute;\n        background: dt('ripple.background');\n        border-radius: 100%;\n        transform: scale(0);\n        pointer-events: none;\n    }\n\n    .p-ink-active {\n        animation: ripple 0.4s linear;\n    }\n\n    @keyframes ripple {\n        100% {\n            opacity: 0;\n            transform: scale(2.5);\n        }\n    }\n",
 	classes: { root: "p-ink" }
-}), zd = $.extend({ style: Rd });
-function Bd(e) {
+}), Ld = $.extend({ style: Id });
+function Rd(e) {
 	"@babel/helpers - typeof";
-	return Bd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Rd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Bd(e);
+	}, Rd(e);
 }
-function Vd(e) {
-	return Gd(e) || Wd(e) || Ud(e) || Hd();
+function zd(e) {
+	return Ud(e) || Hd(e) || Vd(e) || Bd();
 }
-function Hd() {
+function Bd() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Ud(e, t) {
+function Vd(e, t) {
 	if (e) {
-		if (typeof e == "string") return Kd(e, t);
+		if (typeof e == "string") return Wd(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Kd(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Wd(e, t) : void 0;
 	}
 }
-function Wd(e) {
+function Hd(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Gd(e) {
-	if (Array.isArray(e)) return Kd(e);
+function Ud(e) {
+	if (Array.isArray(e)) return Wd(e);
 }
-function Kd(e, t) {
+function Wd(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function qd(e, t, n) {
-	return (t = Jd(t)) in e ? Object.defineProperty(e, t, {
+function Gd(e, t, n) {
+	return (t = Kd(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Jd(e) {
-	var t = Yd(e, "string");
-	return Bd(t) == "symbol" ? t : t + "";
+function Kd(e) {
+	var t = qd(e, "string");
+	return Rd(t) == "symbol" ? t : t + "";
 }
-function Yd(e, t) {
-	if (Bd(e) != "object" || !e) return e;
+function qd(e, t) {
+	if (Rd(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Bd(r) != "object") return r;
+		if (Rd(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Xd = zd.extend("ripple", {
+var Jd = Ld.extend("ripple", {
 	watch: { "config.ripple": function(e) {
 		e ? (this.createRipple(this.$host), this.bindEvents(this.$host), this.$host.setAttribute("data-pd-ripple", !0), this.$host.style.overflow = "hidden", this.$host.style.position = "relative") : (this.remove(this.$host), this.$host.removeAttribute("data-pd-ripple"));
 	} },
@@ -6307,7 +6308,7 @@ var Xd = zd.extend("ripple", {
 		},
 		createRipple: function(e) {
 			var t = this.getInk(e);
-			t || (t = Hc("span", qd(qd({
+			t || (t = Bc("span", Gd(Gd({
 				role: "presentation",
 				"aria-hidden": !0,
 				"data-p-ink": !0,
@@ -6323,65 +6324,65 @@ var Xd = zd.extend("ripple", {
 		onMouseDown: function(e) {
 			var t = this, n = e.currentTarget, r = this.getInk(n);
 			if (!(!r || getComputedStyle(r, null).display === "none")) {
-				if (!this.isUnstyled() && Tc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "false"), !Jc(r) && !el(r)) {
-					var i = Math.max(Ic(n), Zc(n));
+				if (!this.isUnstyled() && Cc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "false"), !Kc(r) && !Qc(r)) {
+					var i = Math.max(Pc(n), Yc(n));
 					r.style.height = i + "px", r.style.width = i + "px";
 				}
-				var a = Xc(n), o = e.pageX - a.left + document.body.scrollTop - el(r) / 2, s = e.pageY - a.top + document.body.scrollLeft - Jc(r) / 2;
-				r.style.top = s + "px", r.style.left = o + "px", !this.isUnstyled() && Sc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "true"), this.timeout = setTimeout(function() {
-					r && (!t.isUnstyled() && Tc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "false"));
+				var a = Jc(n), o = e.pageX - a.left + document.body.scrollTop - Qc(r) / 2, s = e.pageY - a.top + document.body.scrollLeft - Kc(r) / 2;
+				r.style.top = s + "px", r.style.left = o + "px", !this.isUnstyled() && bc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "true"), this.timeout = setTimeout(function() {
+					r && (!t.isUnstyled() && Cc(r, "p-ink-active"), r.setAttribute("data-p-ink-active", "false"));
 				}, 401);
 			}
 		},
 		onAnimationEnd: function(e) {
-			this.timeout && clearTimeout(this.timeout), !this.isUnstyled() && Tc(e.currentTarget, "p-ink-active"), e.currentTarget.setAttribute("data-p-ink-active", "false");
+			this.timeout && clearTimeout(this.timeout), !this.isUnstyled() && Cc(e.currentTarget, "p-ink-active"), e.currentTarget.setAttribute("data-p-ink-active", "false");
 		},
 		getInk: function(e) {
-			return e && e.children ? Vd(e.children).find(function(e) {
-				return Gc(e, "data-pc-name") === "ripple";
+			return e && e.children ? zd(e.children).find(function(e) {
+				return Uc(e, "data-pc-name") === "ripple";
 			}) : void 0;
 		}
 	}
-}), Zd = "\n    .p-button {\n        display: inline-flex;\n        cursor: pointer;\n        user-select: none;\n        align-items: center;\n        justify-content: center;\n        overflow: hidden;\n        position: relative;\n        color: dt('button.primary.color');\n        background: dt('button.primary.background');\n        border: 1px solid dt('button.primary.border.color');\n        padding: dt('button.padding.y') dt('button.padding.x');\n        font-size: 1rem;\n        font-family: inherit;\n        font-feature-settings: inherit;\n        transition:\n            background dt('button.transition.duration'),\n            color dt('button.transition.duration'),\n            border-color dt('button.transition.duration'),\n            outline-color dt('button.transition.duration'),\n            box-shadow dt('button.transition.duration');\n        border-radius: dt('button.border.radius');\n        outline-color: transparent;\n        gap: dt('button.gap');\n    }\n\n    .p-button:disabled {\n        cursor: default;\n    }\n\n    .p-button-icon-right {\n        order: 1;\n    }\n\n    .p-button-icon-right:dir(rtl) {\n        order: -1;\n    }\n\n    .p-button:not(.p-button-vertical) .p-button-icon:not(.p-button-icon-right):dir(rtl) {\n        order: 1;\n    }\n\n    .p-button-icon-bottom {\n        order: 2;\n    }\n\n    .p-button-icon-only {\n        width: dt('button.icon.only.width');\n        padding-inline-start: 0;\n        padding-inline-end: 0;\n        gap: 0;\n    }\n\n    .p-button-icon-only.p-button-rounded {\n        border-radius: 50%;\n        height: dt('button.icon.only.width');\n    }\n\n    .p-button-icon-only .p-button-label {\n        visibility: hidden;\n        width: 0;\n    }\n\n    .p-button-icon-only::after {\n        content: \"\xA0\";\n        visibility: hidden;\n        width: 0;\n    }\n\n    .p-button-sm {\n        font-size: dt('button.sm.font.size');\n        padding: dt('button.sm.padding.y') dt('button.sm.padding.x');\n    }\n\n    .p-button-sm .p-button-icon {\n        font-size: dt('button.sm.font.size');\n    }\n\n    .p-button-sm.p-button-icon-only {\n        width: dt('button.sm.icon.only.width');\n    }\n\n    .p-button-sm.p-button-icon-only.p-button-rounded {\n        height: dt('button.sm.icon.only.width');\n    }\n\n    .p-button-lg {\n        font-size: dt('button.lg.font.size');\n        padding: dt('button.lg.padding.y') dt('button.lg.padding.x');\n    }\n\n    .p-button-lg .p-button-icon {\n        font-size: dt('button.lg.font.size');\n    }\n\n    .p-button-lg.p-button-icon-only {\n        width: dt('button.lg.icon.only.width');\n    }\n\n    .p-button-lg.p-button-icon-only.p-button-rounded {\n        height: dt('button.lg.icon.only.width');\n    }\n\n    .p-button-vertical {\n        flex-direction: column;\n    }\n\n    .p-button-label {\n        font-weight: dt('button.label.font.weight');\n    }\n\n    .p-button-fluid {\n        width: 100%;\n    }\n\n    .p-button-fluid.p-button-icon-only {\n        width: dt('button.icon.only.width');\n    }\n\n    .p-button:not(:disabled):hover {\n        background: dt('button.primary.hover.background');\n        border: 1px solid dt('button.primary.hover.border.color');\n        color: dt('button.primary.hover.color');\n    }\n\n    .p-button:not(:disabled):active {\n        background: dt('button.primary.active.background');\n        border: 1px solid dt('button.primary.active.border.color');\n        color: dt('button.primary.active.color');\n    }\n\n    .p-button:focus-visible {\n        box-shadow: dt('button.primary.focus.ring.shadow');\n        outline: dt('button.focus.ring.width') dt('button.focus.ring.style') dt('button.primary.focus.ring.color');\n        outline-offset: dt('button.focus.ring.offset');\n    }\n\n    .p-button .p-badge {\n        min-width: dt('button.badge.size');\n        height: dt('button.badge.size');\n        line-height: dt('button.badge.size');\n    }\n\n    .p-button-raised {\n        box-shadow: dt('button.raised.shadow');\n    }\n\n    .p-button-rounded {\n        border-radius: dt('button.rounded.border.radius');\n    }\n\n    .p-button-secondary {\n        background: dt('button.secondary.background');\n        border: 1px solid dt('button.secondary.border.color');\n        color: dt('button.secondary.color');\n    }\n\n    .p-button-secondary:not(:disabled):hover {\n        background: dt('button.secondary.hover.background');\n        border: 1px solid dt('button.secondary.hover.border.color');\n        color: dt('button.secondary.hover.color');\n    }\n\n    .p-button-secondary:not(:disabled):active {\n        background: dt('button.secondary.active.background');\n        border: 1px solid dt('button.secondary.active.border.color');\n        color: dt('button.secondary.active.color');\n    }\n\n    .p-button-secondary:focus-visible {\n        outline-color: dt('button.secondary.focus.ring.color');\n        box-shadow: dt('button.secondary.focus.ring.shadow');\n    }\n\n    .p-button-success {\n        background: dt('button.success.background');\n        border: 1px solid dt('button.success.border.color');\n        color: dt('button.success.color');\n    }\n\n    .p-button-success:not(:disabled):hover {\n        background: dt('button.success.hover.background');\n        border: 1px solid dt('button.success.hover.border.color');\n        color: dt('button.success.hover.color');\n    }\n\n    .p-button-success:not(:disabled):active {\n        background: dt('button.success.active.background');\n        border: 1px solid dt('button.success.active.border.color');\n        color: dt('button.success.active.color');\n    }\n\n    .p-button-success:focus-visible {\n        outline-color: dt('button.success.focus.ring.color');\n        box-shadow: dt('button.success.focus.ring.shadow');\n    }\n\n    .p-button-info {\n        background: dt('button.info.background');\n        border: 1px solid dt('button.info.border.color');\n        color: dt('button.info.color');\n    }\n\n    .p-button-info:not(:disabled):hover {\n        background: dt('button.info.hover.background');\n        border: 1px solid dt('button.info.hover.border.color');\n        color: dt('button.info.hover.color');\n    }\n\n    .p-button-info:not(:disabled):active {\n        background: dt('button.info.active.background');\n        border: 1px solid dt('button.info.active.border.color');\n        color: dt('button.info.active.color');\n    }\n\n    .p-button-info:focus-visible {\n        outline-color: dt('button.info.focus.ring.color');\n        box-shadow: dt('button.info.focus.ring.shadow');\n    }\n\n    .p-button-warn {\n        background: dt('button.warn.background');\n        border: 1px solid dt('button.warn.border.color');\n        color: dt('button.warn.color');\n    }\n\n    .p-button-warn:not(:disabled):hover {\n        background: dt('button.warn.hover.background');\n        border: 1px solid dt('button.warn.hover.border.color');\n        color: dt('button.warn.hover.color');\n    }\n\n    .p-button-warn:not(:disabled):active {\n        background: dt('button.warn.active.background');\n        border: 1px solid dt('button.warn.active.border.color');\n        color: dt('button.warn.active.color');\n    }\n\n    .p-button-warn:focus-visible {\n        outline-color: dt('button.warn.focus.ring.color');\n        box-shadow: dt('button.warn.focus.ring.shadow');\n    }\n\n    .p-button-help {\n        background: dt('button.help.background');\n        border: 1px solid dt('button.help.border.color');\n        color: dt('button.help.color');\n    }\n\n    .p-button-help:not(:disabled):hover {\n        background: dt('button.help.hover.background');\n        border: 1px solid dt('button.help.hover.border.color');\n        color: dt('button.help.hover.color');\n    }\n\n    .p-button-help:not(:disabled):active {\n        background: dt('button.help.active.background');\n        border: 1px solid dt('button.help.active.border.color');\n        color: dt('button.help.active.color');\n    }\n\n    .p-button-help:focus-visible {\n        outline-color: dt('button.help.focus.ring.color');\n        box-shadow: dt('button.help.focus.ring.shadow');\n    }\n\n    .p-button-danger {\n        background: dt('button.danger.background');\n        border: 1px solid dt('button.danger.border.color');\n        color: dt('button.danger.color');\n    }\n\n    .p-button-danger:not(:disabled):hover {\n        background: dt('button.danger.hover.background');\n        border: 1px solid dt('button.danger.hover.border.color');\n        color: dt('button.danger.hover.color');\n    }\n\n    .p-button-danger:not(:disabled):active {\n        background: dt('button.danger.active.background');\n        border: 1px solid dt('button.danger.active.border.color');\n        color: dt('button.danger.active.color');\n    }\n\n    .p-button-danger:focus-visible {\n        outline-color: dt('button.danger.focus.ring.color');\n        box-shadow: dt('button.danger.focus.ring.shadow');\n    }\n\n    .p-button-contrast {\n        background: dt('button.contrast.background');\n        border: 1px solid dt('button.contrast.border.color');\n        color: dt('button.contrast.color');\n    }\n\n    .p-button-contrast:not(:disabled):hover {\n        background: dt('button.contrast.hover.background');\n        border: 1px solid dt('button.contrast.hover.border.color');\n        color: dt('button.contrast.hover.color');\n    }\n\n    .p-button-contrast:not(:disabled):active {\n        background: dt('button.contrast.active.background');\n        border: 1px solid dt('button.contrast.active.border.color');\n        color: dt('button.contrast.active.color');\n    }\n\n    .p-button-contrast:focus-visible {\n        outline-color: dt('button.contrast.focus.ring.color');\n        box-shadow: dt('button.contrast.focus.ring.shadow');\n    }\n\n    .p-button-outlined {\n        background: transparent;\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined:not(:disabled):hover {\n        background: dt('button.outlined.primary.hover.background');\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined:not(:disabled):active {\n        background: dt('button.outlined.primary.active.background');\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined.p-button-secondary {\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-secondary:not(:disabled):hover {\n        background: dt('button.outlined.secondary.hover.background');\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-secondary:not(:disabled):active {\n        background: dt('button.outlined.secondary.active.background');\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-success {\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-success:not(:disabled):hover {\n        background: dt('button.outlined.success.hover.background');\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-success:not(:disabled):active {\n        background: dt('button.outlined.success.active.background');\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-info {\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-info:not(:disabled):hover {\n        background: dt('button.outlined.info.hover.background');\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-info:not(:disabled):active {\n        background: dt('button.outlined.info.active.background');\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-warn {\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-warn:not(:disabled):hover {\n        background: dt('button.outlined.warn.hover.background');\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-warn:not(:disabled):active {\n        background: dt('button.outlined.warn.active.background');\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-help {\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-help:not(:disabled):hover {\n        background: dt('button.outlined.help.hover.background');\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-help:not(:disabled):active {\n        background: dt('button.outlined.help.active.background');\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-danger {\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-danger:not(:disabled):hover {\n        background: dt('button.outlined.danger.hover.background');\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-danger:not(:disabled):active {\n        background: dt('button.outlined.danger.active.background');\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-contrast {\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-contrast:not(:disabled):hover {\n        background: dt('button.outlined.contrast.hover.background');\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-contrast:not(:disabled):active {\n        background: dt('button.outlined.contrast.active.background');\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-plain {\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-outlined.p-button-plain:not(:disabled):hover {\n        background: dt('button.outlined.plain.hover.background');\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-outlined.p-button-plain:not(:disabled):active {\n        background: dt('button.outlined.plain.active.background');\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-text {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text:not(:disabled):hover {\n        background: dt('button.text.primary.hover.background');\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text:not(:disabled):active {\n        background: dt('button.text.primary.active.background');\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text.p-button-secondary {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-secondary:not(:disabled):hover {\n        background: dt('button.text.secondary.hover.background');\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-secondary:not(:disabled):active {\n        background: dt('button.text.secondary.active.background');\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-success {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-success:not(:disabled):hover {\n        background: dt('button.text.success.hover.background');\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-success:not(:disabled):active {\n        background: dt('button.text.success.active.background');\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-info {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-info:not(:disabled):hover {\n        background: dt('button.text.info.hover.background');\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-info:not(:disabled):active {\n        background: dt('button.text.info.active.background');\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-warn {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-warn:not(:disabled):hover {\n        background: dt('button.text.warn.hover.background');\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-warn:not(:disabled):active {\n        background: dt('button.text.warn.active.background');\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-help {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-help:not(:disabled):hover {\n        background: dt('button.text.help.hover.background');\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-help:not(:disabled):active {\n        background: dt('button.text.help.active.background');\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-danger {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-danger:not(:disabled):hover {\n        background: dt('button.text.danger.hover.background');\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-danger:not(:disabled):active {\n        background: dt('button.text.danger.active.background');\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-contrast {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-contrast:not(:disabled):hover {\n        background: dt('button.text.contrast.hover.background');\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-contrast:not(:disabled):active {\n        background: dt('button.text.contrast.active.background');\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-plain {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-text.p-button-plain:not(:disabled):hover {\n        background: dt('button.text.plain.hover.background');\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-text.p-button-plain:not(:disabled):active {\n        background: dt('button.text.plain.active.background');\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-link {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.color');\n    }\n\n    .p-button-link:not(:disabled):hover {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.hover.color');\n    }\n\n    .p-button-link:not(:disabled):hover .p-button-label {\n        text-decoration: underline;\n    }\n\n    .p-button-link:not(:disabled):active {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.active.color');\n    }\n";
+}), Yd = "\n    .p-button {\n        display: inline-flex;\n        cursor: pointer;\n        user-select: none;\n        align-items: center;\n        justify-content: center;\n        overflow: hidden;\n        position: relative;\n        color: dt('button.primary.color');\n        background: dt('button.primary.background');\n        border: 1px solid dt('button.primary.border.color');\n        padding: dt('button.padding.y') dt('button.padding.x');\n        font-size: 1rem;\n        font-family: inherit;\n        font-feature-settings: inherit;\n        transition:\n            background dt('button.transition.duration'),\n            color dt('button.transition.duration'),\n            border-color dt('button.transition.duration'),\n            outline-color dt('button.transition.duration'),\n            box-shadow dt('button.transition.duration');\n        border-radius: dt('button.border.radius');\n        outline-color: transparent;\n        gap: dt('button.gap');\n    }\n\n    .p-button:disabled {\n        cursor: default;\n    }\n\n    .p-button-icon-right {\n        order: 1;\n    }\n\n    .p-button-icon-right:dir(rtl) {\n        order: -1;\n    }\n\n    .p-button:not(.p-button-vertical) .p-button-icon:not(.p-button-icon-right):dir(rtl) {\n        order: 1;\n    }\n\n    .p-button-icon-bottom {\n        order: 2;\n    }\n\n    .p-button-icon-only {\n        width: dt('button.icon.only.width');\n        padding-inline-start: 0;\n        padding-inline-end: 0;\n        gap: 0;\n    }\n\n    .p-button-icon-only.p-button-rounded {\n        border-radius: 50%;\n        height: dt('button.icon.only.width');\n    }\n\n    .p-button-icon-only .p-button-label {\n        visibility: hidden;\n        width: 0;\n    }\n\n    .p-button-icon-only::after {\n        content: \"\xA0\";\n        visibility: hidden;\n        width: 0;\n    }\n\n    .p-button-sm {\n        font-size: dt('button.sm.font.size');\n        padding: dt('button.sm.padding.y') dt('button.sm.padding.x');\n    }\n\n    .p-button-sm .p-button-icon {\n        font-size: dt('button.sm.font.size');\n    }\n\n    .p-button-sm.p-button-icon-only {\n        width: dt('button.sm.icon.only.width');\n    }\n\n    .p-button-sm.p-button-icon-only.p-button-rounded {\n        height: dt('button.sm.icon.only.width');\n    }\n\n    .p-button-lg {\n        font-size: dt('button.lg.font.size');\n        padding: dt('button.lg.padding.y') dt('button.lg.padding.x');\n    }\n\n    .p-button-lg .p-button-icon {\n        font-size: dt('button.lg.font.size');\n    }\n\n    .p-button-lg.p-button-icon-only {\n        width: dt('button.lg.icon.only.width');\n    }\n\n    .p-button-lg.p-button-icon-only.p-button-rounded {\n        height: dt('button.lg.icon.only.width');\n    }\n\n    .p-button-vertical {\n        flex-direction: column;\n    }\n\n    .p-button-label {\n        font-weight: dt('button.label.font.weight');\n    }\n\n    .p-button-fluid {\n        width: 100%;\n    }\n\n    .p-button-fluid.p-button-icon-only {\n        width: dt('button.icon.only.width');\n    }\n\n    .p-button:not(:disabled):hover {\n        background: dt('button.primary.hover.background');\n        border: 1px solid dt('button.primary.hover.border.color');\n        color: dt('button.primary.hover.color');\n    }\n\n    .p-button:not(:disabled):active {\n        background: dt('button.primary.active.background');\n        border: 1px solid dt('button.primary.active.border.color');\n        color: dt('button.primary.active.color');\n    }\n\n    .p-button:focus-visible {\n        box-shadow: dt('button.primary.focus.ring.shadow');\n        outline: dt('button.focus.ring.width') dt('button.focus.ring.style') dt('button.primary.focus.ring.color');\n        outline-offset: dt('button.focus.ring.offset');\n    }\n\n    .p-button .p-badge {\n        min-width: dt('button.badge.size');\n        height: dt('button.badge.size');\n        line-height: dt('button.badge.size');\n    }\n\n    .p-button-raised {\n        box-shadow: dt('button.raised.shadow');\n    }\n\n    .p-button-rounded {\n        border-radius: dt('button.rounded.border.radius');\n    }\n\n    .p-button-secondary {\n        background: dt('button.secondary.background');\n        border: 1px solid dt('button.secondary.border.color');\n        color: dt('button.secondary.color');\n    }\n\n    .p-button-secondary:not(:disabled):hover {\n        background: dt('button.secondary.hover.background');\n        border: 1px solid dt('button.secondary.hover.border.color');\n        color: dt('button.secondary.hover.color');\n    }\n\n    .p-button-secondary:not(:disabled):active {\n        background: dt('button.secondary.active.background');\n        border: 1px solid dt('button.secondary.active.border.color');\n        color: dt('button.secondary.active.color');\n    }\n\n    .p-button-secondary:focus-visible {\n        outline-color: dt('button.secondary.focus.ring.color');\n        box-shadow: dt('button.secondary.focus.ring.shadow');\n    }\n\n    .p-button-success {\n        background: dt('button.success.background');\n        border: 1px solid dt('button.success.border.color');\n        color: dt('button.success.color');\n    }\n\n    .p-button-success:not(:disabled):hover {\n        background: dt('button.success.hover.background');\n        border: 1px solid dt('button.success.hover.border.color');\n        color: dt('button.success.hover.color');\n    }\n\n    .p-button-success:not(:disabled):active {\n        background: dt('button.success.active.background');\n        border: 1px solid dt('button.success.active.border.color');\n        color: dt('button.success.active.color');\n    }\n\n    .p-button-success:focus-visible {\n        outline-color: dt('button.success.focus.ring.color');\n        box-shadow: dt('button.success.focus.ring.shadow');\n    }\n\n    .p-button-info {\n        background: dt('button.info.background');\n        border: 1px solid dt('button.info.border.color');\n        color: dt('button.info.color');\n    }\n\n    .p-button-info:not(:disabled):hover {\n        background: dt('button.info.hover.background');\n        border: 1px solid dt('button.info.hover.border.color');\n        color: dt('button.info.hover.color');\n    }\n\n    .p-button-info:not(:disabled):active {\n        background: dt('button.info.active.background');\n        border: 1px solid dt('button.info.active.border.color');\n        color: dt('button.info.active.color');\n    }\n\n    .p-button-info:focus-visible {\n        outline-color: dt('button.info.focus.ring.color');\n        box-shadow: dt('button.info.focus.ring.shadow');\n    }\n\n    .p-button-warn {\n        background: dt('button.warn.background');\n        border: 1px solid dt('button.warn.border.color');\n        color: dt('button.warn.color');\n    }\n\n    .p-button-warn:not(:disabled):hover {\n        background: dt('button.warn.hover.background');\n        border: 1px solid dt('button.warn.hover.border.color');\n        color: dt('button.warn.hover.color');\n    }\n\n    .p-button-warn:not(:disabled):active {\n        background: dt('button.warn.active.background');\n        border: 1px solid dt('button.warn.active.border.color');\n        color: dt('button.warn.active.color');\n    }\n\n    .p-button-warn:focus-visible {\n        outline-color: dt('button.warn.focus.ring.color');\n        box-shadow: dt('button.warn.focus.ring.shadow');\n    }\n\n    .p-button-help {\n        background: dt('button.help.background');\n        border: 1px solid dt('button.help.border.color');\n        color: dt('button.help.color');\n    }\n\n    .p-button-help:not(:disabled):hover {\n        background: dt('button.help.hover.background');\n        border: 1px solid dt('button.help.hover.border.color');\n        color: dt('button.help.hover.color');\n    }\n\n    .p-button-help:not(:disabled):active {\n        background: dt('button.help.active.background');\n        border: 1px solid dt('button.help.active.border.color');\n        color: dt('button.help.active.color');\n    }\n\n    .p-button-help:focus-visible {\n        outline-color: dt('button.help.focus.ring.color');\n        box-shadow: dt('button.help.focus.ring.shadow');\n    }\n\n    .p-button-danger {\n        background: dt('button.danger.background');\n        border: 1px solid dt('button.danger.border.color');\n        color: dt('button.danger.color');\n    }\n\n    .p-button-danger:not(:disabled):hover {\n        background: dt('button.danger.hover.background');\n        border: 1px solid dt('button.danger.hover.border.color');\n        color: dt('button.danger.hover.color');\n    }\n\n    .p-button-danger:not(:disabled):active {\n        background: dt('button.danger.active.background');\n        border: 1px solid dt('button.danger.active.border.color');\n        color: dt('button.danger.active.color');\n    }\n\n    .p-button-danger:focus-visible {\n        outline-color: dt('button.danger.focus.ring.color');\n        box-shadow: dt('button.danger.focus.ring.shadow');\n    }\n\n    .p-button-contrast {\n        background: dt('button.contrast.background');\n        border: 1px solid dt('button.contrast.border.color');\n        color: dt('button.contrast.color');\n    }\n\n    .p-button-contrast:not(:disabled):hover {\n        background: dt('button.contrast.hover.background');\n        border: 1px solid dt('button.contrast.hover.border.color');\n        color: dt('button.contrast.hover.color');\n    }\n\n    .p-button-contrast:not(:disabled):active {\n        background: dt('button.contrast.active.background');\n        border: 1px solid dt('button.contrast.active.border.color');\n        color: dt('button.contrast.active.color');\n    }\n\n    .p-button-contrast:focus-visible {\n        outline-color: dt('button.contrast.focus.ring.color');\n        box-shadow: dt('button.contrast.focus.ring.shadow');\n    }\n\n    .p-button-outlined {\n        background: transparent;\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined:not(:disabled):hover {\n        background: dt('button.outlined.primary.hover.background');\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined:not(:disabled):active {\n        background: dt('button.outlined.primary.active.background');\n        border-color: dt('button.outlined.primary.border.color');\n        color: dt('button.outlined.primary.color');\n    }\n\n    .p-button-outlined.p-button-secondary {\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-secondary:not(:disabled):hover {\n        background: dt('button.outlined.secondary.hover.background');\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-secondary:not(:disabled):active {\n        background: dt('button.outlined.secondary.active.background');\n        border-color: dt('button.outlined.secondary.border.color');\n        color: dt('button.outlined.secondary.color');\n    }\n\n    .p-button-outlined.p-button-success {\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-success:not(:disabled):hover {\n        background: dt('button.outlined.success.hover.background');\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-success:not(:disabled):active {\n        background: dt('button.outlined.success.active.background');\n        border-color: dt('button.outlined.success.border.color');\n        color: dt('button.outlined.success.color');\n    }\n\n    .p-button-outlined.p-button-info {\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-info:not(:disabled):hover {\n        background: dt('button.outlined.info.hover.background');\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-info:not(:disabled):active {\n        background: dt('button.outlined.info.active.background');\n        border-color: dt('button.outlined.info.border.color');\n        color: dt('button.outlined.info.color');\n    }\n\n    .p-button-outlined.p-button-warn {\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-warn:not(:disabled):hover {\n        background: dt('button.outlined.warn.hover.background');\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-warn:not(:disabled):active {\n        background: dt('button.outlined.warn.active.background');\n        border-color: dt('button.outlined.warn.border.color');\n        color: dt('button.outlined.warn.color');\n    }\n\n    .p-button-outlined.p-button-help {\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-help:not(:disabled):hover {\n        background: dt('button.outlined.help.hover.background');\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-help:not(:disabled):active {\n        background: dt('button.outlined.help.active.background');\n        border-color: dt('button.outlined.help.border.color');\n        color: dt('button.outlined.help.color');\n    }\n\n    .p-button-outlined.p-button-danger {\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-danger:not(:disabled):hover {\n        background: dt('button.outlined.danger.hover.background');\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-danger:not(:disabled):active {\n        background: dt('button.outlined.danger.active.background');\n        border-color: dt('button.outlined.danger.border.color');\n        color: dt('button.outlined.danger.color');\n    }\n\n    .p-button-outlined.p-button-contrast {\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-contrast:not(:disabled):hover {\n        background: dt('button.outlined.contrast.hover.background');\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-contrast:not(:disabled):active {\n        background: dt('button.outlined.contrast.active.background');\n        border-color: dt('button.outlined.contrast.border.color');\n        color: dt('button.outlined.contrast.color');\n    }\n\n    .p-button-outlined.p-button-plain {\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-outlined.p-button-plain:not(:disabled):hover {\n        background: dt('button.outlined.plain.hover.background');\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-outlined.p-button-plain:not(:disabled):active {\n        background: dt('button.outlined.plain.active.background');\n        border-color: dt('button.outlined.plain.border.color');\n        color: dt('button.outlined.plain.color');\n    }\n\n    .p-button-text {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text:not(:disabled):hover {\n        background: dt('button.text.primary.hover.background');\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text:not(:disabled):active {\n        background: dt('button.text.primary.active.background');\n        border-color: transparent;\n        color: dt('button.text.primary.color');\n    }\n\n    .p-button-text.p-button-secondary {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-secondary:not(:disabled):hover {\n        background: dt('button.text.secondary.hover.background');\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-secondary:not(:disabled):active {\n        background: dt('button.text.secondary.active.background');\n        border-color: transparent;\n        color: dt('button.text.secondary.color');\n    }\n\n    .p-button-text.p-button-success {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-success:not(:disabled):hover {\n        background: dt('button.text.success.hover.background');\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-success:not(:disabled):active {\n        background: dt('button.text.success.active.background');\n        border-color: transparent;\n        color: dt('button.text.success.color');\n    }\n\n    .p-button-text.p-button-info {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-info:not(:disabled):hover {\n        background: dt('button.text.info.hover.background');\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-info:not(:disabled):active {\n        background: dt('button.text.info.active.background');\n        border-color: transparent;\n        color: dt('button.text.info.color');\n    }\n\n    .p-button-text.p-button-warn {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-warn:not(:disabled):hover {\n        background: dt('button.text.warn.hover.background');\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-warn:not(:disabled):active {\n        background: dt('button.text.warn.active.background');\n        border-color: transparent;\n        color: dt('button.text.warn.color');\n    }\n\n    .p-button-text.p-button-help {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-help:not(:disabled):hover {\n        background: dt('button.text.help.hover.background');\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-help:not(:disabled):active {\n        background: dt('button.text.help.active.background');\n        border-color: transparent;\n        color: dt('button.text.help.color');\n    }\n\n    .p-button-text.p-button-danger {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-danger:not(:disabled):hover {\n        background: dt('button.text.danger.hover.background');\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-danger:not(:disabled):active {\n        background: dt('button.text.danger.active.background');\n        border-color: transparent;\n        color: dt('button.text.danger.color');\n    }\n\n    .p-button-text.p-button-contrast {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-contrast:not(:disabled):hover {\n        background: dt('button.text.contrast.hover.background');\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-contrast:not(:disabled):active {\n        background: dt('button.text.contrast.active.background');\n        border-color: transparent;\n        color: dt('button.text.contrast.color');\n    }\n\n    .p-button-text.p-button-plain {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-text.p-button-plain:not(:disabled):hover {\n        background: dt('button.text.plain.hover.background');\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-text.p-button-plain:not(:disabled):active {\n        background: dt('button.text.plain.active.background');\n        border-color: transparent;\n        color: dt('button.text.plain.color');\n    }\n\n    .p-button-link {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.color');\n    }\n\n    .p-button-link:not(:disabled):hover {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.hover.color');\n    }\n\n    .p-button-link:not(:disabled):hover .p-button-label {\n        text-decoration: underline;\n    }\n\n    .p-button-link:not(:disabled):active {\n        background: transparent;\n        border-color: transparent;\n        color: dt('button.link.active.color');\n    }\n";
 //#endregion
 //#region node_modules/primevue/button/style/index.mjs
-function Qd(e) {
+function Xd(e) {
 	"@babel/helpers - typeof";
-	return Qd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Xd = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Qd(e);
+	}, Xd(e);
 }
-function $d(e, t, n) {
-	return (t = ef(t)) in e ? Object.defineProperty(e, t, {
+function Zd(e, t, n) {
+	return (t = Qd(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function ef(e) {
-	var t = tf(e, "string");
-	return Qd(t) == "symbol" ? t : t + "";
+function Qd(e) {
+	var t = $d(e, "string");
+	return Xd(t) == "symbol" ? t : t + "";
 }
-function tf(e, t) {
-	if (Qd(e) != "object" || !e) return e;
+function $d(e, t) {
+	if (Xd(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Qd(r) != "object") return r;
+		if (Xd(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var nf = X.extend({
+var ef = X.extend({
 	name: "button",
-	style: Zd,
+	style: Yd,
 	classes: {
 		root: function(e) {
 			var t = e.instance, n = e.props;
-			return ["p-button p-component", $d($d($d($d($d($d($d($d($d({
+			return ["p-button p-component", Zd(Zd(Zd(Zd(Zd(Zd(Zd(Zd(Zd({
 				"p-button-icon-only": t.hasIcon && !n.label && !n.badge,
 				"p-button-vertical": (n.iconPos === "top" || n.iconPos === "bottom") && n.label,
 				"p-button-loading": n.loading,
@@ -6391,13 +6392,13 @@ var nf = X.extend({
 		loadingIcon: "p-button-loading-icon",
 		icon: function(e) {
 			var t = e.props;
-			return ["p-button-icon", $d({}, `p-button-icon-${t.iconPos}`, t.label)];
+			return ["p-button-icon", Zd({}, `p-button-icon-${t.iconPos}`, t.label)];
 		},
 		label: "p-button-label"
 	}
-}), rf = {
+}), tf = {
 	name: "BaseButton",
-	extends: td,
+	extends: $u,
 	props: {
 		label: {
 			type: String,
@@ -6484,7 +6485,7 @@ var nf = X.extend({
 			default: null
 		}
 	},
-	style: nf,
+	style: ef,
 	provide: function() {
 		return {
 			$pcButton: this,
@@ -6492,39 +6493,39 @@ var nf = X.extend({
 		};
 	}
 };
-function af(e) {
+function nf(e) {
 	"@babel/helpers - typeof";
-	return af = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return nf = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, af(e);
+	}, nf(e);
 }
-function of(e, t, n) {
-	return (t = sf(t)) in e ? Object.defineProperty(e, t, {
+function rf(e, t, n) {
+	return (t = af(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function sf(e) {
-	var t = cf(e, "string");
-	return af(t) == "symbol" ? t : t + "";
+function af(e) {
+	var t = of(e, "string");
+	return nf(t) == "symbol" ? t : t + "";
 }
-function cf(e, t) {
-	if (af(e) != "object" || !e) return e;
+function of(e, t) {
+	if (nf(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (af(r) != "object") return r;
+		if (nf(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var lf = {
+var sf = {
 	name: "Button",
-	extends: rf,
+	extends: tf,
 	inheritAttrs: !1,
 	inject: { $pcFluid: { default: null } },
 	methods: { getPTOptions: function(e) {
@@ -6558,31 +6559,31 @@ var lf = {
 			};
 		},
 		hasFluid: function() {
-			return Xs(this.fluid) ? !!this.$pcFluid : this.fluid;
+			return Js(this.fluid) ? !!this.$pcFluid : this.fluid;
 		},
 		dataP: function() {
-			return q(of(of(of(of(of(of(of(of(of(of({}, this.size, this.size), "icon-only", this.hasIcon && !this.label && !this.badge), "loading", this.loading), "fluid", this.hasFluid), "rounded", this.rounded), "raised", this.raised), "outlined", this.outlined || this.variant === "outlined"), "text", this.text || this.variant === "text"), "link", this.link || this.variant === "link"), "vertical", (this.iconPos === "top" || this.iconPos === "bottom") && this.label));
+			return q(rf(rf(rf(rf(rf(rf(rf(rf(rf(rf({}, this.size, this.size), "icon-only", this.hasIcon && !this.label && !this.badge), "loading", this.loading), "fluid", this.hasFluid), "rounded", this.rounded), "raised", this.raised), "outlined", this.outlined || this.variant === "outlined"), "text", this.text || this.variant === "text"), "link", this.link || this.variant === "link"), "vertical", (this.iconPos === "top" || this.iconPos === "bottom") && this.label));
 		},
 		dataIconP: function() {
-			return q(of(of({}, this.iconPos, this.iconPos), this.size, this.size));
+			return q(rf(rf({}, this.iconPos, this.iconPos), this.size, this.size));
 		},
 		dataLabelP: function() {
-			return q(of(of({}, this.size, this.size), "icon-only", this.hasIcon && !this.label && !this.badge));
+			return q(rf(rf({}, this.size, this.size), "icon-only", this.hasIcon && !this.label && !this.badge));
 		}
 	},
 	components: {
-		SpinnerIcon: ud,
-		Badge: wd
+		SpinnerIcon: cd,
+		Badge: Sd
 	},
-	directives: { ripple: Xd }
-}, uf = ["data-p"], df = ["data-p"];
-function ff(e, t, n, r, i, a) {
-	var o = F("SpinnerIcon"), s = F("Badge"), c = si("ripple");
+	directives: { ripple: Jd }
+}, cf = ["data-p"], lf = ["data-p"];
+function uf(e, t, n, r, i, a) {
+	var o = F("SpinnerIcon"), s = F("Badge"), c = oi("ripple");
 	return e.asChild ? I(e.$slots, "default", {
 		key: 1,
 		class: D(e.cx("root")),
 		a11yAttrs: a.a11yAttrs
-	}) : Vn((R(), B(oi(e.as), W({
+	}) : Bn((R(), B(ai(e.as), W({
 		key: 0,
 		class: e.cx("root"),
 		"data-p": a.dataP
@@ -6618,12 +6619,12 @@ function ff(e, t, n, r, i, a) {
 								e.iconClass
 							],
 							"data-p": a.dataIconP
-						}, e.ptm("icon")), null, 16, uf)) : U("", !0)];
+						}, e.ptm("icon")), null, 16, cf)) : U("", !0)];
 					}),
 					e.label ? (R(), z("span", W({
 						key: 2,
 						class: e.cx("label")
-					}, e.ptm("label"), { "data-p": a.dataLabelP }), O(e.label), 17, df)) : U("", !0),
+					}, e.ptm("label"), { "data-p": a.dataLabelP }), O(e.label), 17, lf)) : U("", !0),
 					e.badge ? (R(), B(s, {
 						key: 3,
 						value: e.badge,
@@ -6644,98 +6645,98 @@ function ff(e, t, n, r, i, a) {
 		_: 3
 	}, 16, ["class", "data-p"])), [[c]]);
 }
-lf.render = ff;
+sf.render = uf;
 //#endregion
 //#region node_modules/@primevue/icons/check/index.mjs
-var pf = {
+var df = {
 	name: "CheckIcon",
-	extends: ld
+	extends: sd
 };
-function mf(e) {
-	return vf(e) || _f(e) || gf(e) || hf();
+function ff(e) {
+	return gf(e) || hf(e) || mf(e) || pf();
 }
-function hf() {
+function pf() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function gf(e, t) {
+function mf(e, t) {
 	if (e) {
-		if (typeof e == "string") return yf(e, t);
+		if (typeof e == "string") return _f(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? yf(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? _f(e, t) : void 0;
 	}
 }
-function _f(e) {
+function hf(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function vf(e) {
-	if (Array.isArray(e)) return yf(e);
+function gf(e) {
+	if (Array.isArray(e)) return _f(e);
 }
-function yf(e, t) {
+function _f(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function bf(e, t, n, r, i, a) {
+function vf(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), mf(t[0] ||= [V("path", {
+	}, e.pti()), ff(t[0] ||= [V("path", {
 		d: "M4.86199 11.5948C4.78717 11.5923 4.71366 11.5745 4.64596 11.5426C4.57826 11.5107 4.51779 11.4652 4.46827 11.4091L0.753985 7.69483C0.683167 7.64891 0.623706 7.58751 0.580092 7.51525C0.536478 7.44299 0.509851 7.36177 0.502221 7.27771C0.49459 7.19366 0.506156 7.10897 0.536046 7.03004C0.565935 6.95111 0.613367 6.88 0.674759 6.82208C0.736151 6.76416 0.8099 6.72095 0.890436 6.69571C0.970973 6.67046 1.05619 6.66385 1.13966 6.67635C1.22313 6.68886 1.30266 6.72017 1.37226 6.76792C1.44186 6.81567 1.4997 6.8786 1.54141 6.95197L4.86199 10.2503L12.6397 2.49483C12.7444 2.42694 12.8689 2.39617 12.9932 2.40745C13.1174 2.41873 13.2343 2.47141 13.3251 2.55705C13.4159 2.64268 13.4753 2.75632 13.4938 2.87973C13.5123 3.00315 13.4888 3.1292 13.4271 3.23768L5.2557 11.4091C5.20618 11.4652 5.14571 11.5107 5.07801 11.5426C5.01031 11.5745 4.9368 11.5923 4.86199 11.5948Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-pf.render = bf;
+df.render = vf;
 //#endregion
 //#region node_modules/@primevue/icons/minus/index.mjs
-var xf = {
+var yf = {
 	name: "MinusIcon",
-	extends: ld
+	extends: sd
 };
-function Sf(e) {
-	return Ef(e) || Tf(e) || wf(e) || Cf();
+function bf(e) {
+	return wf(e) || Cf(e) || Sf(e) || xf();
 }
-function Cf() {
+function xf() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function wf(e, t) {
+function Sf(e, t) {
 	if (e) {
-		if (typeof e == "string") return Df(e, t);
+		if (typeof e == "string") return Tf(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Df(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Tf(e, t) : void 0;
 	}
 }
-function Tf(e) {
+function Cf(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Ef(e) {
-	if (Array.isArray(e)) return Df(e);
+function wf(e) {
+	if (Array.isArray(e)) return Tf(e);
 }
-function Df(e, t) {
+function Tf(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Of(e, t, n, r, i, a) {
+function Ef(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), Sf(t[0] ||= [V("path", {
+	}, e.pti()), bf(t[0] ||= [V("path", {
 		d: "M13.2222 7.77778H0.777778C0.571498 7.77778 0.373667 7.69584 0.227806 7.54998C0.0819442 7.40412 0 7.20629 0 7.00001C0 6.79373 0.0819442 6.5959 0.227806 6.45003C0.373667 6.30417 0.571498 6.22223 0.777778 6.22223H13.2222C13.4285 6.22223 13.6263 6.30417 13.7722 6.45003C13.9181 6.5959 14 6.79373 14 7.00001C14 7.20629 13.9181 7.40412 13.7722 7.54998C13.6263 7.69584 13.4285 7.77778 13.2222 7.77778Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-xf.render = Of;
+yf.render = Ef;
 //#endregion
 //#region node_modules/@primevue/core/baseeditableholder/index.mjs
-var kf = {
+var Df = {
 	name: "BaseEditableHolder",
-	extends: td,
+	extends: $u,
 	emits: ["update:modelValue", "value-change"],
 	props: {
 		modelValue: {
@@ -6854,9 +6855,9 @@ var kf = {
 			return this.$filled;
 		}
 	}
-}, Af = {
+}, Of = {
 	name: "BaseInput",
-	extends: kf,
+	extends: Df,
 	props: {
 		size: {
 			type: String,
@@ -6886,7 +6887,7 @@ var kf = {
 			return this.$fluid;
 		}
 	}
-}, jf = X.extend({
+}, kf = X.extend({
 	name: "checkbox",
 	style: "\n    .p-checkbox {\n        position: relative;\n        display: inline-flex;\n        user-select: none;\n        vertical-align: bottom;\n        width: dt('checkbox.width');\n        height: dt('checkbox.height');\n    }\n\n    .p-checkbox-input {\n        cursor: pointer;\n        appearance: none;\n        position: absolute;\n        inset-block-start: 0;\n        inset-inline-start: 0;\n        width: 100%;\n        height: 100%;\n        padding: 0;\n        margin: 0;\n        opacity: 0;\n        z-index: 1;\n        outline: 0 none;\n        border: 1px solid transparent;\n        border-radius: dt('checkbox.border.radius');\n    }\n\n    .p-checkbox-box {\n        display: flex;\n        justify-content: center;\n        align-items: center;\n        border-radius: dt('checkbox.border.radius');\n        border: 1px solid dt('checkbox.border.color');\n        background: dt('checkbox.background');\n        width: dt('checkbox.width');\n        height: dt('checkbox.height');\n        transition:\n            background dt('checkbox.transition.duration'),\n            color dt('checkbox.transition.duration'),\n            border-color dt('checkbox.transition.duration'),\n            box-shadow dt('checkbox.transition.duration'),\n            outline-color dt('checkbox.transition.duration');\n        outline-color: transparent;\n        box-shadow: dt('checkbox.shadow');\n    }\n\n    .p-checkbox-icon {\n        transition-duration: dt('checkbox.transition.duration');\n        color: dt('checkbox.icon.color');\n        font-size: dt('checkbox.icon.size');\n        width: dt('checkbox.icon.size');\n        height: dt('checkbox.icon.size');\n    }\n\n    .p-checkbox:not(.p-disabled):has(.p-checkbox-input:hover) .p-checkbox-box {\n        border-color: dt('checkbox.hover.border.color');\n    }\n\n    .p-checkbox-checked .p-checkbox-box {\n        border-color: dt('checkbox.checked.border.color');\n        background: dt('checkbox.checked.background');\n    }\n\n    .p-checkbox-checked .p-checkbox-icon {\n        color: dt('checkbox.icon.checked.color');\n    }\n\n    .p-checkbox-checked:not(.p-disabled):has(.p-checkbox-input:hover) .p-checkbox-box {\n        background: dt('checkbox.checked.hover.background');\n        border-color: dt('checkbox.checked.hover.border.color');\n    }\n\n    .p-checkbox-checked:not(.p-disabled):has(.p-checkbox-input:hover) .p-checkbox-icon {\n        color: dt('checkbox.icon.checked.hover.color');\n    }\n\n    .p-checkbox:not(.p-disabled):has(.p-checkbox-input:focus-visible) .p-checkbox-box {\n        border-color: dt('checkbox.focus.border.color');\n        box-shadow: dt('checkbox.focus.ring.shadow');\n        outline: dt('checkbox.focus.ring.width') dt('checkbox.focus.ring.style') dt('checkbox.focus.ring.color');\n        outline-offset: dt('checkbox.focus.ring.offset');\n    }\n\n    .p-checkbox-checked:not(.p-disabled):has(.p-checkbox-input:focus-visible) .p-checkbox-box {\n        border-color: dt('checkbox.checked.focus.border.color');\n    }\n\n    .p-checkbox.p-invalid > .p-checkbox-box {\n        border-color: dt('checkbox.invalid.border.color');\n    }\n\n    .p-checkbox.p-variant-filled .p-checkbox-box {\n        background: dt('checkbox.filled.background');\n    }\n\n    .p-checkbox-checked.p-variant-filled .p-checkbox-box {\n        background: dt('checkbox.checked.background');\n    }\n\n    .p-checkbox-checked.p-variant-filled:not(.p-disabled):has(.p-checkbox-input:hover) .p-checkbox-box {\n        background: dt('checkbox.checked.hover.background');\n    }\n\n    .p-checkbox.p-disabled {\n        opacity: 1;\n    }\n\n    .p-checkbox.p-disabled .p-checkbox-box {\n        background: dt('checkbox.disabled.background');\n        border-color: dt('checkbox.checked.disabled.border.color');\n    }\n\n    .p-checkbox.p-disabled .p-checkbox-box .p-checkbox-icon {\n        color: dt('checkbox.icon.disabled.color');\n    }\n\n    .p-checkbox-sm,\n    .p-checkbox-sm .p-checkbox-box {\n        width: dt('checkbox.sm.width');\n        height: dt('checkbox.sm.height');\n    }\n\n    .p-checkbox-sm .p-checkbox-icon {\n        font-size: dt('checkbox.icon.sm.size');\n        width: dt('checkbox.icon.sm.size');\n        height: dt('checkbox.icon.sm.size');\n    }\n\n    .p-checkbox-lg,\n    .p-checkbox-lg .p-checkbox-box {\n        width: dt('checkbox.lg.width');\n        height: dt('checkbox.lg.height');\n    }\n\n    .p-checkbox-lg .p-checkbox-icon {\n        font-size: dt('checkbox.icon.lg.size');\n        width: dt('checkbox.icon.lg.size');\n        height: dt('checkbox.icon.lg.size');\n    }\n",
 	classes: {
@@ -6905,9 +6906,9 @@ var kf = {
 		input: "p-checkbox-input",
 		icon: "p-checkbox-icon"
 	}
-}), Mf = {
+}), Af = {
 	name: "BaseCheckbox",
-	extends: Af,
+	extends: Of,
 	props: {
 		value: null,
 		binary: Boolean,
@@ -6956,7 +6957,7 @@ var kf = {
 			default: null
 		}
 	},
-	style: jf,
+	style: kf,
 	provide: function() {
 		return {
 			$pcCheckbox: this,
@@ -6964,63 +6965,63 @@ var kf = {
 		};
 	}
 };
-function Nf(e) {
+function jf(e) {
 	"@babel/helpers - typeof";
-	return Nf = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return jf = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Nf(e);
+	}, jf(e);
 }
-function Pf(e, t, n) {
-	return (t = Ff(t)) in e ? Object.defineProperty(e, t, {
+function Mf(e, t, n) {
+	return (t = Nf(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Ff(e) {
-	var t = If(e, "string");
-	return Nf(t) == "symbol" ? t : t + "";
+function Nf(e) {
+	var t = Pf(e, "string");
+	return jf(t) == "symbol" ? t : t + "";
 }
-function If(e, t) {
-	if (Nf(e) != "object" || !e) return e;
+function Pf(e, t) {
+	if (jf(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Nf(r) != "object") return r;
+		if (jf(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-function Lf(e) {
-	return Vf(e) || Bf(e) || zf(e) || Rf();
+function Ff(e) {
+	return zf(e) || Rf(e) || Lf(e) || If();
 }
-function Rf() {
+function If() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function zf(e, t) {
+function Lf(e, t) {
 	if (e) {
-		if (typeof e == "string") return Hf(e, t);
+		if (typeof e == "string") return Bf(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Hf(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Bf(e, t) : void 0;
 	}
 }
-function Bf(e) {
+function Rf(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Vf(e) {
-	if (Array.isArray(e)) return Hf(e);
+function zf(e) {
+	if (Array.isArray(e)) return Bf(e);
 }
-function Hf(e, t) {
+function Bf(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-var Uf = {
+var Vf = {
 	name: "Checkbox",
-	extends: Mf,
+	extends: Af,
 	inheritAttrs: !1,
 	emits: [
 		"change",
@@ -7053,8 +7054,8 @@ var Uf = {
 			var t = this;
 			if (!this.disabled && !this.readonly) {
 				var n = this.$pcCheckboxGroup ? this.$pcCheckboxGroup.d_value : this.d_value, r = this.binary ? this.d_indeterminate ? this.trueValue : this.checked ? this.falseValue : this.trueValue : this.checked || this.d_indeterminate ? n.filter(function(e) {
-					return !tc(e, t.value);
-				}) : n ? [].concat(Lf(n), [this.value]) : [this.value];
+					return !$s(e, t.value);
+				}) : n ? [].concat(Ff(n), [this.value]) : [this.value];
 				this.d_indeterminate && (this.d_indeterminate = !1, this.$emit("update:indeterminate", this.d_indeterminate)), this.$pcCheckboxGroup ? this.$pcCheckboxGroup.writeValue(r, e) : this.writeValue(r, e), this.$emit("change", e);
 			}
 		},
@@ -7075,10 +7076,10 @@ var Uf = {
 		},
 		checked: function() {
 			var e = this.$pcCheckboxGroup ? this.$pcCheckboxGroup.d_value : this.d_value;
-			return this.d_indeterminate ? !1 : this.binary ? e === this.trueValue : nc(this.value, e);
+			return this.d_indeterminate ? !1 : this.binary ? e === this.trueValue : ec(this.value, e);
 		},
 		dataP: function() {
-			return q(Pf({
+			return q(Mf({
 				invalid: this.$invalid,
 				checked: this.checked,
 				disabled: this.disabled,
@@ -7087,15 +7088,15 @@ var Uf = {
 		}
 	},
 	components: {
-		CheckIcon: pf,
-		MinusIcon: xf
+		CheckIcon: df,
+		MinusIcon: yf
 	}
-}, Wf = [
+}, Hf = [
 	"data-p-checked",
 	"data-p-indeterminate",
 	"data-p-disabled",
 	"data-p"
-], Gf = [
+], Uf = [
 	"id",
 	"value",
 	"name",
@@ -7107,8 +7108,8 @@ var Uf = {
 	"aria-labelledby",
 	"aria-label",
 	"aria-invalid"
-], Kf = ["data-p"];
-function qf(e, t, n, r, i, a) {
+], Wf = ["data-p"];
+function Gf(e, t, n, r, i, a) {
 	var o = F("CheckIcon"), s = F("MinusIcon");
 	return R(), z("div", W({ class: e.cx("root") }, a.getPTOptions("root"), {
 		"data-p-checked": a.checked,
@@ -7140,7 +7141,7 @@ function qf(e, t, n, r, i, a) {
 		onChange: t[2] ||= function() {
 			return a.onChange && a.onChange.apply(a, arguments);
 		}
-	}, a.getPTOptions("input")), null, 16, Gf), V("div", W({ class: e.cx("box") }, a.getPTOptions("box"), { "data-p": a.dataP }), [I(e.$slots, "icon", {
+	}, a.getPTOptions("input")), null, 16, Uf), V("div", W({ class: e.cx("box") }, a.getPTOptions("box"), { "data-p": a.dataP }), [I(e.$slots, "icon", {
 		checked: a.checked,
 		indeterminate: i.d_indeterminate,
 		class: D(e.cx("icon")),
@@ -7153,14 +7154,14 @@ function qf(e, t, n, r, i, a) {
 			key: 1,
 			class: e.cx("icon")
 		}, a.getPTOptions("icon"), { "data-p": a.dataP }), null, 16, ["class", "data-p"])) : U("", !0)];
-	})], 16, Kf)], 16, Wf);
+	})], 16, Wf)], 16, Hf);
 }
-Uf.render = qf;
+Vf.render = Gf;
 //#endregion
 //#region node_modules/primevue/inputtext/index.mjs
-var Jf = {
+var Kf = {
 	name: "BaseInputText",
-	extends: Af,
+	extends: Of,
 	style: X.extend({
 		name: "inputtext",
 		style: "\n    .p-inputtext {\n        font-family: inherit;\n        font-feature-settings: inherit;\n        font-size: 1rem;\n        color: dt('inputtext.color');\n        background: dt('inputtext.background');\n        padding-block: dt('inputtext.padding.y');\n        padding-inline: dt('inputtext.padding.x');\n        border: 1px solid dt('inputtext.border.color');\n        transition:\n            background dt('inputtext.transition.duration'),\n            color dt('inputtext.transition.duration'),\n            border-color dt('inputtext.transition.duration'),\n            outline-color dt('inputtext.transition.duration'),\n            box-shadow dt('inputtext.transition.duration');\n        appearance: none;\n        border-radius: dt('inputtext.border.radius');\n        outline-color: transparent;\n        box-shadow: dt('inputtext.shadow');\n    }\n\n    .p-inputtext:enabled:hover {\n        border-color: dt('inputtext.hover.border.color');\n    }\n\n    .p-inputtext:enabled:focus {\n        border-color: dt('inputtext.focus.border.color');\n        box-shadow: dt('inputtext.focus.ring.shadow');\n        outline: dt('inputtext.focus.ring.width') dt('inputtext.focus.ring.style') dt('inputtext.focus.ring.color');\n        outline-offset: dt('inputtext.focus.ring.offset');\n    }\n\n    .p-inputtext.p-invalid {\n        border-color: dt('inputtext.invalid.border.color');\n    }\n\n    .p-inputtext.p-variant-filled {\n        background: dt('inputtext.filled.background');\n    }\n\n    .p-inputtext.p-variant-filled:enabled:hover {\n        background: dt('inputtext.filled.hover.background');\n    }\n\n    .p-inputtext.p-variant-filled:enabled:focus {\n        background: dt('inputtext.filled.focus.background');\n    }\n\n    .p-inputtext:disabled {\n        opacity: 1;\n        background: dt('inputtext.disabled.background');\n        color: dt('inputtext.disabled.color');\n    }\n\n    .p-inputtext::placeholder {\n        color: dt('inputtext.placeholder.color');\n    }\n\n    .p-inputtext.p-invalid::placeholder {\n        color: dt('inputtext.invalid.placeholder.color');\n    }\n\n    .p-inputtext-sm {\n        font-size: dt('inputtext.sm.font.size');\n        padding-block: dt('inputtext.sm.padding.y');\n        padding-inline: dt('inputtext.sm.padding.x');\n    }\n\n    .p-inputtext-lg {\n        font-size: dt('inputtext.lg.font.size');\n        padding-block: dt('inputtext.lg.padding.y');\n        padding-inline: dt('inputtext.lg.padding.x');\n    }\n\n    .p-inputtext-fluid {\n        width: 100%;\n    }\n",
@@ -7183,39 +7184,39 @@ var Jf = {
 		};
 	}
 };
-function Yf(e) {
+function qf(e) {
 	"@babel/helpers - typeof";
-	return Yf = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return qf = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Yf(e);
+	}, qf(e);
 }
-function Xf(e, t, n) {
-	return (t = Zf(t)) in e ? Object.defineProperty(e, t, {
+function Jf(e, t, n) {
+	return (t = Yf(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Zf(e) {
-	var t = Qf(e, "string");
-	return Yf(t) == "symbol" ? t : t + "";
+function Yf(e) {
+	var t = Xf(e, "string");
+	return qf(t) == "symbol" ? t : t + "";
 }
-function Qf(e, t) {
-	if (Yf(e) != "object" || !e) return e;
+function Xf(e, t) {
+	if (qf(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Yf(r) != "object") return r;
+		if (qf(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var $f = {
+var Zf = {
 	name: "InputText",
-	extends: Jf,
+	extends: Kf,
 	inheritAttrs: !1,
 	methods: { onInput: function(e) {
 		this.writeValue(e.target.value, e);
@@ -7228,21 +7229,21 @@ var $f = {
 			} }), this.formField);
 		},
 		dataP: function() {
-			return q(Xf({
+			return q(Jf({
 				invalid: this.$invalid,
 				fluid: this.$fluid,
 				filled: this.$variant === "filled"
 			}, this.size, this.size));
 		}
 	}
-}, ep = [
+}, Qf = [
 	"value",
 	"name",
 	"disabled",
 	"aria-invalid",
 	"data-p"
 ];
-function tp(e, t, n, r, i, a) {
+function $f(e, t, n, r, i, a) {
 	return R(), z("input", W({
 		type: "text",
 		class: e.cx("root"),
@@ -7254,12 +7255,12 @@ function tp(e, t, n, r, i, a) {
 		onInput: t[0] ||= function() {
 			return a.onInput && a.onInput.apply(a, arguments);
 		}
-	}, a.attrs), null, 16, ep);
+	}, a.attrs), null, 16, Qf);
 }
-$f.render = tp;
+Zf.render = $f;
 //#endregion
 //#region node_modules/primevue/textarea/style/index.mjs
-var np = X.extend({
+var ep = X.extend({
 	name: "textarea",
 	style: "\n    .p-textarea {\n        font-family: inherit;\n        font-feature-settings: inherit;\n        font-size: 1rem;\n        color: dt('textarea.color');\n        background: dt('textarea.background');\n        padding-block: dt('textarea.padding.y');\n        padding-inline: dt('textarea.padding.x');\n        border: 1px solid dt('textarea.border.color');\n        transition:\n            background dt('textarea.transition.duration'),\n            color dt('textarea.transition.duration'),\n            border-color dt('textarea.transition.duration'),\n            outline-color dt('textarea.transition.duration'),\n            box-shadow dt('textarea.transition.duration');\n        appearance: none;\n        border-radius: dt('textarea.border.radius');\n        outline-color: transparent;\n        box-shadow: dt('textarea.shadow');\n    }\n\n    .p-textarea:enabled:hover {\n        border-color: dt('textarea.hover.border.color');\n    }\n\n    .p-textarea:enabled:focus {\n        border-color: dt('textarea.focus.border.color');\n        box-shadow: dt('textarea.focus.ring.shadow');\n        outline: dt('textarea.focus.ring.width') dt('textarea.focus.ring.style') dt('textarea.focus.ring.color');\n        outline-offset: dt('textarea.focus.ring.offset');\n    }\n\n    .p-textarea.p-invalid {\n        border-color: dt('textarea.invalid.border.color');\n    }\n\n    .p-textarea.p-variant-filled {\n        background: dt('textarea.filled.background');\n    }\n\n    .p-textarea.p-variant-filled:enabled:hover {\n        background: dt('textarea.filled.hover.background');\n    }\n\n    .p-textarea.p-variant-filled:enabled:focus {\n        background: dt('textarea.filled.focus.background');\n    }\n\n    .p-textarea:disabled {\n        opacity: 1;\n        background: dt('textarea.disabled.background');\n        color: dt('textarea.disabled.color');\n    }\n\n    .p-textarea::placeholder {\n        color: dt('textarea.placeholder.color');\n    }\n\n    .p-textarea.p-invalid::placeholder {\n        color: dt('textarea.invalid.placeholder.color');\n    }\n\n    .p-textarea-fluid {\n        width: 100%;\n    }\n\n    .p-textarea-resizable {\n        overflow: hidden;\n        resize: none;\n    }\n\n    .p-textarea-sm {\n        font-size: dt('textarea.sm.font.size');\n        padding-block: dt('textarea.sm.padding.y');\n        padding-inline: dt('textarea.sm.padding.x');\n    }\n\n    .p-textarea-lg {\n        font-size: dt('textarea.lg.font.size');\n        padding-block: dt('textarea.lg.padding.y');\n        padding-inline: dt('textarea.lg.padding.x');\n    }\n",
 	classes: { root: function(e) {
@@ -7274,11 +7275,11 @@ var np = X.extend({
 			"p-textarea-fluid": t.$fluid
 		}];
 	} }
-}), rp = {
+}), tp = {
 	name: "BaseTextarea",
-	extends: Af,
+	extends: Of,
 	props: { autoResize: Boolean },
-	style: np,
+	style: ep,
 	provide: function() {
 		return {
 			$pcTextarea: this,
@@ -7286,39 +7287,39 @@ var np = X.extend({
 		};
 	}
 };
-function ip(e) {
+function np(e) {
 	"@babel/helpers - typeof";
-	return ip = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return np = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, ip(e);
+	}, np(e);
 }
-function ap(e, t, n) {
-	return (t = op(t)) in e ? Object.defineProperty(e, t, {
+function rp(e, t, n) {
+	return (t = ip(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function op(e) {
-	var t = sp(e, "string");
-	return ip(t) == "symbol" ? t : t + "";
+function ip(e) {
+	var t = ap(e, "string");
+	return np(t) == "symbol" ? t : t + "";
 }
-function sp(e, t) {
-	if (ip(e) != "object" || !e) return e;
+function ap(e, t) {
+	if (np(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (ip(r) != "object") return r;
+		if (np(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var cp = {
+var op = {
 	name: "Textarea",
-	extends: rp,
+	extends: tp,
 	inheritAttrs: !1,
 	observer: null,
 	mounted: function() {
@@ -7354,21 +7355,21 @@ var cp = {
 			} }), this.formField);
 		},
 		dataP: function() {
-			return q(ap({
+			return q(rp({
 				invalid: this.$invalid,
 				fluid: this.$fluid,
 				filled: this.$variant === "filled"
 			}, this.size, this.size));
 		}
 	}
-}, lp = [
+}, sp = [
 	"value",
 	"name",
 	"disabled",
 	"aria-invalid",
 	"data-p"
 ];
-function up(e, t, n, r, i, a) {
+function cp(e, t, n, r, i, a) {
 	return R(), z("textarea", W({
 		class: e.cx("root"),
 		value: e.d_value,
@@ -7379,55 +7380,55 @@ function up(e, t, n, r, i, a) {
 		onInput: t[0] ||= function() {
 			return a.onInput && a.onInput.apply(a, arguments);
 		}
-	}, a.attrs), null, 16, lp);
+	}, a.attrs), null, 16, sp);
 }
-cp.render = up;
+op.render = cp;
 //#endregion
 //#region node_modules/@primevue/core/utils/index.mjs
-function dp(e) {
+function lp(e) {
 	"@babel/helpers - typeof";
-	return dp = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return lp = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, dp(e);
+	}, lp(e);
 }
-function fp(e, t) {
+function up(e, t) {
 	if (!(e instanceof t)) throw TypeError("Cannot call a class as a function");
 }
-function pp(e, t) {
+function dp(e, t) {
 	for (var n = 0; n < t.length; n++) {
 		var r = t[n];
-		r.enumerable = r.enumerable || !1, r.configurable = !0, "value" in r && (r.writable = !0), Object.defineProperty(e, hp(r.key), r);
+		r.enumerable = r.enumerable || !1, r.configurable = !0, "value" in r && (r.writable = !0), Object.defineProperty(e, pp(r.key), r);
 	}
 }
-function mp(e, t, n) {
-	return t && pp(e.prototype, t), Object.defineProperty(e, "prototype", { writable: !1 }), e;
+function fp(e, t, n) {
+	return t && dp(e.prototype, t), Object.defineProperty(e, "prototype", { writable: !1 }), e;
 }
-function hp(e) {
-	var t = gp(e, "string");
-	return dp(t) == "symbol" ? t : t + "";
+function pp(e) {
+	var t = mp(e, "string");
+	return lp(t) == "symbol" ? t : t + "";
 }
-function gp(e, t) {
-	if (dp(e) != "object" || !e) return e;
+function mp(e, t) {
+	if (lp(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (dp(r) != "object") return r;
+		if (lp(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return String(e);
 }
-var _p = /* @__PURE__ */ function() {
+var hp = /*#__PURE__*/ function() {
 	function e(t) {
 		var n = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : function() {};
-		fp(this, e), this.element = t, this.listener = n;
+		up(this, e), this.element = t, this.listener = n;
 	}
-	return mp(e, [
+	return fp(e, [
 		{
 			key: "bindScrollListener",
 			value: function() {
-				this.scrollableParents = $c(this.element);
+				this.scrollableParents = Zc(this.element);
 				for (var e = 0; e < this.scrollableParents.length; e++) this.scrollableParents[e].addEventListener("scroll", this.listener);
 			}
 		},
@@ -7444,187 +7445,187 @@ var _p = /* @__PURE__ */ function() {
 			}
 		}
 	]);
-}(), vp = {
+}(), gp = {
 	name: "BlankIcon",
-	extends: ld
+	extends: sd
 };
-function yp(e) {
-	return Cp(e) || Sp(e) || xp(e) || bp();
+function _p(e) {
+	return xp(e) || bp(e) || yp(e) || vp();
 }
-function bp() {
+function vp() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function xp(e, t) {
+function yp(e, t) {
 	if (e) {
-		if (typeof e == "string") return wp(e, t);
+		if (typeof e == "string") return Sp(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? wp(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Sp(e, t) : void 0;
 	}
 }
-function Sp(e) {
+function bp(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Cp(e) {
-	if (Array.isArray(e)) return wp(e);
+function xp(e) {
+	if (Array.isArray(e)) return Sp(e);
 }
-function wp(e, t) {
+function Sp(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Tp(e, t, n, r, i, a) {
+function Cp(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), yp(t[0] ||= [V("rect", {
+	}, e.pti()), _p(t[0] ||= [V("rect", {
 		width: "1",
 		height: "1",
 		fill: "currentColor",
 		"fill-opacity": "0"
 	}, null, -1)]), 16);
 }
-vp.render = Tp;
+gp.render = Cp;
 //#endregion
 //#region node_modules/@primevue/icons/chevrondown/index.mjs
-var Ep = {
+var wp = {
 	name: "ChevronDownIcon",
-	extends: ld
+	extends: sd
 };
-function Dp(e) {
-	return jp(e) || Ap(e) || kp(e) || Op();
+function Tp(e) {
+	return kp(e) || Op(e) || Dp(e) || Ep();
 }
-function Op() {
+function Ep() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function kp(e, t) {
+function Dp(e, t) {
 	if (e) {
-		if (typeof e == "string") return Mp(e, t);
+		if (typeof e == "string") return Ap(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Mp(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Ap(e, t) : void 0;
 	}
 }
-function Ap(e) {
+function Op(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function jp(e) {
-	if (Array.isArray(e)) return Mp(e);
+function kp(e) {
+	if (Array.isArray(e)) return Ap(e);
 }
-function Mp(e, t) {
+function Ap(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Np(e, t, n, r, i, a) {
+function jp(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), Dp(t[0] ||= [V("path", {
+	}, e.pti()), Tp(t[0] ||= [V("path", {
 		d: "M7.01744 10.398C6.91269 10.3985 6.8089 10.378 6.71215 10.3379C6.61541 10.2977 6.52766 10.2386 6.45405 10.1641L1.13907 4.84913C1.03306 4.69404 0.985221 4.5065 1.00399 4.31958C1.02276 4.13266 1.10693 3.95838 1.24166 3.82747C1.37639 3.69655 1.55301 3.61742 1.74039 3.60402C1.92777 3.59062 2.11386 3.64382 2.26584 3.75424L7.01744 8.47394L11.769 3.75424C11.9189 3.65709 12.097 3.61306 12.2748 3.62921C12.4527 3.64535 12.6199 3.72073 12.7498 3.84328C12.8797 3.96582 12.9647 4.12842 12.9912 4.30502C13.0177 4.48162 12.9841 4.662 12.8958 4.81724L7.58083 10.1322C7.50996 10.2125 7.42344 10.2775 7.32656 10.3232C7.22968 10.3689 7.12449 10.3944 7.01744 10.398Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-Ep.render = Np;
+wp.render = jp;
 //#endregion
 //#region node_modules/@primevue/icons/search/index.mjs
-var Pp = {
+var Mp = {
 	name: "SearchIcon",
-	extends: ld
+	extends: sd
 };
-function Fp(e) {
-	return zp(e) || Rp(e) || Lp(e) || Ip();
+function Np(e) {
+	return Lp(e) || Ip(e) || Fp(e) || Pp();
 }
-function Ip() {
+function Pp() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Lp(e, t) {
+function Fp(e, t) {
 	if (e) {
-		if (typeof e == "string") return Bp(e, t);
+		if (typeof e == "string") return Rp(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Bp(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Rp(e, t) : void 0;
 	}
 }
-function Rp(e) {
+function Ip(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function zp(e) {
-	if (Array.isArray(e)) return Bp(e);
+function Lp(e) {
+	if (Array.isArray(e)) return Rp(e);
 }
-function Bp(e, t) {
+function Rp(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Vp(e, t, n, r, i, a) {
+function zp(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), Fp(t[0] ||= [V("path", {
+	}, e.pti()), Np(t[0] ||= [V("path", {
 		"fill-rule": "evenodd",
 		"clip-rule": "evenodd",
 		d: "M2.67602 11.0265C3.6661 11.688 4.83011 12.0411 6.02086 12.0411C6.81149 12.0411 7.59438 11.8854 8.32483 11.5828C8.87005 11.357 9.37808 11.0526 9.83317 10.6803L12.9769 13.8241C13.0323 13.8801 13.0983 13.9245 13.171 13.9548C13.2438 13.985 13.3219 14.0003 13.4007 14C13.4795 14.0003 13.5575 13.985 13.6303 13.9548C13.7031 13.9245 13.7691 13.8801 13.8244 13.8241C13.9367 13.7116 13.9998 13.5592 13.9998 13.4003C13.9998 13.2414 13.9367 13.089 13.8244 12.9765L10.6807 9.8328C11.053 9.37773 11.3573 8.86972 11.5831 8.32452C11.8857 7.59408 12.0414 6.81119 12.0414 6.02056C12.0414 4.8298 11.6883 3.66579 11.0268 2.67572C10.3652 1.68564 9.42494 0.913972 8.32483 0.45829C7.22472 0.00260857 6.01418 -0.116618 4.84631 0.115686C3.67844 0.34799 2.60568 0.921393 1.76369 1.76338C0.921698 2.60537 0.348296 3.67813 0.115991 4.84601C-0.116313 6.01388 0.00291375 7.22441 0.458595 8.32452C0.914277 9.42464 1.68595 10.3649 2.67602 11.0265ZM3.35565 2.0158C4.14456 1.48867 5.07206 1.20731 6.02086 1.20731C7.29317 1.20731 8.51338 1.71274 9.41304 2.6124C10.3127 3.51206 10.8181 4.73226 10.8181 6.00457C10.8181 6.95337 10.5368 7.88088 10.0096 8.66978C9.48251 9.45868 8.73328 10.0736 7.85669 10.4367C6.98011 10.7997 6.01554 10.8947 5.08496 10.7096C4.15439 10.5245 3.2996 10.0676 2.62869 9.39674C1.95778 8.72583 1.50089 7.87104 1.31579 6.94046C1.13068 6.00989 1.22568 5.04532 1.58878 4.16874C1.95187 3.29215 2.56675 2.54292 3.35565 2.0158Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-Pp.render = Vp;
+Mp.render = zp;
 //#endregion
 //#region node_modules/@primevue/icons/times/index.mjs
-var Hp = {
+var Bp = {
 	name: "TimesIcon",
-	extends: ld
+	extends: sd
 };
-function Up(e) {
-	return qp(e) || Kp(e) || Gp(e) || Wp();
+function Vp(e) {
+	return Gp(e) || Wp(e) || Up(e) || Hp();
 }
-function Wp() {
+function Hp() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Gp(e, t) {
+function Up(e, t) {
 	if (e) {
-		if (typeof e == "string") return Jp(e, t);
+		if (typeof e == "string") return Kp(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Jp(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Kp(e, t) : void 0;
 	}
 }
-function Kp(e) {
+function Wp(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function qp(e) {
-	if (Array.isArray(e)) return Jp(e);
+function Gp(e) {
+	if (Array.isArray(e)) return Kp(e);
 }
-function Jp(e, t) {
+function Kp(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Yp(e, t, n, r, i, a) {
+function qp(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), Up(t[0] ||= [V("path", {
+	}, e.pti()), Vp(t[0] ||= [V("path", {
 		d: "M8.01186 7.00933L12.27 2.75116C12.341 2.68501 12.398 2.60524 12.4375 2.51661C12.4769 2.42798 12.4982 2.3323 12.4999 2.23529C12.5016 2.13827 12.4838 2.0419 12.4474 1.95194C12.4111 1.86197 12.357 1.78024 12.2884 1.71163C12.2198 1.64302 12.138 1.58893 12.0481 1.55259C11.9581 1.51625 11.8617 1.4984 11.7647 1.50011C11.6677 1.50182 11.572 1.52306 11.4834 1.56255C11.3948 1.60204 11.315 1.65898 11.2488 1.72997L6.99067 5.98814L2.7325 1.72997C2.59553 1.60234 2.41437 1.53286 2.22718 1.53616C2.03999 1.53946 1.8614 1.61529 1.72901 1.74767C1.59663 1.88006 1.5208 2.05865 1.5175 2.24584C1.5142 2.43303 1.58368 2.61419 1.71131 2.75116L5.96948 7.00933L1.71131 11.2675C1.576 11.403 1.5 11.5866 1.5 11.7781C1.5 11.9696 1.576 12.1532 1.71131 12.2887C1.84679 12.424 2.03043 12.5 2.2219 12.5C2.41338 12.5 2.59702 12.424 2.7325 12.2887L6.99067 8.03052L11.2488 12.2887C11.3843 12.424 11.568 12.5 11.7594 12.5C11.9509 12.5 12.1346 12.424 12.27 12.2887C12.4053 12.1532 12.4813 11.9696 12.4813 11.7781C12.4813 11.5866 12.4053 11.403 12.27 11.2675L8.01186 7.00933Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-Hp.render = Yp;
+Bp.render = qp;
 //#endregion
 //#region node_modules/primevue/iconfield/index.mjs
-var Xp = {
+var Jp = {
 	name: "IconField",
 	extends: {
 		name: "BaseIconField",
-		extends: td,
+		extends: $u,
 		style: X.extend({
 			name: "iconfield",
 			style: "\n    .p-iconfield {\n        position: relative;\n        display: block;\n    }\n\n    .p-inputicon {\n        position: absolute;\n        top: 50%;\n        margin-top: calc(-1 * (dt('icon.size') / 2));\n        color: dt('iconfield.icon.color');\n        line-height: 1;\n        z-index: 1;\n    }\n\n    .p-iconfield .p-inputicon:first-child {\n        inset-inline-start: dt('form.field.padding.x');\n    }\n\n    .p-iconfield .p-inputicon:last-child {\n        inset-inline-end: dt('form.field.padding.x');\n    }\n\n    .p-iconfield .p-inputtext:not(:first-child),\n    .p-iconfield .p-inputwrapper:not(:first-child) .p-inputtext {\n        padding-inline-start: calc((dt('form.field.padding.x') * 2) + dt('icon.size'));\n    }\n\n    .p-iconfield .p-inputtext:not(:last-child) {\n        padding-inline-end: calc((dt('form.field.padding.x') * 2) + dt('icon.size'));\n    }\n\n    .p-iconfield:has(.p-inputfield-sm) .p-inputicon {\n        font-size: dt('form.field.sm.font.size');\n        width: dt('form.field.sm.font.size');\n        height: dt('form.field.sm.font.size');\n        margin-top: calc(-1 * (dt('form.field.sm.font.size') / 2));\n    }\n\n    .p-iconfield:has(.p-inputfield-lg) .p-inputicon {\n        font-size: dt('form.field.lg.font.size');\n        width: dt('form.field.lg.font.size');\n        height: dt('form.field.lg.font.size');\n        margin-top: calc(-1 * (dt('form.field.lg.font.size') / 2));\n    }\n",
@@ -7639,17 +7640,17 @@ var Xp = {
 	},
 	inheritAttrs: !1
 };
-function Zp(e, t, n, r, i, a) {
+function Yp(e, t, n, r, i, a) {
 	return R(), z("div", W({ class: e.cx("root") }, e.ptmi("root")), [I(e.$slots, "default")], 16);
 }
-Xp.render = Zp;
+Jp.render = Yp;
 //#endregion
 //#region node_modules/primevue/inputicon/index.mjs
-var Qp = {
+var Xp = {
 	name: "InputIcon",
 	extends: {
 		name: "BaseInputIcon",
-		extends: td,
+		extends: $u,
 		style: X.extend({
 			name: "inputicon",
 			classes: { root: "p-inputicon" }
@@ -7667,13 +7668,13 @@ var Qp = {
 		return [this.cx("root"), this.class];
 	} }
 };
-function $p(e, t, n, r, i, a) {
+function Zp(e, t, n, r, i, a) {
 	return R(), z("span", W({ class: a.containerClass }, e.ptmi("root"), { "aria-hidden": "true" }), [I(e.$slots, "default")], 16);
 }
-Qp.render = $p;
+Xp.render = Zp;
 //#endregion
 //#region node_modules/primevue/overlayeventbus/index.mjs
-var em = bc(), tm = {
+var Qp = vc(), $p = {
 	name: "Portal",
 	props: {
 		appendTo: {
@@ -7689,28 +7690,28 @@ var em = bc(), tm = {
 		return { mounted: !1 };
 	},
 	mounted: function() {
-		this.mounted = nl();
+		this.mounted = el();
 	},
 	computed: { inline: function() {
 		return this.disabled || this.appendTo === "self";
 	} }
 };
-function nm(e, t, n, r, i, a) {
-	return a.inline ? I(e.$slots, "default", { key: 0 }) : i.mounted ? (R(), B(ur, {
+function em(e, t, n, r, i, a) {
+	return a.inline ? I(e.$slots, "default", { key: 0 }) : i.mounted ? (R(), B(lr, {
 		key: 1,
 		to: n.appendTo
 	}, [I(e.$slots, "default")], 8, ["to"])) : U("", !0);
 }
-tm.render = nm;
+$p.render = em;
 //#endregion
 //#region node_modules/primevue/virtualscroller/style/index.mjs
-var rm = X.extend({
+var tm = X.extend({
 	name: "virtualscroller",
 	css: "\n.p-virtualscroller {\n    position: relative;\n    overflow: auto;\n    contain: strict;\n    transform: translateZ(0);\n    will-change: scroll-position;\n    outline: 0 none;\n}\n\n.p-virtualscroller-content {\n    position: absolute;\n    top: 0;\n    left: 0;\n    min-height: 100%;\n    min-width: 100%;\n    will-change: transform;\n}\n\n.p-virtualscroller-spacer {\n    position: absolute;\n    top: 0;\n    left: 0;\n    height: 1px;\n    width: 1px;\n    transform-origin: 0 0;\n    pointer-events: none;\n}\n\n.p-virtualscroller-loader {\n    position: sticky;\n    top: 0;\n    left: 0;\n    width: 100%;\n    height: 100%;\n}\n\n.p-virtualscroller-loader-mask {\n    display: flex;\n    align-items: center;\n    justify-content: center;\n}\n\n.p-virtualscroller-horizontal > .p-virtualscroller-content {\n    display: flex;\n}\n\n.p-virtualscroller-inline .p-virtualscroller-content {\n    position: static;\n}\n\n.p-virtualscroller .p-virtualscroller-loading {\n    transform: none !important;\n    min-height: 0;\n    position: sticky;\n    inset-block-start: 0;\n    inset-inline-start: 0;\n}\n",
 	style: "\n    .p-virtualscroller-loader {\n        background: dt('virtualscroller.loader.mask.background');\n        color: dt('virtualscroller.loader.mask.color');\n    }\n\n    .p-virtualscroller-loading-icon {\n        font-size: dt('virtualscroller.loader.icon.size');\n        width: dt('virtualscroller.loader.icon.size');\n        height: dt('virtualscroller.loader.icon.size');\n    }\n"
-}), im = {
+}), nm = {
 	name: "BaseVirtualScroller",
-	extends: td,
+	extends: $u,
 	props: {
 		id: {
 			type: String,
@@ -7793,7 +7794,7 @@ var rm = X.extend({
 			default: !1
 		}
 	},
-	style: rm,
+	style: tm,
 	provide: function() {
 		return {
 			$pcVirtualScroller: this,
@@ -7802,18 +7803,18 @@ var rm = X.extend({
 	},
 	beforeMount: function() {
 		var e;
-		rm.loadCSS({ nonce: (e = this.$primevueConfig) == null || (e = e.csp) == null ? void 0 : e.nonce });
+		tm.loadCSS({ nonce: (e = this.$primevueConfig) == null || (e = e.csp) == null ? void 0 : e.nonce });
 	}
 };
-function am(e) {
+function rm(e) {
 	"@babel/helpers - typeof";
-	return am = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return rm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, am(e);
+	}, rm(e);
 }
-function om(e, t) {
+function im(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -7823,42 +7824,42 @@ function om(e, t) {
 	}
 	return n;
 }
-function sm(e) {
+function am(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? om(Object(n), !0).forEach(function(t) {
-			cm(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : om(Object(n)).forEach(function(t) {
+		t % 2 ? im(Object(n), !0).forEach(function(t) {
+			om(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : im(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function cm(e, t, n) {
-	return (t = lm(t)) in e ? Object.defineProperty(e, t, {
+function om(e, t, n) {
+	return (t = sm(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function lm(e) {
-	var t = um(e, "string");
-	return am(t) == "symbol" ? t : t + "";
+function sm(e) {
+	var t = cm(e, "string");
+	return rm(t) == "symbol" ? t : t + "";
 }
-function um(e, t) {
-	if (am(e) != "object" || !e) return e;
+function cm(e, t) {
+	if (rm(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (am(r) != "object") return r;
+		if (rm(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var dm = {
+var lm = {
 	name: "VirtualScroller",
-	extends: im,
+	extends: nm,
 	inheritAttrs: !1,
 	emits: [
 		"update:numToleratedItems",
@@ -7953,7 +7954,7 @@ var dm = {
 	},
 	methods: {
 		viewInit: function() {
-			il(this.element) && (this.setContentEl(this.content), this.init(), this.calculateAutoSize(), this.defaultWidth = el(this.element), this.defaultHeight = Jc(this.element), this.defaultContentWidth = el(this.content), this.defaultContentHeight = Jc(this.content), this.initialized = !0), this.element && this.bindResizeListener();
+			nl(this.element) && (this.setContentEl(this.content), this.init(), this.calculateAutoSize(), this.defaultWidth = Qc(this.element), this.defaultHeight = Kc(this.element), this.defaultContentWidth = Qc(this.content), this.defaultContentHeight = Kc(this.content), this.initialized = !0), this.element && this.bindResizeListener();
 		},
 		init: function() {
 			this.disabled || (this.setSize(), this.calculateOptions(), this.setSpacerSize());
@@ -8091,7 +8092,7 @@ var dm = {
 				if (e.content) {
 					var t = e.isBoth(), n = e.isHorizontal(), r = e.isVertical();
 					e.content.style.minHeight = e.content.style.minWidth = "auto", e.content.style.position = "relative", e.element.style.contain = "none";
-					var i = [el(e.element), Jc(e.element)], a = i[0], o = i[1];
+					var i = [Qc(e.element), Kc(e.element)], a = i[0], o = i[1];
 					(t || n) && (e.element.style.width = a < e.defaultWidth ? a + "px" : e.scrollWidth || e.defaultWidth + "px"), (t || r) && (e.element.style.height = o < e.defaultHeight ? o + "px" : e.scrollHeight || e.defaultHeight + "px"), e.content.style.minHeight = e.content.style.minWidth = "", e.content.style.position = "", e.element.style.contain = "";
 				}
 			});
@@ -8135,7 +8136,7 @@ var dm = {
 			if (t) {
 				var n = this.isBoth(), r = this.isHorizontal(), i = this.getContentPosition(), a = function(t, n, r) {
 					var i = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : 0;
-					return e.spacerStyle = sm(sm({}, e.spacerStyle), cm({}, `${t}`, (n || []).length * r + i + "px"));
+					return e.spacerStyle = am(am({}, e.spacerStyle), om({}, `${t}`, (n || []).length * r + i + "px"));
 				};
 				n ? (a("height", t, this.itemSize[0], i.y), a("width", this.columns || t[1], this.itemSize[1], i.x)) : r ? a("width", this.columns || t, this.itemSize, i.x) : a("height", t, this.itemSize, i.y);
 			}
@@ -8147,7 +8148,7 @@ var dm = {
 					return e * t;
 				}, o = function() {
 					var e = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : 0, n = arguments.length > 1 && arguments[1] !== void 0 ? arguments[1] : 0;
-					return t.contentStyle = sm(sm({}, t.contentStyle), { transform: `translate3d(${e}px, ${n}px, 0)` });
+					return t.contentStyle = am(am({}, t.contentStyle), { transform: `translate3d(${e}px, ${n}px, 0)` });
 				};
 				if (n) o(a(i.cols, this.itemSize[1]), a(i.rows, this.itemSize[0]));
 				else {
@@ -8234,9 +8235,9 @@ var dm = {
 		onResize: function() {
 			var e = this;
 			this.resizeTimeout && clearTimeout(this.resizeTimeout), this.resizeTimeout = setTimeout(function() {
-				if (il(e.element)) {
-					var t = e.isBoth(), n = e.isVertical(), r = e.isHorizontal(), i = [el(e.element), Jc(e.element)], a = i[0], o = i[1], s = a !== e.defaultWidth, c = o !== e.defaultHeight;
-					(t ? s || c : r ? s : n && c) && (e.d_numToleratedItems = e.numToleratedItems, e.defaultWidth = a, e.defaultHeight = o, e.defaultContentWidth = el(e.content), e.defaultContentHeight = Jc(e.content), e.init());
+				if (nl(e.element)) {
+					var t = e.isBoth(), n = e.isVertical(), r = e.isHorizontal(), i = [Qc(e.element), Kc(e.element)], a = i[0], o = i[1], s = a !== e.defaultWidth, c = o !== e.defaultHeight;
+					(t ? s || c : r ? s : n && c) && (e.d_numToleratedItems = e.numToleratedItems, e.defaultWidth = a, e.defaultHeight = o, e.defaultContentWidth = Qc(e.content), e.defaultContentHeight = Kc(e.content), e.init());
 				}
 			}, this.resizeDelay);
 		},
@@ -8262,7 +8263,7 @@ var dm = {
 		},
 		getLoaderOptions: function(e, t) {
 			var n = this.loaderArr.length;
-			return sm({
+			return am({
 				index: e,
 				count: n,
 				first: e === 0,
@@ -8278,7 +8279,7 @@ var dm = {
 			return this.step && !this.lazy ? this.page !== this.getPageByFirst(e ?? this.first) : !0;
 		},
 		setContentEl: function(e) {
-			this.content = e || this.content || Wc(this.element, "[data-pc-section=\"content\"]");
+			this.content = e || this.content || Hc(this.element, "[data-pc-section=\"content\"]");
 		},
 		elementRef: function(e) {
 			this.element = e;
@@ -8322,9 +8323,9 @@ var dm = {
 			return this.columns;
 		}
 	},
-	components: { SpinnerIcon: ud }
-}, fm = ["tabindex"];
-function pm(e, t, n, r, i, a) {
+	components: { SpinnerIcon: cd }
+}, um = ["tabindex"];
+function dm(e, t, n, r, i, a) {
 	var o = F("SpinnerIcon");
 	return e.disabled ? (R(), z(L, { key: 1 }, [I(e.$slots, "default"), I(e.$slots, "content", {
 		items: e.items,
@@ -8360,7 +8361,7 @@ function pm(e, t, n, r, i, a) {
 				ref: a.contentRef,
 				class: a.contentClass,
 				style: i.contentStyle
-			}, e.ptm("content")), [(R(!0), z(L, null, ui(a.loadedItems, function(t, n) {
+			}, e.ptm("content")), [(R(!0), z(L, null, li(a.loadedItems, function(t, n) {
 				return I(e.$slots, "item", {
 					key: n,
 					item: t,
@@ -8376,7 +8377,7 @@ function pm(e, t, n, r, i, a) {
 		!e.loaderDisabled && e.showLoader && i.d_loading ? (R(), z("div", W({
 			key: 1,
 			class: a.loaderClass
-		}, e.ptm("loader")), [e.$slots && e.$slots.loader ? (R(!0), z(L, { key: 0 }, ui(i.loaderArr, function(t, n) {
+		}, e.ptm("loader")), [e.$slots && e.$slots.loader ? (R(!0), z(L, { key: 0 }, li(i.loaderArr, function(t, n) {
 			return I(e.$slots, "loader", {
 				key: n,
 				options: a.getLoaderOptions(n, a.isBoth() && { numCols: e.d_numItemsInViewport.cols })
@@ -8387,12 +8388,12 @@ function pm(e, t, n, r, i, a) {
 				class: "p-virtualscroller-loading-icon"
 			}, e.ptm("loadingIcon")), null, 16)];
 		})], 16)) : U("", !0)
-	], 16, fm));
+	], 16, um));
 }
-dm.render = pm;
+lm.render = dm;
 //#endregion
 //#region node_modules/primevue/select/style/index.mjs
-var mm = X.extend({
+var fm = X.extend({
 	name: "select",
 	style: "\n    .p-select {\n        display: inline-flex;\n        cursor: pointer;\n        position: relative;\n        user-select: none;\n        background: dt('select.background');\n        border: 1px solid dt('select.border.color');\n        transition:\n            background dt('select.transition.duration'),\n            color dt('select.transition.duration'),\n            border-color dt('select.transition.duration'),\n            outline-color dt('select.transition.duration'),\n            box-shadow dt('select.transition.duration');\n        border-radius: dt('select.border.radius');\n        outline-color: transparent;\n        box-shadow: dt('select.shadow');\n    }\n\n    .p-select:not(.p-disabled):hover {\n        border-color: dt('select.hover.border.color');\n    }\n\n    .p-select:not(.p-disabled).p-focus {\n        border-color: dt('select.focus.border.color');\n        box-shadow: dt('select.focus.ring.shadow');\n        outline: dt('select.focus.ring.width') dt('select.focus.ring.style') dt('select.focus.ring.color');\n        outline-offset: dt('select.focus.ring.offset');\n    }\n\n    .p-select.p-variant-filled {\n        background: dt('select.filled.background');\n    }\n\n    .p-select.p-variant-filled:not(.p-disabled):hover {\n        background: dt('select.filled.hover.background');\n    }\n\n    .p-select.p-variant-filled:not(.p-disabled).p-focus {\n        background: dt('select.filled.focus.background');\n    }\n\n    .p-select.p-invalid {\n        border-color: dt('select.invalid.border.color');\n    }\n\n    .p-select.p-disabled {\n        opacity: 1;\n        background: dt('select.disabled.background');\n    }\n\n    .p-select-clear-icon {\n        align-self: center;\n        color: dt('select.clear.icon.color');\n        inset-inline-end: dt('select.dropdown.width');\n    }\n\n    .p-select-dropdown {\n        display: flex;\n        align-items: center;\n        justify-content: center;\n        flex-shrink: 0;\n        background: transparent;\n        color: dt('select.dropdown.color');\n        width: dt('select.dropdown.width');\n        border-start-end-radius: dt('select.border.radius');\n        border-end-end-radius: dt('select.border.radius');\n    }\n\n    .p-select-label {\n        display: block;\n        white-space: nowrap;\n        overflow: hidden;\n        flex: 1 1 auto;\n        width: 1%;\n        padding: dt('select.padding.y') dt('select.padding.x');\n        text-overflow: ellipsis;\n        cursor: pointer;\n        color: dt('select.color');\n        background: transparent;\n        border: 0 none;\n        outline: 0 none;\n        font-size: 1rem;\n    }\n\n    .p-select-label.p-placeholder {\n        color: dt('select.placeholder.color');\n    }\n\n    .p-select.p-invalid .p-select-label.p-placeholder {\n        color: dt('select.invalid.placeholder.color');\n    }\n\n    .p-select.p-disabled .p-select-label {\n        color: dt('select.disabled.color');\n    }\n\n    .p-select-label-empty {\n        overflow: hidden;\n        opacity: 0;\n    }\n\n    input.p-select-label {\n        cursor: default;\n    }\n\n    .p-select-overlay {\n        position: absolute;\n        top: 0;\n        left: 0;\n        background: dt('select.overlay.background');\n        color: dt('select.overlay.color');\n        border: 1px solid dt('select.overlay.border.color');\n        border-radius: dt('select.overlay.border.radius');\n        box-shadow: dt('select.overlay.shadow');\n        min-width: 100%;\n        transform-origin: inherit;\n        will-change: transform;\n    }\n\n    .p-select-header {\n        padding: dt('select.list.header.padding');\n    }\n\n    .p-select-filter {\n        width: 100%;\n    }\n\n    .p-select-list-container {\n        overflow: auto;\n    }\n\n    .p-select-option-group {\n        cursor: auto;\n        margin: 0;\n        padding: dt('select.option.group.padding');\n        background: dt('select.option.group.background');\n        color: dt('select.option.group.color');\n        font-weight: dt('select.option.group.font.weight');\n    }\n\n    .p-select-list {\n        margin: 0;\n        padding: 0;\n        list-style-type: none;\n        padding: dt('select.list.padding');\n        gap: dt('select.list.gap');\n        display: flex;\n        flex-direction: column;\n    }\n\n    .p-select-option {\n        cursor: pointer;\n        font-weight: normal;\n        white-space: nowrap;\n        position: relative;\n        overflow: hidden;\n        display: flex;\n        align-items: center;\n        padding: dt('select.option.padding');\n        border: 0 none;\n        color: dt('select.option.color');\n        background: transparent;\n        transition:\n            background dt('select.transition.duration'),\n            color dt('select.transition.duration'),\n            border-color dt('select.transition.duration'),\n            box-shadow dt('select.transition.duration'),\n            outline-color dt('select.transition.duration');\n        border-radius: dt('select.option.border.radius');\n    }\n\n    .p-select-option:not(.p-select-option-selected):not(.p-disabled).p-focus {\n        background: dt('select.option.focus.background');\n        color: dt('select.option.focus.color');\n    }\n\n    .p-select-option:not(.p-select-option-selected):not(.p-disabled):hover {\n        background: dt('select.option.focus.background');\n        color: dt('select.option.focus.color');\n    }\n\n    .p-select-option.p-select-option-selected {\n        background: dt('select.option.selected.background');\n        color: dt('select.option.selected.color');\n    }\n\n    .p-select-option.p-select-option-selected.p-focus {\n        background: dt('select.option.selected.focus.background');\n        color: dt('select.option.selected.focus.color');\n    }\n   \n    .p-select-option-blank-icon {\n        flex-shrink: 0;\n    }\n\n    .p-select-option-check-icon {\n        position: relative;\n        flex-shrink: 0;\n        margin-inline-start: dt('select.checkmark.gutter.start');\n        margin-inline-end: dt('select.checkmark.gutter.end');\n        color: dt('select.checkmark.color');\n    }\n\n    .p-select-empty-message {\n        padding: dt('select.empty.message.padding');\n    }\n\n    .p-select-fluid {\n        display: flex;\n        width: 100%;\n    }\n\n    .p-select-sm .p-select-label {\n        font-size: dt('select.sm.font.size');\n        padding-block: dt('select.sm.padding.y');\n        padding-inline: dt('select.sm.padding.x');\n    }\n\n    .p-select-sm .p-select-dropdown .p-icon {\n        font-size: dt('select.sm.font.size');\n        width: dt('select.sm.font.size');\n        height: dt('select.sm.font.size');\n    }\n\n    .p-select-lg .p-select-label {\n        font-size: dt('select.lg.font.size');\n        padding-block: dt('select.lg.padding.y');\n        padding-inline: dt('select.lg.padding.x');\n    }\n\n    .p-select-lg .p-select-dropdown .p-icon {\n        font-size: dt('select.lg.font.size');\n        width: dt('select.lg.font.size');\n        height: dt('select.lg.font.size');\n    }\n\n    .p-floatlabel-in .p-select-filter {\n        padding-block-start: dt('select.padding.y');\n        padding-block-end: dt('select.padding.y');\n    }\n",
 	classes: {
@@ -8442,9 +8443,9 @@ var mm = X.extend({
 		optionBlankIcon: "p-select-option-blank-icon",
 		emptyMessage: "p-select-empty-message"
 	}
-}), hm = {
+}), pm = {
 	name: "BaseSelect",
-	extends: Af,
+	extends: Of,
 	props: {
 		options: Array,
 		optionLabel: [String, Function],
@@ -8610,7 +8611,7 @@ var mm = X.extend({
 			default: null
 		}
 	},
-	style: mm,
+	style: fm,
 	provide: function() {
 		return {
 			$pcSelect: this,
@@ -8618,39 +8619,39 @@ var mm = X.extend({
 		};
 	}
 };
-function gm(e) {
+function mm(e) {
 	"@babel/helpers - typeof";
-	return gm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return mm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, gm(e);
+	}, mm(e);
 }
-function _m(e) {
-	return xm(e) || bm(e) || ym(e) || vm();
+function hm(e) {
+	return ym(e) || vm(e) || _m(e) || gm();
 }
-function vm() {
+function gm() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function ym(e, t) {
+function _m(e, t) {
 	if (e) {
-		if (typeof e == "string") return Sm(e, t);
+		if (typeof e == "string") return bm(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Sm(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? bm(e, t) : void 0;
 	}
 }
-function bm(e) {
+function vm(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function xm(e) {
-	if (Array.isArray(e)) return Sm(e);
+function ym(e) {
+	if (Array.isArray(e)) return bm(e);
 }
-function Sm(e, t) {
+function bm(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Cm(e, t) {
+function xm(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -8660,42 +8661,42 @@ function Cm(e, t) {
 	}
 	return n;
 }
-function wm(e) {
+function Sm(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Cm(Object(n), !0).forEach(function(t) {
-			Tm(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Cm(Object(n)).forEach(function(t) {
+		t % 2 ? xm(Object(n), !0).forEach(function(t) {
+			Cm(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : xm(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Tm(e, t, n) {
-	return (t = Em(t)) in e ? Object.defineProperty(e, t, {
+function Cm(e, t, n) {
+	return (t = wm(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Em(e) {
-	var t = Dm(e, "string");
-	return gm(t) == "symbol" ? t : t + "";
+function wm(e) {
+	var t = Tm(e, "string");
+	return mm(t) == "symbol" ? t : t + "";
 }
-function Dm(e, t) {
-	if (gm(e) != "object" || !e) return e;
+function Tm(e, t) {
+	if (mm(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (gm(r) != "object") return r;
+		if (mm(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Om = {
+var Em = {
 	name: "Select",
-	extends: hm,
+	extends: pm,
 	inheritAttrs: !1,
 	emits: [
 		"change",
@@ -8743,20 +8744,20 @@ var Om = {
 		this.overlayVisible && this.isModelValueChanged && this.scrollInView(this.findSelectedOptionIndex()), this.isModelValueChanged = !1;
 	},
 	beforeUnmount: function() {
-		this.unbindOutsideClickListener(), this.unbindResizeListener(), this.unbindLabelClickListener(), this.unbindMatchMediaOrientationListener(), this.scrollHandler &&= (this.scrollHandler.destroy(), null), this.overlay &&= (ul.clear(this.overlay), null);
+		this.unbindOutsideClickListener(), this.unbindResizeListener(), this.unbindLabelClickListener(), this.unbindMatchMediaOrientationListener(), this.scrollHandler &&= (this.scrollHandler.destroy(), null), this.overlay &&= (cl.clear(this.overlay), null);
 	},
 	methods: {
 		getOptionIndex: function(e, t) {
 			return this.virtualScrollerDisabled ? e : t && t(e).index;
 		},
 		getOptionLabel: function(e) {
-			return this.optionLabel ? ec(e, this.optionLabel) : e;
+			return this.optionLabel ? Qs(e, this.optionLabel) : e;
 		},
 		getOptionValue: function(e) {
-			return this.optionValue ? ec(e, this.optionValue) : e;
+			return this.optionValue ? Qs(e, this.optionValue) : e;
 		},
 		getOptionRenderKey: function(e, t) {
-			return (this.dataKey ? ec(e, this.dataKey) : this.getOptionLabel(e)) + "_" + t;
+			return (this.dataKey ? Qs(e, this.dataKey) : this.getOptionLabel(e)) + "_" + t;
 		},
 		getPTItemOptions: function(e, t, n, r) {
 			return this.ptm(r, { context: {
@@ -8768,16 +8769,16 @@ var Om = {
 			} });
 		},
 		isOptionDisabled: function(e) {
-			return this.optionDisabled ? ec(e, this.optionDisabled) : !1;
+			return this.optionDisabled ? Qs(e, this.optionDisabled) : !1;
 		},
 		isOptionGroup: function(e) {
 			return this.optionGroupLabel && e.optionGroup && e.group;
 		},
 		getOptionGroupLabel: function(e) {
-			return ec(e, this.optionGroupLabel);
+			return Qs(e, this.optionGroupLabel);
 		},
 		getOptionGroupChildren: function(e) {
-			return ec(e, this.optionGroupChildren);
+			return Qs(e, this.optionGroupChildren);
 		},
 		getAriaPosInset: function(e) {
 			var t = this;
@@ -8812,7 +8813,7 @@ var Om = {
 				e.preventDefault();
 				return;
 			}
-			if (tl()) switch (e.code) {
+			if ($c()) switch (e.code) {
 				case "Backspace":
 					this.onBackspaceKey(e, this.editable);
 					break;
@@ -8867,7 +8868,7 @@ var Om = {
 				case "ShiftLeft":
 				case "ShiftRight": break;
 				default:
-					!n && pc(e.key) && (!this.overlayVisible && this.show(), !this.editable && this.searchOptions(e, e.key), this.filter && this.$nextTick(function() {
+					!n && dc(e.key) && (!this.overlayVisible && this.show(), !this.editable && this.searchOptions(e, e.key), this.filter && this.$nextTick(function() {
 						t.$refs.filterInput && J(t.$refs.filterInput.$el);
 					}));
 					break;
@@ -8885,10 +8886,10 @@ var Om = {
 			this.updateModel(e, null), this.resetFilterOnClear && (this.filterValue = null);
 		},
 		onFirstHiddenFocus: function(e) {
-			J(e.relatedTarget === this.$refs.focusInput ? qc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])") : this.$refs.focusInput);
+			J(e.relatedTarget === this.$refs.focusInput ? Gc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])") : this.$refs.focusInput);
 		},
 		onLastHiddenFocus: function(e) {
-			J(e.relatedTarget === this.$refs.focusInput ? Yc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])") : this.$refs.focusInput);
+			J(e.relatedTarget === this.$refs.focusInput ? qc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])") : this.$refs.focusInput);
 		},
 		onOptionSelect: function(e, t) {
 			var n = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : !0;
@@ -8944,7 +8945,7 @@ var Om = {
 			this.overlayVisible && this.alignOverlay();
 		},
 		onOverlayClick: function(e) {
-			em.emit("overlay-click", {
+			Qp.emit("overlay-click", {
 				originalEvent: e,
 				target: this.$el
 			});
@@ -9016,7 +9017,7 @@ var Om = {
 		},
 		onOverlayEnter: function(e) {
 			var t = this;
-			ul.set("overlay", e, this.$primevue.config.zIndex.overlay), Fc(e, {
+			cl.set("overlay", e, this.$primevue.config.zIndex.overlay), Nc(e, {
 				position: "absolute",
 				top: "0"
 			}), this.alignOverlay(), this.scrollInView(), this.$attrSelector && e.setAttribute(this.$attrSelector, ""), setTimeout(function() {
@@ -9033,10 +9034,10 @@ var Om = {
 			}), this.$emit("hide"), this.overlay = null;
 		},
 		onOverlayAfterLeave: function(e) {
-			ul.clear(e);
+			cl.clear(e);
 		},
 		alignOverlay: function() {
-			this.appendTo === "self" ? Lc(this.overlay, this.$el) : this.overlay && (this.overlay.style.minWidth = Ic(this.$el) + "px", Pc(this.overlay, this.$el));
+			this.appendTo === "self" ? Fc(this.overlay, this.$el) : this.overlay && (this.overlay.style.minWidth = Pc(this.$el) + "px", Mc(this.overlay, this.$el));
 		},
 		bindOutsideClickListener: function() {
 			var e = this;
@@ -9050,7 +9051,7 @@ var Om = {
 		},
 		bindScrollListener: function() {
 			var e = this;
-			this.scrollHandler ||= new _p(this.$refs.container, function() {
+			this.scrollHandler ||= new hp(this.$refs.container, function() {
 				e.overlayVisible && e.hide();
 			}), this.scrollHandler.bindScrollListener();
 		},
@@ -9060,7 +9061,7 @@ var Om = {
 		bindResizeListener: function() {
 			var e = this;
 			this.resizeListener || (this.resizeListener = function() {
-				e.overlayVisible && !al() && e.hide();
+				e.overlayVisible && !rl() && e.hide();
 			}, window.addEventListener("resize", this.resizeListener));
 		},
 		unbindResizeListener: function() {
@@ -9070,7 +9071,7 @@ var Om = {
 			var e = this;
 			if (!this.editable && !this.labelClickListener) {
 				var t = document.querySelector(`label[for="${this.labelId}"]`);
-				t && il(t) && (this.labelClickListener = function() {
+				t && nl(t) && (this.labelClickListener = function() {
 					J(e.$refs.focusInput);
 				}, t.addEventListener("click", this.labelClickListener));
 			}
@@ -9078,7 +9079,7 @@ var Om = {
 		unbindLabelClickListener: function() {
 			if (this.labelClickListener) {
 				var e = document.querySelector(`label[for="${this.labelId}"]`);
-				e && il(e) && e.removeEventListener("click", this.labelClickListener);
+				e && nl(e) && e.removeEventListener("click", this.labelClickListener);
 			}
 		},
 		bindMatchMediaOrientationListener: function() {
@@ -9094,7 +9095,7 @@ var Om = {
 			this.matchMediaOrientationListener &&= (this.queryOrientation.removeEventListener("change", this.matchMediaOrientationListener), this.queryOrientation = null, null);
 		},
 		hasFocusableElements: function() {
-			return Kc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])").length > 0;
+			return Wc(this.overlay, ":not([data-p-hidden-focusable=\"true\"])").length > 0;
 		},
 		isOptionExactMatched: function(e) {
 			return this.isValidOption(e) && typeof this.getOptionLabel(e) == "string" && this.getOptionLabel(e)?.toLocaleLowerCase(this.filterLocale) == this.searchValue.toLocaleLowerCase(this.filterLocale);
@@ -9109,7 +9110,7 @@ var Om = {
 			return this.isValidOption(e) && this.isSelected(e);
 		},
 		isSelected: function(e) {
-			return tc(this.d_value, this.getOptionValue(e), this.equalityKey);
+			return $s(this.d_value, this.getOptionValue(e), this.equalityKey);
 		},
 		findFirstOptionIndex: function() {
 			var e = this;
@@ -9119,7 +9120,7 @@ var Om = {
 		},
 		findLastOptionIndex: function() {
 			var e = this;
-			return oc(this.visibleOptions, function(t) {
+			return ic(this.visibleOptions, function(t) {
 				return e.isValidOption(t);
 			});
 		},
@@ -9130,7 +9131,7 @@ var Om = {
 			return n > -1 ? n + e + 1 : e;
 		},
 		findPrevOptionIndex: function(e) {
-			var t = this, n = e > 0 ? oc(this.visibleOptions.slice(0, e), function(e) {
+			var t = this, n = e > 0 ? ic(this.visibleOptions.slice(0, e), function(e) {
 				return t.isValidOption(e);
 			}) : -1;
 			return n > -1 ? n : e;
@@ -9167,7 +9168,7 @@ var Om = {
 		scrollInView: function() {
 			var e = this, t = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : -1;
 			this.$nextTick(function() {
-				var n = t === -1 ? e.focusedOptionId : `${e.$id}_${t}`, r = Wc(e.list, `li[id="${n}"]`);
+				var n = t === -1 ? e.focusedOptionId : `${e.$id}_${t}`, r = Hc(e.list, `li[id="${n}"]`);
 				r ? r.scrollIntoView && r.scrollIntoView({
 					block: "nearest",
 					inline: "nearest"
@@ -9211,14 +9212,14 @@ var Om = {
 		visibleOptions: function() {
 			var e = this, t = this.optionGroupLabel ? this.flatOptions(this.options) : this.options || [];
 			if (this.filterValue) {
-				var n = Gl.filter(t, this.searchFields, this.filterValue, this.filterMatchMode, this.filterLocale);
+				var n = Ul.filter(t, this.searchFields, this.filterValue, this.filterMatchMode, this.filterLocale);
 				if (this.optionGroupLabel) {
 					var r = this.options || [], i = [];
 					return r.forEach(function(t) {
 						var r = e.getOptionGroupChildren(t).filter(function(e) {
 							return n.includes(e);
 						});
-						r.length > 0 && i.push(wm(wm({}, t), {}, Tm({}, typeof e.optionGroupChildren == "string" ? e.optionGroupChildren : "items", _m(r))));
+						r.length > 0 && i.push(Sm(Sm({}, t), {}, Cm({}, typeof e.optionGroupChildren == "string" ? e.optionGroupChildren : "items", hm(r))));
 					}), this.flatOptions(i);
 				}
 				return n;
@@ -9279,7 +9280,7 @@ var Om = {
 			return !this.virtualScrollerOptions;
 		},
 		containerDataP: function() {
-			return q(Tm({
+			return q(Cm({
 				invalid: this.$invalid,
 				disabled: this.disabled,
 				focus: this.focused,
@@ -9288,7 +9289,7 @@ var Om = {
 			}, this.size, this.size));
 		},
 		labelDataP: function() {
-			return q(Tm(Tm({
+			return q(Cm(Cm({
 				placeholder: !this.editable && this.label === this.placeholder,
 				clearable: this.showClear,
 				disabled: this.disabled,
@@ -9296,27 +9297,27 @@ var Om = {
 			}, this.size, this.size), "empty", !this.editable && !this.$slots.value && (this.label === "p-emptylabel" || this.label.length === 0)));
 		},
 		dropdownIconDataP: function() {
-			return q(Tm({}, this.size, this.size));
+			return q(Cm({}, this.size, this.size));
 		},
 		overlayDataP: function() {
-			return q(Tm({}, "portal-" + this.appendTo, "portal-" + this.appendTo));
+			return q(Cm({}, "portal-" + this.appendTo, "portal-" + this.appendTo));
 		}
 	},
-	directives: { ripple: Xd },
+	directives: { ripple: Jd },
 	components: {
-		InputText: $f,
-		VirtualScroller: dm,
-		Portal: tm,
-		InputIcon: Qp,
-		IconField: Xp,
-		TimesIcon: Hp,
-		ChevronDownIcon: Ep,
-		SpinnerIcon: ud,
-		SearchIcon: Pp,
-		CheckIcon: pf,
-		BlankIcon: vp
+		InputText: Zf,
+		VirtualScroller: lm,
+		Portal: $p,
+		InputIcon: Xp,
+		IconField: Jp,
+		TimesIcon: Bp,
+		ChevronDownIcon: wp,
+		SpinnerIcon: cd,
+		SearchIcon: Mp,
+		CheckIcon: df,
+		BlankIcon: gp
 	}
-}, km = ["id", "data-p"], Am = [
+}, Dm = ["id", "data-p"], Om = [
 	"name",
 	"id",
 	"value",
@@ -9330,7 +9331,7 @@ var Om = {
 	"aria-activedescendant",
 	"aria-invalid",
 	"data-p"
-], jm = [
+], km = [
 	"name",
 	"id",
 	"tabindex",
@@ -9342,7 +9343,7 @@ var Om = {
 	"aria-invalid",
 	"aria-disabled",
 	"data-p"
-], Mm = ["data-p"], Nm = ["id"], Pm = ["id"], Fm = [
+], Am = ["data-p"], jm = ["id"], Mm = ["id"], Nm = [
 	"id",
 	"aria-label",
 	"aria-selected",
@@ -9355,8 +9356,8 @@ var Om = {
 	"data-p-focused",
 	"data-p-disabled"
 ];
-function Im(e, t, n, r, i, a) {
-	var o = F("SpinnerIcon"), s = F("InputText"), c = F("SearchIcon"), l = F("InputIcon"), u = F("IconField"), d = F("CheckIcon"), f = F("BlankIcon"), p = F("VirtualScroller"), m = F("Portal"), h = si("ripple");
+function Pm(e, t, n, r, i, a) {
+	var o = F("SpinnerIcon"), s = F("InputText"), c = F("SearchIcon"), l = F("InputIcon"), u = F("IconField"), d = F("CheckIcon"), f = F("BlankIcon"), p = F("VirtualScroller"), m = F("Portal"), h = oi("ripple");
 	return R(), z("div", W({
 		ref: "container",
 		id: e.$id,
@@ -9404,7 +9405,7 @@ function Im(e, t, n, r, i, a) {
 				return a.onEditableInput && a.onEditableInput.apply(a, arguments);
 			},
 			"data-p": a.labelDataP
-		}, e.ptm("label")), null, 16, Am)) : (R(), z("span", W({
+		}, e.ptm("label")), null, 16, Om)) : (R(), z("span", W({
 			key: 1,
 			ref: "focusInput",
 			name: e.name,
@@ -9439,14 +9440,14 @@ function Im(e, t, n, r, i, a) {
 			value: e.d_value,
 			placeholder: e.placeholder
 		}, function() {
-			return [Ha(O(a.label === "p-emptylabel" ? "\xA0" : a.label ?? "empty"), 1)];
-		})], 16, jm)),
+			return [Va(O(a.label === "p-emptylabel" ? "\xA0" : a.label ?? "empty"), 1)];
+		})], 16, km)),
 		a.isClearIconVisible ? I(e.$slots, "clearicon", {
 			key: 2,
 			class: D(e.cx("clearIcon")),
 			clearCallback: a.onClearClick
 		}, function() {
-			return [(R(), B(oi(e.clearIcon ? "i" : "TimesIcon"), W({
+			return [(R(), B(ai(e.clearIcon ? "i" : "TimesIcon"), W({
 				ref: "clearIcon",
 				class: [e.cx("clearIcon"), e.clearIcon],
 				onClick: a.onClearClick
@@ -9474,7 +9475,7 @@ function Im(e, t, n, r, i, a) {
 			key: 1,
 			class: D(e.cx("dropdownIcon"))
 		}, function() {
-			return [(R(), B(oi(e.dropdownIcon ? "span" : "ChevronDownIcon"), W({
+			return [(R(), B(ai(e.dropdownIcon ? "span" : "ChevronDownIcon"), W({
 				class: [e.cx("dropdownIcon"), e.dropdownIcon],
 				"aria-hidden": "true",
 				"data-p": a.dropdownIconDataP
@@ -9482,7 +9483,7 @@ function Im(e, t, n, r, i, a) {
 		})], 16),
 		H(m, { appendTo: e.appendTo }, {
 			default: P(function() {
-				return [H(jo, W({
+				return [H(Ao, W({
 					name: "p-anchored-overlay",
 					onEnter: a.onOverlayEnter,
 					onAfterEnter: a.onOverlayAfterEnter,
@@ -9595,7 +9596,7 @@ function Im(e, t, n, r, i, a) {
 								tabindex: -1,
 								disabled: a.virtualScrollerDisabled,
 								pt: e.ptm("virtualScroller")
-							}), di({
+							}), ui({
 								content: P(function(n) {
 									var r = n.styleClass, o = n.contentRef, s = n.items, c = n.getItemOptions, l = n.contentStyle, u = n.itemSize;
 									return [V("ul", W({
@@ -9606,7 +9607,7 @@ function Im(e, t, n, r, i, a) {
 										class: [e.cx("list"), r],
 										style: l,
 										role: "listbox"
-									}, e.ptm("list")), [(R(!0), z(L, null, ui(s, function(n, r) {
+									}, e.ptm("list")), [(R(!0), z(L, null, li(s, function(n, r) {
 										return R(), z(L, { key: a.getOptionRenderKey(n, a.getOptionIndex(r, c)) }, [a.isOptionGroup(n) ? (R(), z("li", W({
 											key: 0,
 											id: e.$id + "_" + a.getOptionIndex(r, c),
@@ -9618,7 +9619,7 @@ function Im(e, t, n, r, i, a) {
 											index: a.getOptionIndex(r, c)
 										}, function() {
 											return [V("span", W({ class: e.cx("optionGroupLabel") }, { ref_for: !0 }, e.ptm("optionGroupLabel")), O(a.getOptionGroupLabel(n.optionGroup)), 17)];
-										})], 16, Pm)) : Vn((R(), z("li", W({
+										})], 16, Mm)) : Bn((R(), z("li", W({
 											key: 1,
 											id: e.$id + "_" + a.getOptionIndex(r, c),
 											class: e.cx("option", {
@@ -9638,7 +9639,7 @@ function Im(e, t, n, r, i, a) {
 											onMousemove: function(e) {
 												return a.onOptionMouseMove(e, a.getOptionIndex(r, c));
 											},
-											onClick: t[8] ||= Fs(function() {}, ["stop"]),
+											onClick: t[8] ||= Ns(function() {}, ["stop"]),
 											"data-p-selected": !e.checkmark && a.isSelected(n),
 											"data-p-focused": i.focusedOptionIndex === a.getOptionIndex(r, c),
 											"data-p-disabled": a.isOptionDisabled(n)
@@ -9654,20 +9655,20 @@ function Im(e, t, n, r, i, a) {
 											index: a.getOptionIndex(r, c)
 										}, function() {
 											return [V("span", W({ class: e.cx("optionLabel") }, { ref_for: !0 }, e.ptm("optionLabel")), O(a.getOptionLabel(n)), 17)];
-										})], 16, Fm)), [[h]])], 64);
+										})], 16, Nm)), [[h]])], 64);
 									}), 128)), i.filterValue && (!s || s && s.length === 0) ? (R(), z("li", W({
 										key: 0,
 										class: e.cx("emptyMessage"),
 										role: "option"
 									}, e.ptm("emptyMessage"), { "data-p-hidden-accessible": !0 }), [I(e.$slots, "emptyfilter", {}, function() {
-										return [Ha(O(a.emptyFilterMessageText), 1)];
+										return [Va(O(a.emptyFilterMessageText), 1)];
 									})], 16)) : !e.options || e.options && e.options.length === 0 ? (R(), z("li", W({
 										key: 1,
 										class: e.cx("emptyMessage"),
 										role: "option"
 									}, e.ptm("emptyMessage"), { "data-p-hidden-accessible": !0 }), [I(e.$slots, "empty", {}, function() {
-										return [Ha(O(a.emptyMessageText), 1)];
-									})], 16)) : U("", !0)], 16, Nm)];
+										return [Va(O(a.emptyMessageText), 1)];
+									})], 16)) : U("", !0)], 16, jm)];
 								}),
 								_: 2
 							}, [e.$slots.loader ? {
@@ -9711,7 +9712,7 @@ function Im(e, t, n, r, i, a) {
 								"data-p-hidden-accessible": !0,
 								"data-p-hidden-focusable": !0
 							}), null, 16)
-						], 16, Mm)) : U("", !0)];
+						], 16, Am)) : U("", !0)];
 					}),
 					_: 3
 				}, 16, [
@@ -9723,12 +9724,12 @@ function Im(e, t, n, r, i, a) {
 			}),
 			_: 3
 		}, 8, ["appendTo"])
-	], 16, km);
+	], 16, Dm);
 }
-Om.render = Im;
+Em.render = Pm;
 //#endregion
 //#region node_modules/primevue/togglebutton/style/index.mjs
-var Lm = X.extend({
+var Fm = X.extend({
 	name: "togglebutton",
 	style: "\n    .p-togglebutton {\n        display: inline-flex;\n        cursor: pointer;\n        user-select: none;\n        overflow: hidden;\n        position: relative;\n        color: dt('togglebutton.color');\n        background: dt('togglebutton.background');\n        border: 1px solid dt('togglebutton.border.color');\n        padding: dt('togglebutton.padding');\n        font-size: 1rem;\n        font-family: inherit;\n        font-feature-settings: inherit;\n        transition:\n            background dt('togglebutton.transition.duration'),\n            color dt('togglebutton.transition.duration'),\n            border-color dt('togglebutton.transition.duration'),\n            outline-color dt('togglebutton.transition.duration'),\n            box-shadow dt('togglebutton.transition.duration');\n        border-radius: dt('togglebutton.border.radius');\n        outline-color: transparent;\n        font-weight: dt('togglebutton.font.weight');\n    }\n\n    .p-togglebutton-content {\n        display: inline-flex;\n        flex: 1 1 auto;\n        align-items: center;\n        justify-content: center;\n        gap: dt('togglebutton.gap');\n        padding: dt('togglebutton.content.padding');\n        background: transparent;\n        border-radius: dt('togglebutton.content.border.radius');\n        transition:\n            background dt('togglebutton.transition.duration'),\n            color dt('togglebutton.transition.duration'),\n            border-color dt('togglebutton.transition.duration'),\n            outline-color dt('togglebutton.transition.duration'),\n            box-shadow dt('togglebutton.transition.duration');\n    }\n\n    .p-togglebutton:not(:disabled):not(.p-togglebutton-checked):hover {\n        background: dt('togglebutton.hover.background');\n        color: dt('togglebutton.hover.color');\n    }\n\n    .p-togglebutton.p-togglebutton-checked {\n        background: dt('togglebutton.checked.background');\n        border-color: dt('togglebutton.checked.border.color');\n        color: dt('togglebutton.checked.color');\n    }\n\n    .p-togglebutton-checked .p-togglebutton-content {\n        background: dt('togglebutton.content.checked.background');\n        box-shadow: dt('togglebutton.content.checked.shadow');\n    }\n\n    .p-togglebutton:focus-visible {\n        box-shadow: dt('togglebutton.focus.ring.shadow');\n        outline: dt('togglebutton.focus.ring.width') dt('togglebutton.focus.ring.style') dt('togglebutton.focus.ring.color');\n        outline-offset: dt('togglebutton.focus.ring.offset');\n    }\n\n    .p-togglebutton.p-invalid {\n        border-color: dt('togglebutton.invalid.border.color');\n    }\n\n    .p-togglebutton:disabled {\n        opacity: 1;\n        cursor: default;\n        background: dt('togglebutton.disabled.background');\n        border-color: dt('togglebutton.disabled.border.color');\n        color: dt('togglebutton.disabled.color');\n    }\n\n    .p-togglebutton-label,\n    .p-togglebutton-icon {\n        position: relative;\n        transition: none;\n    }\n\n    .p-togglebutton-icon {\n        color: dt('togglebutton.icon.color');\n    }\n\n    .p-togglebutton:not(:disabled):not(.p-togglebutton-checked):hover .p-togglebutton-icon {\n        color: dt('togglebutton.icon.hover.color');\n    }\n\n    .p-togglebutton.p-togglebutton-checked .p-togglebutton-icon {\n        color: dt('togglebutton.icon.checked.color');\n    }\n\n    .p-togglebutton:disabled .p-togglebutton-icon {\n        color: dt('togglebutton.icon.disabled.color');\n    }\n\n    .p-togglebutton-sm {\n        padding: dt('togglebutton.sm.padding');\n        font-size: dt('togglebutton.sm.font.size');\n    }\n\n    .p-togglebutton-sm .p-togglebutton-content {\n        padding: dt('togglebutton.content.sm.padding');\n    }\n\n    .p-togglebutton-lg {\n        padding: dt('togglebutton.lg.padding');\n        font-size: dt('togglebutton.lg.font.size');\n    }\n\n    .p-togglebutton-lg .p-togglebutton-content {\n        padding: dt('togglebutton.content.lg.padding');\n    }\n\n    .p-togglebutton-fluid {\n        width: 100%;\n    }\n",
 	classes: {
@@ -9746,9 +9747,9 @@ var Lm = X.extend({
 		icon: "p-togglebutton-icon",
 		label: "p-togglebutton-label"
 	}
-}), Rm = {
+}), Im = {
 	name: "BaseToggleButton",
-	extends: kf,
+	extends: Df,
 	props: {
 		onIcon: String,
 		offIcon: String,
@@ -9785,7 +9786,7 @@ var Lm = X.extend({
 			default: null
 		}
 	},
-	style: Lm,
+	style: Fm,
 	provide: function() {
 		return {
 			$pcToggleButton: this,
@@ -9793,39 +9794,39 @@ var Lm = X.extend({
 		};
 	}
 };
-function zm(e) {
+function Lm(e) {
 	"@babel/helpers - typeof";
-	return zm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Lm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, zm(e);
+	}, Lm(e);
 }
-function Bm(e, t, n) {
-	return (t = Vm(t)) in e ? Object.defineProperty(e, t, {
+function Rm(e, t, n) {
+	return (t = zm(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Vm(e) {
-	var t = Hm(e, "string");
-	return zm(t) == "symbol" ? t : t + "";
+function zm(e) {
+	var t = Bm(e, "string");
+	return Lm(t) == "symbol" ? t : t + "";
 }
-function Hm(e, t) {
-	if (zm(e) != "object" || !e) return e;
+function Bm(e, t) {
+	if (Lm(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (zm(r) != "object") return r;
+		if (Lm(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Um = {
+var Vm = {
 	name: "ToggleButton",
-	extends: Rm,
+	extends: Im,
 	inheritAttrs: !1,
 	emits: ["change"],
 	methods: {
@@ -9854,14 +9855,14 @@ var Um = {
 			return this.hasLabel ? this.d_value ? this.onLabel : this.offLabel : "\xA0";
 		},
 		dataP: function() {
-			return q(Bm({
+			return q(Rm({
 				checked: this.active,
 				invalid: this.$invalid
 			}, this.size, this.size));
 		}
 	},
-	directives: { ripple: Xd }
-}, Wm = [
+	directives: { ripple: Jd }
+}, Hm = [
 	"tabindex",
 	"disabled",
 	"aria-pressed",
@@ -9870,10 +9871,10 @@ var Um = {
 	"data-p-checked",
 	"data-p-disabled",
 	"data-p"
-], Gm = ["data-p"];
-function Km(e, t, n, r, i, a) {
-	var o = si("ripple");
-	return Vn((R(), z("button", W({
+], Um = ["data-p"];
+function Wm(e, t, n, r, i, a) {
+	var o = oi("ripple");
+	return Bn((R(), z("button", W({
 		type: "button",
 		class: e.cx("root"),
 		tabindex: e.tabindex,
@@ -9901,12 +9902,12 @@ function Km(e, t, n, r, i, a) {
 				class: [e.cx("icon"), e.d_value ? e.onIcon : e.offIcon]
 			}, a.getPTOptions("icon")), null, 16)) : U("", !0)];
 		}), V("span", W({ class: e.cx("label") }, a.getPTOptions("label")), O(a.label), 17)];
-	})], 16, Gm)], 16, Wm)), [[o]]);
+	})], 16, Um)], 16, Hm)), [[o]]);
 }
-Um.render = Km;
+Vm.render = Wm;
 //#endregion
 //#region node_modules/primevue/tag/style/index.mjs
-var qm = X.extend({
+var Gm = X.extend({
 	name: "tag",
 	style: "\n    .p-tag {\n        display: inline-flex;\n        align-items: center;\n        justify-content: center;\n        background: dt('tag.primary.background');\n        color: dt('tag.primary.color');\n        font-size: dt('tag.font.size');\n        font-weight: dt('tag.font.weight');\n        padding: dt('tag.padding');\n        border-radius: dt('tag.border.radius');\n        gap: dt('tag.gap');\n    }\n\n    .p-tag-icon {\n        font-size: dt('tag.icon.size');\n        width: dt('tag.icon.size');\n        height: dt('tag.icon.size');\n    }\n\n    .p-tag-rounded {\n        border-radius: dt('tag.rounded.border.radius');\n    }\n\n    .p-tag-success {\n        background: dt('tag.success.background');\n        color: dt('tag.success.color');\n    }\n\n    .p-tag-info {\n        background: dt('tag.info.background');\n        color: dt('tag.info.color');\n    }\n\n    .p-tag-warn {\n        background: dt('tag.warn.background');\n        color: dt('tag.warn.color');\n    }\n\n    .p-tag-danger {\n        background: dt('tag.danger.background');\n        color: dt('tag.danger.color');\n    }\n\n    .p-tag-secondary {\n        background: dt('tag.secondary.background');\n        color: dt('tag.secondary.color');\n    }\n\n    .p-tag-contrast {\n        background: dt('tag.contrast.background');\n        color: dt('tag.contrast.color');\n    }\n",
 	classes: {
@@ -9925,16 +9926,16 @@ var qm = X.extend({
 		icon: "p-tag-icon",
 		label: "p-tag-label"
 	}
-}), Jm = {
+}), Km = {
 	name: "BaseTag",
-	extends: td,
+	extends: $u,
 	props: {
 		value: null,
 		severity: null,
 		rounded: Boolean,
 		icon: String
 	},
-	style: qm,
+	style: Gm,
 	provide: function() {
 		return {
 			$pcTag: this,
@@ -9942,49 +9943,49 @@ var qm = X.extend({
 		};
 	}
 };
-function Ym(e) {
+function qm(e) {
 	"@babel/helpers - typeof";
-	return Ym = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return qm = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Ym(e);
+	}, qm(e);
 }
-function Xm(e, t, n) {
-	return (t = Zm(t)) in e ? Object.defineProperty(e, t, {
+function Jm(e, t, n) {
+	return (t = Ym(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Zm(e) {
-	var t = Qm(e, "string");
-	return Ym(t) == "symbol" ? t : t + "";
+function Ym(e) {
+	var t = Xm(e, "string");
+	return qm(t) == "symbol" ? t : t + "";
 }
-function Qm(e, t) {
-	if (Ym(e) != "object" || !e) return e;
+function Xm(e, t) {
+	if (qm(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Ym(r) != "object") return r;
+		if (qm(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var $m = {
+var Zm = {
 	name: "Tag",
-	extends: Jm,
+	extends: Km,
 	inheritAttrs: !1,
 	computed: { dataP: function() {
-		return q(Xm({ rounded: this.rounded }, this.severity, this.severity));
+		return q(Jm({ rounded: this.rounded }, this.severity, this.severity));
 	} }
-}, eh = ["data-p"];
-function th(e, t, n, r, i, a) {
+}, Qm = ["data-p"];
+function $m(e, t, n, r, i, a) {
 	return R(), z("span", W({
 		class: e.cx("root"),
 		"data-p": a.dataP
-	}, e.ptmi("root")), [e.$slots.icon ? (R(), B(oi(e.$slots.icon), W({
+	}, e.ptmi("root")), [e.$slots.icon ? (R(), B(ai(e.$slots.icon), W({
 		key: 0,
 		class: e.cx("icon")
 	}, e.ptm("icon")), null, 16, ["class"])) : e.icon ? (R(), z("span", W({
@@ -9992,111 +9993,111 @@ function th(e, t, n, r, i, a) {
 		class: [e.cx("icon"), e.icon]
 	}, e.ptm("icon")), null, 16)) : U("", !0), e.value != null || e.$slots.default ? I(e.$slots, "default", { key: 2 }, function() {
 		return [V("span", W({ class: e.cx("label") }, e.ptm("label")), O(e.value), 17)];
-	}) : U("", !0)], 16, eh);
+	}) : U("", !0)], 16, Qm);
 }
-$m.render = th;
+Zm.render = $m;
 //#endregion
 //#region node_modules/@primevue/icons/windowmaximize/index.mjs
-var nh = {
+var eh = {
 	name: "WindowMaximizeIcon",
-	extends: ld
+	extends: sd
 };
-function rh(e) {
-	return sh(e) || oh(e) || ah(e) || ih();
+function th(e) {
+	return ah(e) || ih(e) || rh(e) || nh();
 }
-function ih() {
+function nh() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function ah(e, t) {
+function rh(e, t) {
 	if (e) {
-		if (typeof e == "string") return ch(e, t);
+		if (typeof e == "string") return oh(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? ch(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? oh(e, t) : void 0;
 	}
 }
-function oh(e) {
+function ih(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function sh(e) {
-	if (Array.isArray(e)) return ch(e);
+function ah(e) {
+	if (Array.isArray(e)) return oh(e);
 }
-function ch(e, t) {
+function oh(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function lh(e, t, n, r, i, a) {
+function sh(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), rh(t[0] ||= [V("path", {
+	}, e.pti()), th(t[0] ||= [V("path", {
 		"fill-rule": "evenodd",
 		"clip-rule": "evenodd",
 		d: "M7 14H11.8C12.3835 14 12.9431 13.7682 13.3556 13.3556C13.7682 12.9431 14 12.3835 14 11.8V2.2C14 1.61652 13.7682 1.05694 13.3556 0.644365C12.9431 0.231785 12.3835 0 11.8 0H2.2C1.61652 0 1.05694 0.231785 0.644365 0.644365C0.231785 1.05694 0 1.61652 0 2.2V7C0 7.15913 0.063214 7.31174 0.175736 7.42426C0.288258 7.53679 0.44087 7.6 0.6 7.6C0.75913 7.6 0.911742 7.53679 1.02426 7.42426C1.13679 7.31174 1.2 7.15913 1.2 7V2.2C1.2 1.93478 1.30536 1.68043 1.49289 1.49289C1.68043 1.30536 1.93478 1.2 2.2 1.2H11.8C12.0652 1.2 12.3196 1.30536 12.5071 1.49289C12.6946 1.68043 12.8 1.93478 12.8 2.2V11.8C12.8 12.0652 12.6946 12.3196 12.5071 12.5071C12.3196 12.6946 12.0652 12.8 11.8 12.8H7C6.84087 12.8 6.68826 12.8632 6.57574 12.9757C6.46321 13.0883 6.4 13.2409 6.4 13.4C6.4 13.5591 6.46321 13.7117 6.57574 13.8243C6.68826 13.9368 6.84087 14 7 14ZM9.77805 7.42192C9.89013 7.534 10.0415 7.59788 10.2 7.59995C10.3585 7.59788 10.5099 7.534 10.622 7.42192C10.7341 7.30985 10.798 7.15844 10.8 6.99995V3.94242C10.8066 3.90505 10.8096 3.86689 10.8089 3.82843C10.8079 3.77159 10.7988 3.7157 10.7824 3.6623C10.756 3.55552 10.701 3.45698 10.622 3.37798C10.5099 3.2659 10.3585 3.20202 10.2 3.19995H7.00002C6.84089 3.19995 6.68828 3.26317 6.57576 3.37569C6.46324 3.48821 6.40002 3.64082 6.40002 3.79995C6.40002 3.95908 6.46324 4.11169 6.57576 4.22422C6.68828 4.33674 6.84089 4.39995 7.00002 4.39995H8.80006L6.19997 7.00005C6.10158 7.11005 6.04718 7.25246 6.04718 7.40005C6.04718 7.54763 6.10158 7.69004 6.19997 7.80005C6.30202 7.91645 6.44561 7.98824 6.59997 8.00005C6.75432 7.98824 6.89791 7.91645 6.99997 7.80005L9.60002 5.26841V6.99995C9.6021 7.15844 9.66598 7.30985 9.77805 7.42192ZM1.4 14H3.8C4.17066 13.9979 4.52553 13.8498 4.78763 13.5877C5.04973 13.3256 5.1979 12.9707 5.2 12.6V10.2C5.1979 9.82939 5.04973 9.47452 4.78763 9.21242C4.52553 8.95032 4.17066 8.80215 3.8 8.80005H1.4C1.02934 8.80215 0.674468 8.95032 0.412371 9.21242C0.150274 9.47452 0.00210008 9.82939 0 10.2V12.6C0.00210008 12.9707 0.150274 13.3256 0.412371 13.5877C0.674468 13.8498 1.02934 13.9979 1.4 14ZM1.25858 10.0586C1.29609 10.0211 1.34696 10 1.4 10H3.8C3.85304 10 3.90391 10.0211 3.94142 10.0586C3.97893 10.0961 4 10.147 4 10.2V12.6C4 12.6531 3.97893 12.704 3.94142 12.7415C3.90391 12.779 3.85304 12.8 3.8 12.8H1.4C1.34696 12.8 1.29609 12.779 1.25858 12.7415C1.22107 12.704 1.2 12.6531 1.2 12.6V10.2C1.2 10.147 1.22107 10.0961 1.25858 10.0586Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-nh.render = lh;
+eh.render = sh;
 //#endregion
 //#region node_modules/@primevue/icons/windowminimize/index.mjs
-var uh = {
+var ch = {
 	name: "WindowMinimizeIcon",
-	extends: ld
+	extends: sd
 };
-function dh(e) {
-	return hh(e) || mh(e) || ph(e) || fh();
+function lh(e) {
+	return ph(e) || fh(e) || dh(e) || uh();
 }
-function fh() {
+function uh() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function ph(e, t) {
+function dh(e, t) {
 	if (e) {
-		if (typeof e == "string") return gh(e, t);
+		if (typeof e == "string") return mh(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? gh(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? mh(e, t) : void 0;
 	}
 }
-function mh(e) {
+function fh(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function hh(e) {
-	if (Array.isArray(e)) return gh(e);
+function ph(e) {
+	if (Array.isArray(e)) return mh(e);
 }
-function gh(e, t) {
+function mh(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function _h(e, t, n, r, i, a) {
+function hh(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), dh(t[0] ||= [V("path", {
+	}, e.pti()), lh(t[0] ||= [V("path", {
 		"fill-rule": "evenodd",
 		"clip-rule": "evenodd",
 		d: "M11.8 0H2.2C1.61652 0 1.05694 0.231785 0.644365 0.644365C0.231785 1.05694 0 1.61652 0 2.2V7C0 7.15913 0.063214 7.31174 0.175736 7.42426C0.288258 7.53679 0.44087 7.6 0.6 7.6C0.75913 7.6 0.911742 7.53679 1.02426 7.42426C1.13679 7.31174 1.2 7.15913 1.2 7V2.2C1.2 1.93478 1.30536 1.68043 1.49289 1.49289C1.68043 1.30536 1.93478 1.2 2.2 1.2H11.8C12.0652 1.2 12.3196 1.30536 12.5071 1.49289C12.6946 1.68043 12.8 1.93478 12.8 2.2V11.8C12.8 12.0652 12.6946 12.3196 12.5071 12.5071C12.3196 12.6946 12.0652 12.8 11.8 12.8H7C6.84087 12.8 6.68826 12.8632 6.57574 12.9757C6.46321 13.0883 6.4 13.2409 6.4 13.4C6.4 13.5591 6.46321 13.7117 6.57574 13.8243C6.68826 13.9368 6.84087 14 7 14H11.8C12.3835 14 12.9431 13.7682 13.3556 13.3556C13.7682 12.9431 14 12.3835 14 11.8V2.2C14 1.61652 13.7682 1.05694 13.3556 0.644365C12.9431 0.231785 12.3835 0 11.8 0ZM6.368 7.952C6.44137 7.98326 6.52025 7.99958 6.6 8H9.8C9.95913 8 10.1117 7.93678 10.2243 7.82426C10.3368 7.71174 10.4 7.55913 10.4 7.4C10.4 7.24087 10.3368 7.08826 10.2243 6.97574C10.1117 6.86321 9.95913 6.8 9.8 6.8H8.048L10.624 4.224C10.73 4.11026 10.7877 3.95982 10.7849 3.80438C10.7822 3.64894 10.7192 3.50063 10.6093 3.3907C10.4994 3.28077 10.3511 3.2178 10.1956 3.21506C10.0402 3.21232 9.88974 3.27002 9.776 3.376L7.2 5.952V4.2C7.2 4.04087 7.13679 3.88826 7.02426 3.77574C6.91174 3.66321 6.75913 3.6 6.6 3.6C6.44087 3.6 6.28826 3.66321 6.17574 3.77574C6.06321 3.88826 6 4.04087 6 4.2V7.4C6.00042 7.47975 6.01674 7.55862 6.048 7.632C6.07656 7.70442 6.11971 7.7702 6.17475 7.82524C6.2298 7.88029 6.29558 7.92344 6.368 7.952ZM1.4 8.80005H3.8C4.17066 8.80215 4.52553 8.95032 4.78763 9.21242C5.04973 9.47452 5.1979 9.82939 5.2 10.2V12.6C5.1979 12.9707 5.04973 13.3256 4.78763 13.5877C4.52553 13.8498 4.17066 13.9979 3.8 14H1.4C1.02934 13.9979 0.674468 13.8498 0.412371 13.5877C0.150274 13.3256 0.00210008 12.9707 0 12.6V10.2C0.00210008 9.82939 0.150274 9.47452 0.412371 9.21242C0.674468 8.95032 1.02934 8.80215 1.4 8.80005ZM3.94142 12.7415C3.97893 12.704 4 12.6531 4 12.6V10.2C4 10.147 3.97893 10.0961 3.94142 10.0586C3.90391 10.0211 3.85304 10 3.8 10H1.4C1.34696 10 1.29609 10.0211 1.25858 10.0586C1.22107 10.0961 1.2 10.147 1.2 10.2V12.6C1.2 12.6531 1.22107 12.704 1.25858 12.7415C1.29609 12.779 1.34696 12.8 1.4 12.8H3.8C3.85304 12.8 3.90391 12.779 3.94142 12.7415Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-uh.render = _h;
+ch.render = hh;
 //#endregion
 //#region node_modules/primevue/focustrap/style/index.mjs
-var vh = X.extend({ name: "focustrap-directive" }), yh = $.extend({ style: vh });
-function bh(e) {
+var gh = X.extend({ name: "focustrap-directive" }), _h = $.extend({ style: gh });
+function vh(e) {
 	"@babel/helpers - typeof";
-	return bh = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return vh = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, bh(e);
+	}, vh(e);
 }
-function xh(e, t) {
+function yh(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -10106,40 +10107,40 @@ function xh(e, t) {
 	}
 	return n;
 }
-function Sh(e) {
+function bh(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? xh(Object(n), !0).forEach(function(t) {
-			Ch(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : xh(Object(n)).forEach(function(t) {
+		t % 2 ? yh(Object(n), !0).forEach(function(t) {
+			xh(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : yh(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Ch(e, t, n) {
-	return (t = wh(t)) in e ? Object.defineProperty(e, t, {
+function xh(e, t, n) {
+	return (t = Sh(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function wh(e) {
-	var t = Th(e, "string");
-	return bh(t) == "symbol" ? t : t + "";
+function Sh(e) {
+	var t = Ch(e, "string");
+	return vh(t) == "symbol" ? t : t + "";
 }
-function Th(e, t) {
-	if (bh(e) != "object" || !e) return e;
+function Ch(e, t) {
+	if (vh(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (bh(r) != "object") return r;
+		if (vh(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Eh = yh.extend("focustrap", {
+var wh = _h.extend("focustrap", {
 	mounted: function(e, t) {
 		(t.value || {}).disabled || (this.createHiddenFocusableElements(e, t), this.bind(e, t), this.autoElementFocus(e, t)), e.setAttribute("data-pd-focustrap", !0), this.$el = e;
 	},
@@ -10159,7 +10160,7 @@ var Eh = yh.extend("focustrap", {
 				t.forEach(function(t) {
 					if (t.type === "childList" && !e.contains(document.activeElement)) {
 						var r = function(t) {
-							var i = rl(t) ? rl(t, n.getComputedSelector(e.$_pfocustrap_focusableselector)) ? t : qc(e, n.getComputedSelector(e.$_pfocustrap_focusableselector)) : qc(t);
+							var i = tl(t) ? tl(t, n.getComputedSelector(e.$_pfocustrap_focusableselector)) ? t : Gc(e, n.getComputedSelector(e.$_pfocustrap_focusableselector)) : Gc(t);
 							return K(i) ? i : t.nextSibling && r(t.nextSibling);
 						};
 						J(r(t.nextSibling));
@@ -10175,23 +10176,23 @@ var Eh = yh.extend("focustrap", {
 			e.$_pfocustrap_mutationobserver && e.$_pfocustrap_mutationobserver.disconnect(), e.$_pfocustrap_focusinlistener && e.removeEventListener("focusin", e.$_pfocustrap_focusinlistener) && (e.$_pfocustrap_focusinlistener = null), e.$_pfocustrap_focusoutlistener && e.removeEventListener("focusout", e.$_pfocustrap_focusoutlistener) && (e.$_pfocustrap_focusoutlistener = null);
 		},
 		autoFocus: function(e) {
-			this.autoElementFocus(this.$el, { value: Sh(Sh({}, e), {}, { autoFocus: !0 }) });
+			this.autoElementFocus(this.$el, { value: bh(bh({}, e), {}, { autoFocus: !0 }) });
 		},
 		autoElementFocus: function(e, t) {
-			var n = t.value || {}, r = n.autoFocusSelector, i = r === void 0 ? "" : r, a = n.firstFocusableSelector, o = a === void 0 ? "" : a, s = n.autoFocus, c = s === void 0 ? !1 : s, l = qc(e, `[autofocus]${this.getComputedSelector(i)}`);
-			c && !l && (l = qc(e, this.getComputedSelector(o))), J(l);
+			var n = t.value || {}, r = n.autoFocusSelector, i = r === void 0 ? "" : r, a = n.firstFocusableSelector, o = a === void 0 ? "" : a, s = n.autoFocus, c = s === void 0 ? !1 : s, l = Gc(e, `[autofocus]${this.getComputedSelector(i)}`);
+			c && !l && (l = Gc(e, this.getComputedSelector(o))), J(l);
 		},
 		onFirstHiddenElementFocus: function(e) {
 			var t, n = e.currentTarget, r = e.relatedTarget;
-			J(r === n.$_pfocustrap_lasthiddenfocusableelement || !((t = this.$el) != null && t.contains(r)) ? qc(n.parentElement, this.getComputedSelector(n.$_pfocustrap_focusableselector)) : n.$_pfocustrap_lasthiddenfocusableelement);
+			J(r === n.$_pfocustrap_lasthiddenfocusableelement || !((t = this.$el) != null && t.contains(r)) ? Gc(n.parentElement, this.getComputedSelector(n.$_pfocustrap_focusableselector)) : n.$_pfocustrap_lasthiddenfocusableelement);
 		},
 		onLastHiddenElementFocus: function(e) {
 			var t, n = e.currentTarget, r = e.relatedTarget;
-			J(r === n.$_pfocustrap_firsthiddenfocusableelement || !((t = this.$el) != null && t.contains(r)) ? Yc(n.parentElement, this.getComputedSelector(n.$_pfocustrap_focusableselector)) : n.$_pfocustrap_firsthiddenfocusableelement);
+			J(r === n.$_pfocustrap_firsthiddenfocusableelement || !((t = this.$el) != null && t.contains(r)) ? qc(n.parentElement, this.getComputedSelector(n.$_pfocustrap_focusableselector)) : n.$_pfocustrap_firsthiddenfocusableelement);
 		},
 		createHiddenFocusableElements: function(e, t) {
 			var n = this, r = t.value || {}, i = r.tabIndex, a = i === void 0 ? 0 : i, o = r.firstFocusableSelector, s = o === void 0 ? "" : o, c = r.lastFocusableSelector, l = c === void 0 ? "" : c, u = function(e) {
-				return Hc("span", {
+				return Bc("span", {
 					class: "p-hidden-accessible p-hidden-focusable",
 					tabIndex: a,
 					role: "presentation",
@@ -10207,15 +10208,15 @@ var Eh = yh.extend("focustrap", {
 });
 //#endregion
 //#region node_modules/primevue/utils/index.mjs
-function Dh() {
-	wc({ variableName: Fl("scrollbar.width").name });
+function Th() {
+	Sc({ variableName: Nl("scrollbar.width").name });
 }
-function Oh() {
-	Ec({ variableName: Fl("scrollbar.width").name });
+function Eh() {
+	wc({ variableName: Nl("scrollbar.width").name });
 }
 //#endregion
 //#region node_modules/primevue/dialog/style/index.mjs
-var kh = X.extend({
+var Dh = X.extend({
 	name: "dialog",
 	style: "\n    .p-dialog {\n        max-height: 90%;\n        transform: scale(1);\n        border-radius: dt('dialog.border.radius');\n        box-shadow: dt('dialog.shadow');\n        background: dt('dialog.background');\n        border: 1px solid dt('dialog.border.color');\n        color: dt('dialog.color');\n        will-change: transform;\n    }\n\n    .p-dialog-content {\n        overflow-y: auto;\n        padding: dt('dialog.content.padding');\n        flex-grow: 1;\n    }\n\n    .p-dialog-header {\n        display: flex;\n        align-items: center;\n        justify-content: space-between;\n        flex-shrink: 0;\n        padding: dt('dialog.header.padding');\n    }\n\n    .p-dialog-title {\n        font-weight: dt('dialog.title.font.weight');\n        font-size: dt('dialog.title.font.size');\n    }\n\n    .p-dialog-footer {\n        flex-shrink: 0;\n        padding: dt('dialog.footer.padding');\n        display: flex;\n        justify-content: flex-end;\n        gap: dt('dialog.footer.gap');\n    }\n\n    .p-dialog-header-actions {\n        display: flex;\n        align-items: center;\n        gap: dt('dialog.header.gap');\n    }\n\n    .p-dialog-top .p-dialog,\n    .p-dialog-bottom .p-dialog,\n    .p-dialog-left .p-dialog,\n    .p-dialog-right .p-dialog,\n    .p-dialog-topleft .p-dialog,\n    .p-dialog-topright .p-dialog,\n    .p-dialog-bottomleft .p-dialog,\n    .p-dialog-bottomright .p-dialog {\n        margin: 1rem;\n    }\n\n    .p-dialog-maximized {\n        width: 100vw !important;\n        height: 100vh !important;\n        top: 0px !important;\n        left: 0px !important;\n        max-height: 100%;\n        height: 100%;\n        border-radius: 0;\n    }\n\n    .p-dialog .p-resizable-handle {\n        position: absolute;\n        font-size: 0.1px;\n        display: block;\n        cursor: se-resize;\n        width: 12px;\n        height: 12px;\n        right: 1px;\n        bottom: 1px;\n    }\n\n    .p-dialog-enter-active {\n        animation: p-animate-dialog-enter 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    .p-dialog-leave-active {\n        animation: p-animate-dialog-leave 300ms cubic-bezier(.19,1,.22,1);\n    }\n\n    @keyframes p-animate-dialog-enter {\n        from {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n\n    @keyframes p-animate-dialog-leave {\n        to {\n            opacity: 0;\n            transform: scale(0.93);\n        }\n    }\n",
 	classes: {
@@ -10271,11 +10272,11 @@ var kh = X.extend({
 			pointerEvents: "auto"
 		}
 	}
-}), Ah = {
+}), Oh = {
 	name: "Dialog",
 	extends: {
 		name: "BaseDialog",
-		extends: td,
+		extends: $u,
 		props: {
 			header: {
 				type: null,
@@ -10399,7 +10400,7 @@ var kh = X.extend({
 			},
 			_instance: null
 		},
-		style: kh,
+		style: Dh,
 		provide: function() {
 			return {
 				$pcDialog: this,
@@ -10420,7 +10421,7 @@ var kh = X.extend({
 	],
 	provide: function() {
 		var e = this;
-		return { dialogRef: ho(function() {
+		return { dialogRef: mo(function() {
 			return e._instance;
 		}) };
 	},
@@ -10452,7 +10453,7 @@ var kh = X.extend({
 		this.visible && (this.containerVisible = this.visible);
 	},
 	beforeUnmount: function() {
-		this.unbindDocumentState(), this.unbindGlobalListeners(), this.destroyStyle(), this.mask && this.autoZIndex && ul.clear(this.mask), this.container = null, this.mask = null;
+		this.unbindDocumentState(), this.unbindGlobalListeners(), this.destroyStyle(), this.mask && this.autoZIndex && cl.clear(this.mask), this.container = null, this.mask = null;
 	},
 	mounted: function() {
 		this.breakpoints && this.createStyle();
@@ -10462,19 +10463,19 @@ var kh = X.extend({
 			this.$emit("update:visible", !1);
 		},
 		onEnter: function() {
-			this.$emit("show"), this.target = document.activeElement, this.enableDocumentSettings(), this.bindGlobalListeners(), this.autoZIndex && ul.set("modal", this.mask, this.baseZIndex || this.$primevue.config.zIndex.modal);
+			this.$emit("show"), this.target = document.activeElement, this.enableDocumentSettings(), this.bindGlobalListeners(), this.autoZIndex && cl.set("modal", this.mask, this.baseZIndex || this.$primevue.config.zIndex.modal);
 		},
 		onAfterEnter: function() {
 			this.focus();
 		},
 		onBeforeLeave: function() {
-			this.modal && !this.isUnstyled && Sc(this.mask, "p-overlay-mask-leave-active"), this.dragging && this.documentDragEndListener && this.documentDragEndListener();
+			this.modal && !this.isUnstyled && bc(this.mask, "p-overlay-mask-leave-active"), this.dragging && this.documentDragEndListener && this.documentDragEndListener();
 		},
 		onLeave: function() {
 			this.$emit("hide"), J(this.target), this.target = null, this.focusableClose = null, this.focusableMax = null;
 		},
 		onAfterLeave: function() {
-			this.autoZIndex && ul.clear(this.mask), this.containerVisible = !1, this.unbindDocumentState(), this.unbindGlobalListeners(), this.$emit("after-hide");
+			this.autoZIndex && cl.clear(this.mask), this.containerVisible = !1, this.unbindDocumentState(), this.unbindGlobalListeners(), this.$emit("after-hide");
 		},
 		onMaskMouseDown: function(e) {
 			this.maskMouseDownTarget = e.target;
@@ -10489,13 +10490,13 @@ var kh = X.extend({
 			t || (t = this.$slots.header && e(this.headerContainer), t || (t = this.$slots.default && e(this.content), t || (this.maximizable ? (this.focusableMax = !0, t = this.maximizableButton) : (this.focusableClose = !0, t = this.closeButton)))), t && J(t, { focusVisible: !0 });
 		},
 		maximize: function(e) {
-			this.maximized ? (this.maximized = !1, this.$emit("unmaximize", e)) : (this.maximized = !0, this.$emit("maximize", e)), this.modal || (this.maximized ? Dh() : Oh());
+			this.maximized ? (this.maximized = !1, this.$emit("unmaximize", e)) : (this.maximized = !0, this.$emit("maximize", e)), this.modal || (this.maximized ? Th() : Eh());
 		},
 		enableDocumentSettings: function() {
-			(this.modal || !this.modal && this.blockScroll || this.maximizable && this.maximized) && Dh();
+			(this.modal || !this.modal && this.blockScroll || this.maximizable && this.maximized) && Th();
 		},
 		unbindDocumentState: function() {
-			(this.modal || !this.modal && this.blockScroll || this.maximizable && this.maximized) && Oh();
+			(this.modal || !this.modal && this.blockScroll || this.maximizable && this.maximized) && Eh();
 		},
 		onKeyDown: function(e) {
 			e.code === "Escape" && this.closeOnEscape && !e.isComposing && this.close();
@@ -10530,7 +10531,7 @@ var kh = X.extend({
 		createStyle: function() {
 			if (!this.styleElement && !this.isUnstyled) {
 				var e;
-				this.styleElement = document.createElement("style"), this.styleElement.type = "text/css", ol(this.styleElement, "nonce", (e = this.$primevue) == null || (e = e.config) == null || (e = e.csp) == null ? void 0 : e.nonce), document.head.appendChild(this.styleElement);
+				this.styleElement = document.createElement("style"), this.styleElement.type = "text/css", il(this.styleElement, "nonce", (e = this.$primevue) == null || (e = e.config) == null || (e = e.csp) == null ? void 0 : e.nonce), document.head.appendChild(this.styleElement);
 				var t = "";
 				for (var n in this.breakpoints) t += `
                         @media screen and (max-width: ${n}) {
@@ -10546,7 +10547,7 @@ var kh = X.extend({
 			this.styleElement &&= (document.head.removeChild(this.styleElement), null);
 		},
 		initDrag: function(e) {
-			e.target.closest("div").getAttribute("data-pc-section") !== "headeractions" && this.draggable && (this.dragging = !0, this.lastPageX = e.pageX, this.lastPageY = e.pageY, this.container.style.margin = "0", document.body.setAttribute("data-p-unselectable-text", "true"), !this.isUnstyled && Fc(document.body, { "user-select": "none" }), this.$emit("dragstart", e));
+			e.target.closest("div").getAttribute("data-pc-section") !== "headeractions" && this.draggable && (this.dragging = !0, this.lastPageX = e.pageX, this.lastPageY = e.pageY, this.container.style.margin = "0", document.body.setAttribute("data-p-unselectable-text", "true"), !this.isUnstyled && Nc(document.body, { "user-select": "none" }), this.$emit("dragstart", e));
 		},
 		bindGlobalListeners: function() {
 			this.draggable && (this.bindDocumentDragListener(), this.bindDocumentDragEndListener()), this.closeOnEscape && this.bindDocumentKeyDownListener();
@@ -10558,7 +10559,7 @@ var kh = X.extend({
 			var e = this;
 			this.documentDragListener = function(t) {
 				if (e.dragging) {
-					var n = Ic(e.container), r = Zc(e.container), i = t.pageX - e.lastPageX, a = t.pageY - e.lastPageY, o = e.container.getBoundingClientRect(), s = o.left + i, c = o.top + a, l = kc(), u = getComputedStyle(e.container), d = parseFloat(u.marginLeft), f = parseFloat(u.marginTop);
+					var n = Pc(e.container), r = Yc(e.container), i = t.pageX - e.lastPageX, a = t.pageY - e.lastPageY, o = e.container.getBoundingClientRect(), s = o.left + i, c = o.top + a, l = Dc(), u = getComputedStyle(e.container), d = parseFloat(u.marginLeft), f = parseFloat(u.marginTop);
 					e.container.style.position = "fixed", e.keepInViewport ? (s >= e.minX && s + n < l.width && (e.lastPageX = t.pageX, e.container.style.left = s - d + "px"), c >= e.minY && c + r < l.height && (e.lastPageY = t.pageY, e.container.style.top = c - f + "px")) : (e.lastPageX = t.pageX, e.container.style.left = s - d + "px", e.lastPageY = t.pageY, e.container.style.top = c - f + "px");
 				}
 			}, window.document.addEventListener("mousemove", this.documentDragListener);
@@ -10594,26 +10595,26 @@ var kh = X.extend({
 		}
 	},
 	directives: {
-		ripple: Xd,
-		focustrap: Eh
+		ripple: Jd,
+		focustrap: wh
 	},
 	components: {
-		Button: lf,
-		Portal: tm,
-		WindowMinimizeIcon: uh,
-		WindowMaximizeIcon: nh,
-		TimesIcon: Hp
+		Button: sf,
+		Portal: $p,
+		WindowMinimizeIcon: ch,
+		WindowMaximizeIcon: eh,
+		TimesIcon: Bp
 	}
 };
-function jh(e) {
+function kh(e) {
 	"@babel/helpers - typeof";
-	return jh = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return kh = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, jh(e);
+	}, kh(e);
 }
-function Mh(e, t) {
+function Ah(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -10623,46 +10624,46 @@ function Mh(e, t) {
 	}
 	return n;
 }
-function Nh(e) {
+function jh(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Mh(Object(n), !0).forEach(function(t) {
-			Ph(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Mh(Object(n)).forEach(function(t) {
+		t % 2 ? Ah(Object(n), !0).forEach(function(t) {
+			Mh(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Ah(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Ph(e, t, n) {
-	return (t = Fh(t)) in e ? Object.defineProperty(e, t, {
+function Mh(e, t, n) {
+	return (t = Nh(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Fh(e) {
-	var t = Ih(e, "string");
-	return jh(t) == "symbol" ? t : t + "";
+function Nh(e) {
+	var t = Ph(e, "string");
+	return kh(t) == "symbol" ? t : t + "";
 }
-function Ih(e, t) {
-	if (jh(e) != "object" || !e) return e;
+function Ph(e, t) {
+	if (kh(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (jh(r) != "object") return r;
+		if (kh(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Lh = ["data-p"], Rh = [
+var Fh = ["data-p"], Ih = [
 	"aria-labelledby",
 	"aria-modal",
 	"data-p"
-], zh = ["id"], Bh = ["data-p"];
-function Vh(e, t, n, r, i, a) {
-	var o = F("Button"), s = F("Portal"), c = si("focustrap");
+], Lh = ["id"], Rh = ["data-p"];
+function zh(e, t, n, r, i, a) {
+	var o = F("Button"), s = F("Portal"), c = oi("focustrap");
 	return R(), B(s, { appendTo: e.appendTo }, {
 		default: P(function() {
 			return [i.containerVisible ? (R(), z("div", W({
@@ -10680,7 +10681,7 @@ function Vh(e, t, n, r, i, a) {
 					return a.onMaskMouseUp && a.onMaskMouseUp.apply(a, arguments);
 				},
 				"data-p": a.dataP
-			}, e.ptm("mask")), [H(jo, W({
+			}, e.ptm("mask")), [H(Ao, W({
 				name: "p-dialog",
 				onEnter: a.onEnter,
 				onAfterEnter: a.onAfterEnter,
@@ -10690,7 +10691,7 @@ function Vh(e, t, n, r, i, a) {
 				appear: ""
 			}, e.ptm("transition")), {
 				default: P(function() {
-					return [e.visible ? Vn((R(), z("div", W({
+					return [e.visible ? Bn((R(), z("div", W({
 						key: 0,
 						ref: a.containerRef,
 						class: e.cx("root"),
@@ -10719,7 +10720,7 @@ function Vh(e, t, n, r, i, a) {
 								key: 0,
 								id: a.ariaLabelledById,
 								class: e.cx("title")
-							}, e.ptm("title")), O(e.header), 17, zh)) : U("", !0)];
+							}, e.ptm("title")), O(e.header), 17, Lh)) : U("", !0)];
 						}), V("div", W({ class: e.cx("headerActions") }, e.ptm("headerActions")), [e.maximizable ? I(e.$slots, "maximizebutton", {
 							key: 0,
 							maximized: i.maximized,
@@ -10740,7 +10741,7 @@ function Vh(e, t, n, r, i, a) {
 							}), {
 								icon: P(function(t) {
 									return [I(e.$slots, "maximizeicon", { maximized: i.maximized }, function() {
-										return [(R(), B(oi(a.maximizeIconComponent), W({ class: [t.class, i.maximized ? e.minimizeIcon : e.maximizeIcon] }, e.ptm("pcMaximizeButton").icon), null, 16, ["class"]))];
+										return [(R(), B(ai(a.maximizeIconComponent), W({ class: [t.class, i.maximized ? e.minimizeIcon : e.maximizeIcon] }, e.ptm("pcMaximizeButton").icon), null, 16, ["class"]))];
 									})];
 								}),
 								_: 3
@@ -10769,7 +10770,7 @@ function Vh(e, t, n, r, i, a) {
 							}), {
 								icon: P(function(t) {
 									return [I(e.$slots, "closeicon", {}, function() {
-										return [(R(), B(oi(e.closeIcon ? "span" : "TimesIcon"), W({ class: [e.closeIcon, t.class] }, e.ptm("pcCloseButton").icon), null, 16, ["class"]))];
+										return [(R(), B(ai(e.closeIcon ? "span" : "TimesIcon"), W({ class: [e.closeIcon, t.class] }, e.ptm("pcCloseButton").icon), null, 16, ["class"]))];
 									})];
 								}),
 								_: 3
@@ -10787,15 +10788,15 @@ function Vh(e, t, n, r, i, a) {
 							class: [e.cx("content"), e.contentClass],
 							style: e.contentStyle,
 							"data-p": a.dataP
-						}, Nh(Nh({}, e.contentProps), e.ptm("content"))), [I(e.$slots, "default")], 16, Bh),
+						}, jh(jh({}, e.contentProps), e.ptm("content"))), [I(e.$slots, "default")], 16, Rh),
 						e.footer || e.$slots.footer ? (R(), z("div", W({
 							key: 1,
 							ref: a.footerContainerRef,
 							class: e.cx("footer")
 						}, e.ptm("footer")), [I(e.$slots, "footer", {}, function() {
-							return [Ha(O(e.footer), 1)];
+							return [Va(O(e.footer), 1)];
 						})], 16)) : U("", !0)
-					], 64))], 16, Rh)), [[c, { disabled: !e.modal }]]) : U("", !0)];
+					], 64))], 16, Ih)), [[c, { disabled: !e.modal }]]) : U("", !0)];
 				}),
 				_: 3
 			}, 16, [
@@ -10804,15 +10805,15 @@ function Vh(e, t, n, r, i, a) {
 				"onBeforeLeave",
 				"onLeave",
 				"onAfterLeave"
-			])], 16, Lh)) : U("", !0)];
+			])], 16, Fh)) : U("", !0)];
 		}),
 		_: 3
 	}, 8, ["appendTo"]);
 }
-Ah.render = Vh;
+Oh.render = zh;
 //#endregion
 //#region node_modules/primevue/menu/style/index.mjs
-var Hh = X.extend({
+var Bh = X.extend({
 	name: "menu",
 	style: "\n    .p-menu {\n        background: dt('menu.background');\n        color: dt('menu.color');\n        border: 1px solid dt('menu.border.color');\n        border-radius: dt('menu.border.radius');\n        min-width: 12.5rem;\n    }\n\n    .p-menu-list {\n        margin: 0;\n        padding: dt('menu.list.padding');\n        outline: 0 none;\n        list-style: none;\n        display: flex;\n        flex-direction: column;\n        gap: dt('menu.list.gap');\n    }\n\n    .p-menu-item-content {\n        transition:\n            background dt('menu.transition.duration'),\n            color dt('menu.transition.duration');\n        border-radius: dt('menu.item.border.radius');\n        color: dt('menu.item.color');\n        overflow: hidden;\n    }\n\n    .p-menu-item-link {\n        cursor: pointer;\n        display: flex;\n        align-items: center;\n        text-decoration: none;\n        overflow: hidden;\n        position: relative;\n        color: inherit;\n        padding: dt('menu.item.padding');\n        gap: dt('menu.item.gap');\n        user-select: none;\n        outline: 0 none;\n    }\n\n    .p-menu-item-label {\n        line-height: 1;\n    }\n\n    .p-menu-item-icon {\n        color: dt('menu.item.icon.color');\n    }\n\n    .p-menu-item.p-focus .p-menu-item-content {\n        color: dt('menu.item.focus.color');\n        background: dt('menu.item.focus.background');\n    }\n\n    .p-menu-item.p-focus .p-menu-item-icon {\n        color: dt('menu.item.icon.focus.color');\n    }\n\n    .p-menu-item:not(.p-disabled) .p-menu-item-content:hover {\n        color: dt('menu.item.focus.color');\n        background: dt('menu.item.focus.background');\n    }\n\n    .p-menu-item:not(.p-disabled) .p-menu-item-content:hover .p-menu-item-icon {\n        color: dt('menu.item.icon.focus.color');\n    }\n\n    .p-menu-overlay {\n        box-shadow: dt('menu.shadow');\n    }\n\n    .p-menu-submenu-label {\n        background: dt('menu.submenu.label.background');\n        padding: dt('menu.submenu.label.padding');\n        color: dt('menu.submenu.label.color');\n        font-weight: dt('menu.submenu.label.font.weight');\n    }\n\n    .p-menu-separator {\n        border-block-start: 1px solid dt('menu.separator.border.color');\n    }\n",
 	classes: {
@@ -10836,9 +10837,9 @@ var Hh = X.extend({
 		itemIcon: "p-menu-item-icon",
 		itemLabel: "p-menu-item-label"
 	}
-}), Uh = {
+}), Vh = {
 	name: "BaseMenu",
-	extends: td,
+	extends: $u,
 	props: {
 		popup: {
 			type: Boolean,
@@ -10873,17 +10874,17 @@ var Hh = X.extend({
 			default: null
 		}
 	},
-	style: Hh,
+	style: Bh,
 	provide: function() {
 		return {
 			$pcMenu: this,
 			$parentInstance: this
 		};
 	}
-}, Wh = {
+}, Hh = {
 	name: "Menuitem",
 	hostName: "Menu",
-	extends: td,
+	extends: $u,
 	inheritAttrs: !1,
 	emits: ["item-click", "item-mousemove"],
 	props: {
@@ -10895,7 +10896,7 @@ var Hh = X.extend({
 	},
 	methods: {
 		getItemProp: function(e, t) {
-			return e && e.item ? sc(e.item[t]) : void 0;
+			return e && e.item ? ac(e.item[t]) : void 0;
 		},
 		getPTOptions: function(e) {
 			return this.ptm(e, { context: {
@@ -10952,17 +10953,17 @@ var Hh = X.extend({
 			disabled: this.disabled()
 		});
 	} },
-	directives: { ripple: Xd }
-}, Gh = [
+	directives: { ripple: Jd }
+}, Uh = [
 	"id",
 	"aria-label",
 	"aria-disabled",
 	"data-p-focused",
 	"data-p-disabled",
 	"data-p"
-], Kh = ["data-p"], qh = ["href", "target"], Jh = ["data-p"], Yh = ["data-p"];
-function Xh(e, t, n, r, i, a) {
-	var o = si("ripple");
+], Wh = ["data-p"], Gh = ["href", "target"], Kh = ["data-p"], qh = ["data-p"];
+function Jh(e, t, n, r, i, a) {
+	var o = oi("ripple");
 	return a.visible() ? (R(), z("li", W({
 		key: 0,
 		id: n.id,
@@ -10983,7 +10984,7 @@ function Xh(e, t, n, r, i, a) {
 			return a.onItemMouseMove(e);
 		},
 		"data-p": a.dataP
-	}, a.getPTOptions("itemContent")), [n.templates.item ? n.templates.item ? (R(), B(oi(n.templates.item), {
+	}, a.getPTOptions("itemContent")), [n.templates.item ? n.templates.item ? (R(), B(ai(n.templates.item), {
 		key: 1,
 		item: n.item,
 		label: a.label(),
@@ -10992,13 +10993,13 @@ function Xh(e, t, n, r, i, a) {
 		"item",
 		"label",
 		"props"
-	])) : U("", !0) : Vn((R(), z("a", W({
+	])) : U("", !0) : Bn((R(), z("a", W({
 		key: 0,
 		href: n.item.url,
 		class: e.cx("itemLink"),
 		target: n.item.target,
 		tabindex: "-1"
-	}, a.getPTOptions("itemLink")), [n.templates.itemicon ? (R(), B(oi(n.templates.itemicon), {
+	}, a.getPTOptions("itemLink")), [n.templates.itemicon ? (R(), B(ai(n.templates.itemicon), {
 		key: 0,
 		item: n.item,
 		class: D(e.cx("itemIcon"))
@@ -11006,39 +11007,39 @@ function Xh(e, t, n, r, i, a) {
 		key: 1,
 		class: [e.cx("itemIcon"), n.item.icon],
 		"data-p": a.dataP
-	}, a.getPTOptions("itemIcon")), null, 16, Jh)) : U("", !0), V("span", W({
+	}, a.getPTOptions("itemIcon")), null, 16, Kh)) : U("", !0), V("span", W({
 		class: e.cx("itemLabel"),
 		"data-p": a.dataP
-	}, a.getPTOptions("itemLabel")), O(a.label()), 17, Yh)], 16, qh)), [[o]])], 16, Kh)], 16, Gh)) : U("", !0);
+	}, a.getPTOptions("itemLabel")), O(a.label()), 17, qh)], 16, Gh)), [[o]])], 16, Wh)], 16, Uh)) : U("", !0);
 }
-Wh.render = Xh;
-function Zh(e) {
-	return tg(e) || eg(e) || $h(e) || Qh();
+Hh.render = Jh;
+function Yh(e) {
+	return $h(e) || Qh(e) || Zh(e) || Xh();
 }
-function Qh() {
+function Xh() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function $h(e, t) {
+function Zh(e, t) {
 	if (e) {
-		if (typeof e == "string") return ng(e, t);
+		if (typeof e == "string") return eg(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? ng(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? eg(e, t) : void 0;
 	}
 }
-function eg(e) {
+function Qh(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function tg(e) {
-	if (Array.isArray(e)) return ng(e);
+function $h(e) {
+	if (Array.isArray(e)) return eg(e);
 }
-function ng(e, t) {
+function eg(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-var rg = {
+var tg = {
 	name: "Menu",
-	extends: Uh,
+	extends: Vh,
 	inheritAttrs: !1,
 	emits: [
 		"show",
@@ -11064,7 +11065,7 @@ var rg = {
 		this.popup || (this.bindResizeListener(), this.bindOutsideClickListener());
 	},
 	beforeUnmount: function() {
-		this.unbindResizeListener(), this.unbindOutsideClickListener(), this.scrollHandler &&= (this.scrollHandler.destroy(), null), this.target = null, this.container && this.autoZIndex && ul.clear(this.container), this.container = null;
+		this.unbindResizeListener(), this.unbindOutsideClickListener(), this.scrollHandler &&= (this.scrollHandler.destroy(), null), this.target = null, this.container && this.autoZIndex && cl.clear(this.container), this.container = null;
 	},
 	methods: {
 		itemClick: function(e) {
@@ -11122,29 +11123,29 @@ var rg = {
 			this.changeFocusedOptionIndex(0), e.preventDefault();
 		},
 		onEndKey: function(e) {
-			this.changeFocusedOptionIndex(Uc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]").length - 1), e.preventDefault();
+			this.changeFocusedOptionIndex(Vc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]").length - 1), e.preventDefault();
 		},
 		onEnterKey: function(e) {
-			var t = Wc(this.list, `li[id="${`${this.focusedOptionIndex}`}"]`), n = t && Wc(t, "a[data-pc-section=\"itemlink\"]");
+			var t = Hc(this.list, `li[id="${`${this.focusedOptionIndex}`}"]`), n = t && Hc(t, "a[data-pc-section=\"itemlink\"]");
 			this.popup && J(this.target), n ? n.click() : t && t.click(), e.preventDefault();
 		},
 		onSpaceKey: function(e) {
 			this.onEnterKey(e);
 		},
 		findNextOptionIndex: function(e) {
-			var t = Zh(Uc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]")).findIndex(function(t) {
+			var t = Yh(Vc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]")).findIndex(function(t) {
 				return t.id === e;
 			});
 			return t > -1 ? t + 1 : 0;
 		},
 		findPrevOptionIndex: function(e) {
-			var t = Zh(Uc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]")).findIndex(function(t) {
+			var t = Yh(Vc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]")).findIndex(function(t) {
 				return t.id === e;
 			});
 			return t > -1 ? t - 1 : 0;
 		},
 		changeFocusedOptionIndex: function(e) {
-			var t = Uc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]"), n = e >= t.length ? t.length - 1 : e < 0 ? 0 : e;
+			var t = Vc(this.container, "li[data-pc-section=\"item\"][data-p-disabled=\"false\"]"), n = e >= t.length ? t.length - 1 : e < 0 ? 0 : e;
 			n > -1 && (this.focusedOptionIndex = t[n].getAttribute("id"));
 		},
 		toggle: function(e, t) {
@@ -11157,19 +11158,19 @@ var rg = {
 			this.overlayVisible = !1, this.target = null;
 		},
 		onEnter: function(e) {
-			Fc(e, {
+			Nc(e, {
 				position: "absolute",
 				top: "0"
-			}), this.alignOverlay(), this.bindOutsideClickListener(), this.bindResizeListener(), this.bindScrollListener(), this.autoZIndex && ul.set("menu", e, this.baseZIndex || this.$primevue.config.zIndex.menu), this.popup && J(this.list), this.$emit("show");
+			}), this.alignOverlay(), this.bindOutsideClickListener(), this.bindResizeListener(), this.bindScrollListener(), this.autoZIndex && cl.set("menu", e, this.baseZIndex || this.$primevue.config.zIndex.menu), this.popup && J(this.list), this.$emit("show");
 		},
 		onLeave: function() {
 			this.unbindOutsideClickListener(), this.unbindResizeListener(), this.unbindScrollListener(), this.$emit("hide");
 		},
 		onAfterLeave: function(e) {
-			this.autoZIndex && ul.clear(e);
+			this.autoZIndex && cl.clear(e);
 		},
 		alignOverlay: function() {
-			Pc(this.container, this.target), Ic(this.target) > Ic(this.container) && (this.container.style.minWidth = Ic(this.target) + "px");
+			Mc(this.container, this.target), Pc(this.target) > Pc(this.container) && (this.container.style.minWidth = Pc(this.target) + "px");
 		},
 		bindOutsideClickListener: function() {
 			var e = this;
@@ -11183,7 +11184,7 @@ var rg = {
 		},
 		bindScrollListener: function() {
 			var e = this;
-			this.scrollHandler ||= new _p(this.target, function() {
+			this.scrollHandler ||= new hp(this.target, function() {
 				e.overlayVisible && e.hide();
 			}), this.scrollHandler.bindScrollListener();
 		},
@@ -11193,7 +11194,7 @@ var rg = {
 		bindResizeListener: function() {
 			var e = this;
 			this.resizeListener || (this.resizeListener = function() {
-				e.overlayVisible && !al() && e.hide();
+				e.overlayVisible && !rl() && e.hide();
 			}, window.addEventListener("resize", this.resizeListener));
 		},
 		unbindResizeListener: function() {
@@ -11209,7 +11210,7 @@ var rg = {
 			return typeof e.label == "function" ? e.label() : e.label;
 		},
 		onOverlayClick: function(e) {
-			em.emit("overlay-click", {
+			Qp.emit("overlay-click", {
 				originalEvent: e,
 				target: this.target
 			});
@@ -11230,24 +11231,24 @@ var rg = {
 		}
 	},
 	components: {
-		PVMenuitem: Wh,
-		Portal: tm
+		PVMenuitem: Hh,
+		Portal: $p
 	}
-}, ig = ["id", "data-p"], ag = [
+}, ng = ["id", "data-p"], rg = [
 	"id",
 	"tabindex",
 	"aria-activedescendant",
 	"aria-label",
 	"aria-labelledby"
-], og = ["id"];
-function sg(e, t, n, r, i, a) {
+], ig = ["id"];
+function ag(e, t, n, r, i, a) {
 	var o = F("PVMenuitem"), s = F("Portal");
 	return R(), B(s, {
 		appendTo: e.appendTo,
 		disabled: !e.popup
 	}, {
 		default: P(function() {
-			return [H(jo, W({
+			return [H(Ao, W({
 				name: "p-anchored-overlay",
 				onEnter: a.onEnter,
 				onLeave: a.onLeave,
@@ -11286,15 +11287,15 @@ function sg(e, t, n, r, i, a) {
 							onKeydown: t[2] ||= function() {
 								return a.onListKeyDown && a.onListKeyDown.apply(a, arguments);
 							}
-						}, e.ptm("list")), [(R(!0), z(L, null, ui(e.model, function(t, n) {
+						}, e.ptm("list")), [(R(!0), z(L, null, li(e.model, function(t, n) {
 							return R(), z(L, { key: a.label(t) + n.toString() }, [t.items && a.visible(t) && !t.separator ? (R(), z(L, { key: 0 }, [t.items ? (R(), z("li", W({
 								key: 0,
 								id: e.$id + "_" + n,
 								class: [e.cx("submenuLabel"), t.class],
 								role: "none"
 							}, { ref_for: !0 }, e.ptm("submenuLabel")), [I(e.$slots, e.$slots.submenulabel ? "submenulabel" : "submenuheader", { item: t }, function() {
-								return [Ha(O(a.label(t)), 1)];
-							})], 16, og)) : U("", !0), (R(!0), z(L, null, ui(t.items, function(r, i) {
+								return [Va(O(a.label(t)), 1)];
+							})], 16, ig)) : U("", !0), (R(!0), z(L, null, li(t.items, function(r, i) {
 								return R(), z(L, { key: r.label + n + "_" + i }, [a.visible(r) && !r.separator ? (R(), B(o, {
 									key: 0,
 									id: e.$id + "_" + n + "_" + i,
@@ -11347,12 +11348,12 @@ function sg(e, t, n, r, i, a) {
 								"onItemMousemove",
 								"pt"
 							]))], 64);
-						}), 128))], 16, ag),
+						}), 128))], 16, rg),
 						e.$slots.end ? (R(), z("div", W({
 							key: 1,
 							class: e.cx("end")
 						}, e.ptm("end")), [I(e.$slots, "end")], 16)) : U("", !0)
-					], 16, ig)) : U("", !0)];
+					], 16, ng)) : U("", !0)];
 				}),
 				_: 3
 			}, 16, [
@@ -11364,10 +11365,10 @@ function sg(e, t, n, r, i, a) {
 		_: 3
 	}, 8, ["appendTo", "disabled"]);
 }
-rg.render = sg;
+tg.render = ag;
 //#endregion
 //#region node_modules/primevue/listbox/style/index.mjs
-var cg = X.extend({
+var og = X.extend({
 	name: "listbox",
 	style: "\n    .p-listbox {\n        display: block;\n        background: dt('listbox.background');\n        color: dt('listbox.color');\n        border: 1px solid dt('listbox.border.color');\n        border-radius: dt('listbox.border.radius');\n        transition:\n            background dt('listbox.transition.duration'),\n            color dt('listbox.transition.duration'),\n            border-color dt('listbox.transition.duration'),\n            box-shadow dt('listbox.transition.duration'),\n            outline-color dt('listbox.transition.duration');\n        outline-color: transparent;\n        box-shadow: dt('listbox.shadow');\n    }\n\n    .p-listbox.p-disabled {\n        opacity: 1;\n        background: dt('listbox.disabled.background');\n        color: dt('listbox.disabled.color');\n    }\n\n    .p-listbox.p-disabled .p-listbox-option {\n        color: dt('listbox.disabled.color');\n    }\n\n    .p-listbox.p-invalid {\n        border-color: dt('listbox.invalid.border.color');\n    }\n\n    .p-listbox-header {\n        padding: dt('listbox.list.header.padding');\n    }\n\n    .p-listbox-filter {\n        width: 100%;\n    }\n\n    .p-listbox-list-container {\n        overflow: auto;\n    }\n\n    .p-listbox-list {\n        list-style-type: none;\n        margin: 0;\n        padding: dt('listbox.list.padding');\n        outline: 0 none;\n        display: flex;\n        flex-direction: column;\n        gap: dt('listbox.list.gap');\n    }\n\n    .p-listbox-option {\n        display: flex;\n        align-items: center;\n        cursor: pointer;\n        position: relative;\n        overflow: hidden;\n        padding: dt('listbox.option.padding');\n        border: 0 none;\n        border-radius: dt('listbox.option.border.radius');\n        color: dt('listbox.option.color');\n        transition:\n            background dt('listbox.transition.duration'),\n            color dt('listbox.transition.duration'),\n            border-color dt('listbox.transition.duration'),\n            box-shadow dt('listbox.transition.duration'),\n            outline-color dt('listbox.transition.duration');\n    }\n\n    .p-listbox-striped li:nth-child(even of .p-listbox-option) {\n        background: dt('listbox.option.striped.background');\n    }\n\n    .p-listbox .p-listbox-list .p-listbox-option.p-listbox-option-selected {\n        background: dt('listbox.option.selected.background');\n        color: dt('listbox.option.selected.color');\n    }\n\n    .p-listbox:not(.p-disabled) .p-listbox-option.p-listbox-option-selected.p-focus {\n        background: dt('listbox.option.selected.focus.background');\n        color: dt('listbox.option.selected.focus.color');\n    }\n\n    .p-listbox:not(.p-disabled) .p-listbox-option:not(.p-listbox-option-selected):not(.p-disabled).p-focus {\n        background: dt('listbox.option.focus.background');\n        color: dt('listbox.option.focus.color');\n    }\n\n    .p-listbox:not(.p-disabled) .p-listbox-option:not(.p-listbox-option-selected):not(.p-disabled):hover {\n        background: dt('listbox.option.focus.background');\n        color: dt('listbox.option.focus.color');\n    }\n\n    .p-listbox-option-blank-icon {\n        flex-shrink: 0;\n    }\n\n    .p-listbox-option-check-icon {\n        position: relative;\n        flex-shrink: 0;\n        margin-inline-start: dt('listbox.checkmark.gutter.start');\n        margin-inline-end: dt('listbox.checkmark.gutter.end');\n        color: dt('listbox.checkmark.color');\n    }\n\n    .p-listbox-option-group {\n        margin: 0;\n        padding: dt('listbox.option.group.padding');\n        color: dt('listbox.option.group.color');\n        background: dt('listbox.option.group.background');\n        font-weight: dt('listbox.option.group.font.weight');\n    }\n\n    .p-listbox-empty-message {\n        padding: dt('listbox.empty.message.padding');\n    }\n\n    .p-listbox-fluid {\n        width: 100%;\n    }\n",
 	classes: {
@@ -11397,9 +11398,9 @@ var cg = X.extend({
 		optionBlankIcon: "p-listbox-option-blank-icon",
 		emptyMessage: "p-listbox-empty-message"
 	}
-}), lg = {
+}), sg = {
 	name: "BaseListbox",
-	extends: kf,
+	extends: Df,
 	props: {
 		options: Array,
 		optionLabel: null,
@@ -11501,7 +11502,7 @@ var cg = X.extend({
 			default: null
 		}
 	},
-	style: cg,
+	style: og,
 	provide: function() {
 		return {
 			$pcListbox: this,
@@ -11509,33 +11510,33 @@ var cg = X.extend({
 		};
 	}
 };
-function ug(e) {
-	return mg(e) || pg(e) || fg(e) || dg();
+function cg(e) {
+	return fg(e) || dg(e) || ug(e) || lg();
 }
-function dg() {
+function lg() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function fg(e, t) {
+function ug(e, t) {
 	if (e) {
-		if (typeof e == "string") return hg(e, t);
+		if (typeof e == "string") return pg(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? hg(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? pg(e, t) : void 0;
 	}
 }
-function pg(e) {
+function dg(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function mg(e) {
-	if (Array.isArray(e)) return hg(e);
+function fg(e) {
+	if (Array.isArray(e)) return pg(e);
 }
-function hg(e, t) {
+function pg(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-var gg = {
+var mg = {
 	name: "Listbox",
-	extends: lg,
+	extends: sg,
 	inheritAttrs: !1,
 	emits: [
 		"change",
@@ -11569,13 +11570,13 @@ var gg = {
 			return this.virtualScrollerDisabled ? e : t && t(e).index;
 		},
 		getOptionLabel: function(e) {
-			return this.optionLabel ? ec(e, this.optionLabel) : typeof e == "string" || typeof e == "number" || typeof e == "boolean" ? e : null;
+			return this.optionLabel ? Qs(e, this.optionLabel) : typeof e == "string" || typeof e == "number" || typeof e == "boolean" ? e : null;
 		},
 		getOptionValue: function(e) {
-			return this.optionValue ? ec(e, this.optionValue) : e;
+			return this.optionValue ? Qs(e, this.optionValue) : e;
 		},
 		getOptionRenderKey: function(e, t) {
-			return (this.dataKey ? ec(e, this.dataKey) : this.getOptionLabel(e)) + "_" + t;
+			return (this.dataKey ? Qs(e, this.dataKey) : this.getOptionLabel(e)) + "_" + t;
 		},
 		getPTOptions: function(e, t, n, r) {
 			return this.ptm(r, { context: {
@@ -11585,16 +11586,16 @@ var gg = {
 			} });
 		},
 		isOptionDisabled: function(e) {
-			return this.optionDisabled ? ec(e, this.optionDisabled) : !1;
+			return this.optionDisabled ? Qs(e, this.optionDisabled) : !1;
 		},
 		isOptionGroup: function(e) {
 			return this.optionGroupLabel && e.optionGroup && e.group;
 		},
 		getOptionGroupLabel: function(e) {
-			return ec(e, this.optionGroupLabel);
+			return Qs(e, this.optionGroupLabel);
 		},
 		getOptionGroupChildren: function(e) {
-			return ec(e, this.optionGroupChildren);
+			return Qs(e, this.optionGroupChildren);
 		},
 		getAriaPosInset: function(e) {
 			var t = this;
@@ -11604,11 +11605,11 @@ var gg = {
 		},
 		onFirstHiddenFocus: function() {
 			J(this.list);
-			var e = qc(this.$el, ":not([data-p-hidden-focusable=\"true\"])");
-			this.$refs.lastHiddenFocusableElement.tabIndex = Bc(e) ? void 0 : -1, this.$refs.firstHiddenFocusableElement.tabIndex = -1;
+			var e = Gc(this.$el, ":not([data-p-hidden-focusable=\"true\"])");
+			this.$refs.lastHiddenFocusableElement.tabIndex = Rc(e) ? void 0 : -1, this.$refs.firstHiddenFocusableElement.tabIndex = -1;
 		},
 		onLastHiddenFocus: function(e) {
-			e.relatedTarget === this.list ? (J(qc(this.$el, ":not([data-p-hidden-focusable=\"true\"])")), this.$refs.firstHiddenFocusableElement.tabIndex = void 0) : J(this.$refs.firstHiddenFocusableElement), this.$refs.lastHiddenFocusableElement.tabIndex = -1;
+			e.relatedTarget === this.list ? (J(Gc(this.$el, ":not([data-p-hidden-focusable=\"true\"])")), this.$refs.firstHiddenFocusableElement.tabIndex = void 0) : J(this.$refs.firstHiddenFocusableElement), this.$refs.lastHiddenFocusableElement.tabIndex = -1;
 		},
 		onFocusout: function(e) {
 			!this.$el.contains(e.relatedTarget) && this.$refs.lastHiddenFocusableElement && this.$refs.firstHiddenFocusableElement && (this.$refs.lastHiddenFocusableElement.tabIndex = this.$refs.firstHiddenFocusableElement.tabIndex = void 0);
@@ -11660,7 +11661,7 @@ var gg = {
 						this.updateModel(e, r), e.preventDefault();
 						break;
 					}
-					!n && pc(e.key) && (this.searchOptions(e, e.key), e.preventDefault());
+					!n && dc(e.key) && (this.searchOptions(e, e.key), e.preventDefault());
 					break;
 			}
 		},
@@ -11698,8 +11699,8 @@ var gg = {
 			var n = this.isSelected(t), r = null;
 			if (!this.optionTouched && this.metaKeySelection) {
 				var i = e.metaKey || e.ctrlKey;
-				n ? r = i ? this.removeOption(t) : [this.getOptionValue(t)] : (r = i && this.d_value || [], r = [].concat(ug(r), [this.getOptionValue(t)]));
-			} else r = n ? this.removeOption(t) : [].concat(ug(this.d_value || []), [this.getOptionValue(t)]);
+				n ? r = i ? this.removeOption(t) : [this.getOptionValue(t)] : (r = i && this.d_value || [], r = [].concat(cg(r), [this.getOptionValue(t)]));
+			} else r = n ? this.removeOption(t) : [].concat(cg(this.d_value || []), [this.getOptionValue(t)]);
 			this.updateModel(e, r);
 		},
 		onOptionSelectRange: function(e) {
@@ -11808,7 +11809,7 @@ var gg = {
 			return this.isValidOption(e) && this.isSelected(e);
 		},
 		isEquals: function(e, t) {
-			return tc(e, t, this.equalityKey);
+			return $s(e, t, this.equalityKey);
 		},
 		isSelected: function(e) {
 			var t = this, n = this.getOptionValue(e);
@@ -11824,7 +11825,7 @@ var gg = {
 		},
 		findLastOptionIndex: function() {
 			var e = this;
-			return oc(this.visibleOptions, function(t) {
+			return ic(this.visibleOptions, function(t) {
 				return e.isValidOption(t);
 			});
 		},
@@ -11835,7 +11836,7 @@ var gg = {
 			return n > -1 ? n + e + 1 : e;
 		},
 		findPrevOptionIndex: function(e) {
-			var t = this, n = e > 0 ? oc(this.visibleOptions.slice(0, e), function(e) {
+			var t = this, n = e > 0 ? ic(this.visibleOptions.slice(0, e), function(e) {
 				return t.isValidOption(e);
 			}) : -1;
 			return n > -1 ? n : e;
@@ -11862,7 +11863,7 @@ var gg = {
 		},
 		findLastSelectedOptionIndex: function() {
 			var e = this;
-			return this.$filled ? oc(this.visibleOptions, function(t) {
+			return this.$filled ? ic(this.visibleOptions, function(t) {
 				return e.isValidSelectedOption(t);
 			}) : -1;
 		},
@@ -11873,7 +11874,7 @@ var gg = {
 			return n > -1 ? n + e + 1 : -1;
 		},
 		findPrevSelectedOptionIndex: function(e) {
-			var t = this, n = this.$filled && e > 0 ? oc(this.visibleOptions.slice(0, e), function(e) {
+			var t = this, n = this.$filled && e > 0 ? ic(this.visibleOptions.slice(0, e), function(e) {
 				return t.isValidSelectedOption(e);
 			}) : -1;
 			return n > -1 ? n : -1;
@@ -11907,7 +11908,7 @@ var gg = {
 		removeOption: function(e) {
 			var t = this;
 			return this.d_value.filter(function(n) {
-				return !tc(n, t.getOptionValue(e), t.equalityKey);
+				return !$s(n, t.getOptionValue(e), t.equalityKey);
 			});
 		},
 		changeFocusedOptionIndex: function(e, t) {
@@ -11916,7 +11917,7 @@ var gg = {
 		scrollInView: function() {
 			var e = this, t = arguments.length > 0 && arguments[0] !== void 0 ? arguments[0] : -1;
 			this.$nextTick(function() {
-				var n = t === -1 ? e.focusedOptionId : `${e.$id}_${t}`, r = Wc(e.list, `li[id="${n}"]`);
+				var n = t === -1 ? e.focusedOptionId : `${e.$id}_${t}`, r = Hc(e.list, `li[id="${n}"]`);
 				r ? r.scrollIntoView && r.scrollIntoView({
 					block: "nearest",
 					inline: "nearest",
@@ -11942,16 +11943,16 @@ var gg = {
 	},
 	computed: {
 		optionsListFlat: function() {
-			return this.filterValue ? Gl.filter(this.options, this.searchFields, this.filterValue, this.filterMatchMode, this.filterLocale) : this.options;
+			return this.filterValue ? Ul.filter(this.options, this.searchFields, this.filterValue, this.filterMatchMode, this.filterLocale) : this.options;
 		},
 		optionsListGroup: function() {
 			var e = this, t = [];
 			return (this.options || []).forEach(function(n) {
-				var r = e.getOptionGroupChildren(n) || [], i = e.filterValue ? Gl.filter(r, e.searchFields, e.filterValue, e.filterMatchMode, e.filterLocale) : r;
+				var r = e.getOptionGroupChildren(n) || [], i = e.filterValue ? Ul.filter(r, e.searchFields, e.filterValue, e.filterMatchMode, e.filterLocale) : r;
 				i != null && i.length && t.push.apply(t, [{
 					optionGroup: n,
 					group: !0
-				}].concat(ug(i)));
+				}].concat(cg(i)));
 			}), t;
 		},
 		visibleOptions: function() {
@@ -12006,24 +12007,24 @@ var gg = {
 			});
 		}
 	},
-	directives: { ripple: Xd },
+	directives: { ripple: Jd },
 	components: {
-		InputText: $f,
-		VirtualScroller: dm,
-		InputIcon: Qp,
-		IconField: Xp,
-		SearchIcon: Pp,
-		CheckIcon: pf,
-		BlankIcon: vp
+		InputText: Zf,
+		VirtualScroller: lm,
+		InputIcon: Xp,
+		IconField: Jp,
+		SearchIcon: Mp,
+		CheckIcon: df,
+		BlankIcon: gp
 	}
-}, _g = ["id", "data-p"], vg = ["tabindex"], yg = [
+}, hg = ["id", "data-p"], gg = ["tabindex"], _g = [
 	"id",
 	"aria-multiselectable",
 	"aria-label",
 	"aria-labelledby",
 	"aria-activedescendant",
 	"aria-disabled"
-], bg = ["id"], xg = [
+], vg = ["id"], yg = [
 	"id",
 	"aria-label",
 	"aria-selected",
@@ -12037,9 +12038,9 @@ var gg = {
 	"data-p-selected",
 	"data-p-focused",
 	"data-p-disabled"
-], Sg = ["tabindex"];
-function Cg(e, t, n, r, i, a) {
-	var o = F("InputText"), s = F("SearchIcon"), c = F("InputIcon"), l = F("IconField"), u = F("CheckIcon"), d = F("BlankIcon"), f = F("VirtualScroller"), p = si("ripple");
+], bg = ["tabindex"];
+function xg(e, t, n, r, i, a) {
+	var o = F("InputText"), s = F("SearchIcon"), c = F("InputIcon"), l = F("IconField"), u = F("CheckIcon"), d = F("BlankIcon"), f = F("VirtualScroller"), p = oi("ripple");
 	return R(), z("div", W({
 		id: e.$id,
 		class: e.cx("root"),
@@ -12060,7 +12061,7 @@ function Cg(e, t, n, r, i, a) {
 		}, e.ptm("hiddenFirstFocusableEl"), {
 			"data-p-hidden-accessible": !0,
 			"data-p-hidden-focusable": !0
-		}), null, 16, vg),
+		}), null, 16, gg),
 		e.$slots.header ? (R(), z("div", W({
 			key: 0,
 			class: e.cx("header")
@@ -12136,7 +12137,7 @@ function Cg(e, t, n, r, i, a) {
 			tabindex: -1,
 			disabled: a.virtualScrollerDisabled,
 			pt: e.ptm("virtualScroller")
-		}), di({
+		}), ui({
 			content: P(function(n) {
 				var r = n.styleClass, o = n.contentRef, s = n.items, c = n.getItemOptions, l = n.contentStyle, f = n.itemSize;
 				return [V("ul", W({
@@ -12162,7 +12163,7 @@ function Cg(e, t, n, r, i, a) {
 					onKeydown: t[5] ||= function() {
 						return a.onListKeyDown && a.onListKeyDown.apply(a, arguments);
 					}
-				}, e.ptm("list")), [(R(!0), z(L, null, ui(s, function(n, r) {
+				}, e.ptm("list")), [(R(!0), z(L, null, li(s, function(n, r) {
 					return R(), z(L, { key: a.getOptionRenderKey(n, a.getOptionIndex(r, c)) }, [a.isOptionGroup(n) ? (R(), z("li", W({
 						key: 0,
 						id: e.$id + "_" + a.getOptionIndex(r, c),
@@ -12173,8 +12174,8 @@ function Cg(e, t, n, r, i, a) {
 						option: n.optionGroup,
 						index: a.getOptionIndex(r, c)
 					}, function() {
-						return [Ha(O(a.getOptionGroupLabel(n.optionGroup)), 1)];
-					})], 16, bg)) : Vn((R(), z("li", W({
+						return [Va(O(a.getOptionGroupLabel(n.optionGroup)), 1)];
+					})], 16, vg)) : Bn((R(), z("li", W({
 						key: 1,
 						id: e.$id + "_" + a.getOptionIndex(r, c),
 						style: { height: f ? f + "px" : void 0 },
@@ -12219,21 +12220,21 @@ function Cg(e, t, n, r, i, a) {
 						selected: a.isSelected(n),
 						index: a.getOptionIndex(r, c)
 					}, function() {
-						return [Ha(O(a.getOptionLabel(n)), 1)];
-					})], 16, xg)), [[p]])], 64);
+						return [Va(O(a.getOptionLabel(n)), 1)];
+					})], 16, yg)), [[p]])], 64);
 				}), 128)), i.filterValue && (!s || s && s.length === 0) ? (R(), z("li", W({
 					key: 0,
 					class: e.cx("emptyMessage"),
 					role: "option"
 				}, e.ptm("emptyMessage")), [I(e.$slots, "emptyfilter", {}, function() {
-					return [Ha(O(a.emptyFilterMessageText), 1)];
+					return [Va(O(a.emptyFilterMessageText), 1)];
 				})], 16)) : !e.options || e.options && e.options.length === 0 ? (R(), z("li", W({
 					key: 1,
 					class: e.cx("emptyMessage"),
 					role: "option"
 				}, e.ptm("emptyMessage")), [I(e.$slots, "empty", {}, function() {
-					return [Ha(O(a.emptyMessageText), 1)];
-				})], 16)) : U("", !0)], 16, yg)];
+					return [Va(O(a.emptyMessageText), 1)];
+				})], 16)) : U("", !0)], 16, _g)];
 			}),
 			_: 2
 		}, [e.$slots.loader ? {
@@ -12276,13 +12277,13 @@ function Cg(e, t, n, r, i, a) {
 		}, e.ptm("hiddenLastFocusableEl"), {
 			"data-p-hidden-accessible": !0,
 			"data-p-hidden-focusable": !0
-		}), null, 16, Sg)
-	], 16, _g);
+		}), null, 16, bg)
+	], 16, hg);
 }
-gg.render = Cg;
+mg.render = xg;
 //#endregion
 //#region node_modules/primevue/tree/style/index.mjs
-var wg = X.extend({
+var Sg = X.extend({
 	name: "tree",
 	style: "\n    .p-tree {\n        display: block;\n        background: dt('tree.background');\n        color: dt('tree.color');\n        padding: dt('tree.padding');\n        position: relative;\n    }\n\n    .p-tree-root-children,\n    .p-tree-node-children {\n        display: flex;\n        list-style-type: none;\n        flex-direction: column;\n        margin: 0;\n        gap: dt('tree.gap');\n    }\n\n    .p-tree-root-children {\n        padding: 0;\n        padding-block-start: dt('tree.gap');\n    }\n\n    .p-tree-node-children {\n        padding: 0;\n        padding-block-start: dt('tree.gap');\n        padding-inline-start: dt('tree.indent');\n    }\n\n    .p-tree-node {\n        padding: 0;\n        outline: 0 none;\n    }\n\n    .p-tree-node-content {\n        border-radius: dt('tree.node.border.radius');\n        padding: dt('tree.node.padding');\n        display: flex;\n        align-items: center;\n        outline-color: transparent;\n        color: dt('tree.node.color');\n        gap: dt('tree.node.gap');\n        transition:\n            background dt('tree.transition.duration'),\n            color dt('tree.transition.duration'),\n            outline-color dt('tree.transition.duration'),\n            box-shadow dt('tree.transition.duration');\n    }\n\n    .p-tree-node-content[data-p-dragging] {\n        outline: 1px dashed dt('primary.color');\n        outline-offset: -1px;\n    }\n\n    .p-tree-node-content[data-pc-section=\"drag-image\"] {\n        background: dt('tree.background');\n    }\n\n    .p-tree-node:focus-visible > .p-tree-node-content {\n        box-shadow: dt('tree.node.focus.ring.shadow');\n        outline: dt('tree.node.focus.ring.width') dt('tree.node.focus.ring.style') dt('tree.node.focus.ring.color');\n        outline-offset: dt('tree.node.focus.ring.offset');\n    }\n\n    .p-tree-node-content.p-tree-node-selectable:not(.p-tree-node-selected):hover {\n        background: dt('tree.node.hover.background');\n        color: dt('tree.node.hover.color');\n    }\n\n    .p-tree-node-content.p-tree-node-selectable:not(.p-tree-node-selected):hover .p-tree-node-icon {\n        color: dt('tree.node.icon.hover.color');\n    }\n\n    .p-tree-node-content.p-tree-node-selected {\n        background: dt('tree.node.selected.background');\n        color: dt('tree.node.selected.color');\n    }\n\n    .p-tree-node-content.p-tree-node-selected .p-tree-node-toggle-button {\n        color: inherit;\n    }\n\n    .p-tree-node-content.p-tree-node-dragover {\n        background: dt('tree.node.hover.background');\n        color: dt('tree.node.hover.color');\n    }\n\n    .p-tree-node-content:focus-visible,\n    .p-tree-node-content.p-tree-node-contextmenu-selected {\n        box-shadow: dt('tree.node.focus.ring.shadow');\n        outline: dt('tree.node.focus.ring.width') dt('tree.node.focus.ring.style') dt('tree.node.focus.ring.color');\n        outline-offset: dt('tree.node.focus.ring.offset');\n    }\n\n    .p-tree-node-drop-point {\n		outline: 1px solid dt('primary.color');\n	}\n\n    .p-tree-node-toggle-button {\n        cursor: pointer;\n        user-select: none;\n        display: inline-flex;\n        align-items: center;\n        justify-content: center;\n        overflow: hidden;\n        position: relative;\n        flex-shrink: 0;\n        width: dt('tree.node.toggle.button.size');\n        height: dt('tree.node.toggle.button.size');\n        color: dt('tree.node.toggle.button.color');\n        border: 0 none;\n        background: transparent;\n        border-radius: dt('tree.node.toggle.button.border.radius');\n        transition:\n            background dt('tree.transition.duration'),\n            color dt('tree.transition.duration'),\n            border-color dt('tree.transition.duration'),\n            outline-color dt('tree.transition.duration'),\n            box-shadow dt('tree.transition.duration');\n        outline-color: transparent;\n        padding: 0;\n    }\n\n    .p-tree-node-toggle-button:enabled:hover {\n        background: dt('tree.node.toggle.button.hover.background');\n        color: dt('tree.node.toggle.button.hover.color');\n    }\n\n    .p-tree-node-content.p-tree-node-selected .p-tree-node-toggle-button:hover {\n        background: dt('tree.node.toggle.button.selected.hover.background');\n        color: dt('tree.node.toggle.button.selected.hover.color');\n    }\n\n    .p-tree-root {\n        overflow: auto;\n    }\n\n    .p-tree-node-selectable {\n        cursor: pointer;\n        user-select: none;\n    }\n\n    .p-tree-node-leaf > .p-tree-node-content .p-tree-node-toggle-button {\n        visibility: hidden;\n    }\n\n    .p-tree-node-icon {\n        color: dt('tree.node.icon.color');\n        transition: color dt('tree.transition.duration');\n    }\n\n    .p-tree-node-content.p-tree-node-selected .p-tree-node-icon {\n        color: dt('tree.node.icon.selected.color');\n    }\n\n    .p-tree-filter {\n        margin: dt('tree.filter.margin');\n    }\n\n    .p-tree-filter-input {\n        width: 100%;\n    }\n\n    .p-tree-loading-icon {\n        font-size: dt('tree.loading.icon.size');\n        width: dt('tree.loading.icon.size');\n        height: dt('tree.loading.icon.size');\n    }\n\n    .p-tree .p-tree-mask {\n        position: absolute;\n        z-index: 1;\n        display: flex;\n        align-items: center;\n        justify-content: center;\n    }\n\n    .p-tree-flex-scrollable {\n        display: flex;\n        flex: 1;\n        height: 100%;\n        flex-direction: column;\n    }\n\n    .p-tree-flex-scrollable .p-tree-root {\n        flex: 1;\n    }\n",
 	classes: {
@@ -12325,52 +12326,52 @@ var wg = X.extend({
 		emptyMessage: "p-tree-empty-message",
 		dropPoint: "p-tree-node-drop-point"
 	}
-}), Tg = {
+}), Cg = {
 	name: "ChevronRightIcon",
-	extends: ld
+	extends: sd
 };
-function Eg(e) {
-	return Ag(e) || kg(e) || Og(e) || Dg();
+function wg(e) {
+	return Og(e) || Dg(e) || Eg(e) || Tg();
 }
-function Dg() {
+function Tg() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Og(e, t) {
+function Eg(e, t) {
 	if (e) {
-		if (typeof e == "string") return jg(e, t);
+		if (typeof e == "string") return kg(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? jg(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? kg(e, t) : void 0;
 	}
 }
-function kg(e) {
+function Dg(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Ag(e) {
-	if (Array.isArray(e)) return jg(e);
+function Og(e) {
+	if (Array.isArray(e)) return kg(e);
 }
-function jg(e, t) {
+function kg(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Mg(e, t, n, r, i, a) {
+function Ag(e, t, n, r, i, a) {
 	return R(), z("svg", W({
 		width: "14",
 		height: "14",
 		viewBox: "0 0 14 14",
 		fill: "none",
 		xmlns: "http://www.w3.org/2000/svg"
-	}, e.pti()), Eg(t[0] ||= [V("path", {
+	}, e.pti()), wg(t[0] ||= [V("path", {
 		d: "M4.38708 13C4.28408 13.0005 4.18203 12.9804 4.08691 12.9409C3.99178 12.9014 3.9055 12.8433 3.83313 12.7701C3.68634 12.6231 3.60388 12.4238 3.60388 12.2161C3.60388 12.0084 3.68634 11.8091 3.83313 11.6622L8.50507 6.99022L3.83313 2.31827C3.69467 2.16968 3.61928 1.97313 3.62287 1.77005C3.62645 1.56698 3.70872 1.37322 3.85234 1.22959C3.99596 1.08597 4.18972 1.00371 4.3928 1.00012C4.59588 0.996539 4.79242 1.07192 4.94102 1.21039L10.1669 6.43628C10.3137 6.58325 10.3962 6.78249 10.3962 6.99022C10.3962 7.19795 10.3137 7.39718 10.1669 7.54416L4.94102 12.7701C4.86865 12.8433 4.78237 12.9014 4.68724 12.9409C4.59212 12.9804 4.49007 13.0005 4.38708 13Z",
 		fill: "currentColor"
 	}, null, -1)]), 16);
 }
-Tg.render = Mg;
+Cg.render = Ag;
 //#endregion
 //#region node_modules/primevue/tree/index.mjs
-var Ng = {
+var jg = {
 	name: "BaseTree",
-	extends: td,
+	extends: $u,
 	props: {
 		value: {
 			type: null,
@@ -12465,55 +12466,55 @@ var Ng = {
 			default: null
 		}
 	},
-	style: wg,
+	style: Sg,
 	provide: function() {
 		return {
 			$pcTree: this,
 			$parentInstance: this
 		};
 	}
-}, Pg = /* @__PURE__ */ Ht({
+}, Mg = /* @__PURE__ */ Vt({
 	isDragging: !1,
 	dragNode: null,
 	dragScope: null
-}), Fg = /* @__PURE__ */ new Set(), Ig = /* @__PURE__ */ new Set();
-function Lg() {
+}), Ng = /* @__PURE__ */ new Set(), Pg = /* @__PURE__ */ new Set();
+function Fg() {
 	return {
-		dragState: Pg,
+		dragState: Mg,
 		startDrag: function(e) {
-			Pg.isDragging = !0, Pg.dragNode = e.node, Pg.dragScope = e.scope, Fg.forEach(function(t) {
+			Mg.isDragging = !0, Mg.dragNode = e.node, Mg.dragScope = e.scope, Ng.forEach(function(t) {
 				return t(e);
 			});
 		},
 		stopDrag: function(e) {
-			Pg.isDragging = !1, Pg.dragNode = null, Pg.dragScope = null, Ig.forEach(function(t) {
+			Mg.isDragging = !1, Mg.dragNode = null, Mg.dragScope = null, Pg.forEach(function(t) {
 				return t(e);
 			});
 		},
 		onDragStart: function(e) {
-			return Fg.add(e), function() {
-				return Fg.delete(e);
+			return Ng.add(e), function() {
+				return Ng.delete(e);
 			};
 		},
 		onDragStop: function(e) {
-			return Ig.add(e), function() {
-				return Ig.delete(e);
+			return Pg.add(e), function() {
+				return Pg.delete(e);
 			};
 		}
 	};
 }
-function Rg(e) {
+function Ig(e) {
 	"@babel/helpers - typeof";
-	return Rg = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return Ig = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, Rg(e);
+	}, Ig(e);
 }
-function zg(e, t) {
+function Lg(e, t) {
 	var n = typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (!n) {
-		if (Array.isArray(e) || (n = Hg(e)) || t) {
+		if (Array.isArray(e) || (n = Bg(e)) || t) {
 			n && (e = n);
 			var r = 0, i = function() {};
 			return {
@@ -12553,31 +12554,31 @@ function zg(e, t) {
 		}
 	};
 }
-function Bg(e) {
-	return Wg(e) || Ug(e) || Hg(e) || Vg();
+function Rg(e) {
+	return Hg(e) || Vg(e) || Bg(e) || zg();
 }
-function Vg() {
+function zg() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function Hg(e, t) {
+function Bg(e, t) {
 	if (e) {
-		if (typeof e == "string") return Gg(e, t);
+		if (typeof e == "string") return Ug(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Gg(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? Ug(e, t) : void 0;
 	}
 }
-function Ug(e) {
+function Vg(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function Wg(e) {
-	if (Array.isArray(e)) return Gg(e);
+function Hg(e) {
+	if (Array.isArray(e)) return Ug(e);
 }
-function Gg(e, t) {
+function Ug(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function Kg(e, t) {
+function Wg(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -12587,43 +12588,43 @@ function Kg(e, t) {
 	}
 	return n;
 }
-function qg(e) {
+function Gg(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? Kg(Object(n), !0).forEach(function(t) {
-			Jg(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Kg(Object(n)).forEach(function(t) {
+		t % 2 ? Wg(Object(n), !0).forEach(function(t) {
+			Kg(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : Wg(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function Jg(e, t, n) {
-	return (t = Yg(t)) in e ? Object.defineProperty(e, t, {
+function Kg(e, t, n) {
+	return (t = qg(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function Yg(e) {
-	var t = Xg(e, "string");
-	return Rg(t) == "symbol" ? t : t + "";
+function qg(e) {
+	var t = Jg(e, "string");
+	return Ig(t) == "symbol" ? t : t + "";
 }
-function Xg(e, t) {
-	if (Rg(e) != "object" || !e) return e;
+function Jg(e, t) {
+	if (Ig(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (Rg(r) != "object") return r;
+		if (Ig(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var Zg = {
+var Yg = {
 	name: "TreeNode",
 	hostName: "Tree",
-	extends: td,
+	extends: $u,
 	emits: [
 		"node-toggle",
 		"node-click",
@@ -12723,7 +12724,7 @@ var Zg = {
 			} });
 		},
 		onClick: function(e) {
-			if (this.toggleClicked || Gc(e.target, "[data-pc-section=\"nodetogglebutton\"]") || Gc(e.target.parentElement, "[data-pc-section=\"nodetogglebutton\"]")) {
+			if (this.toggleClicked || Uc(e.target, "[data-pc-section=\"nodetogglebutton\"]") || Uc(e.target.parentElement, "[data-pc-section=\"nodetogglebutton\"]")) {
 				this.toggleClicked = !1;
 				return;
 			}
@@ -12789,7 +12790,7 @@ var Zg = {
 			}));
 		},
 		onArrowLeft: function(e) {
-			var t = Wc(e.currentTarget, "[data-pc-section=\"nodetogglebutton\"]");
+			var t = Hc(e.currentTarget, "[data-pc-section=\"nodetogglebutton\"]");
 			if (this.level === 0 && !this.expanded) return !1;
 			if (this.expanded && !this.leaf) return t.click(), !1;
 			var n = this.findBeforeClickableNode(e.currentTarget);
@@ -12807,7 +12808,7 @@ var Zg = {
 				if (r.key === t.key) return e;
 				if (r.children && r.children.length > 0) {
 					var i = n.removeNodeFromTree(r.children, t);
-					e.push(qg(qg({}, r), {}, { children: i }));
+					e.push(Gg(Gg({}, r), {}, { children: i }));
 				} else e.push(r);
 				return e;
 			}, []);
@@ -12817,13 +12818,13 @@ var Zg = {
 				return e.key === t;
 			});
 			return a === -1 ? e.map(function(e) {
-				return e.children && e.children.length > 0 ? qg(qg({}, e), {}, { children: i.insertNodeInSiblings(e.children, t, n, r) }) : e;
+				return e.children && e.children.length > 0 ? Gg(Gg({}, e), {}, { children: i.insertNodeInSiblings(e.children, t, n, r) }) : e;
 			}) : e.toSpliced(a + r, 0, n);
 		},
 		addNodeAsChild: function(e, t, n) {
 			var r = this;
 			return e.map(function(e) {
-				return e.key === t ? qg(qg({}, e), {}, { children: [].concat(Bg(e.children || []), [n]) }) : e.children && e.children.length > 0 ? qg(qg({}, e), {}, { children: r.addNodeAsChild(e.children, t, n) }) : e;
+				return e.key === t ? Gg(Gg({}, e), {}, { children: [].concat(Rg(e.children || []), [n]) }) : e.children && e.children.length > 0 ? Gg(Gg({}, e), {}, { children: r.addNodeAsChild(e.children, t, n) }) : e;
 			});
 		},
 		insertNodeOnDrop: function() {
@@ -12878,7 +12879,7 @@ var Zg = {
 			if (this.isNodeDraggable) {
 				e.dataTransfer.effectAllowed = "all", e.dataTransfer.setData("text", "data");
 				var t = e.currentTarget, n = t.cloneNode(!0), r = n.querySelector("[data-pc-section=\"nodetogglebutton\"]"), i = n.querySelector("[data-pc-name=\"pcnodecheckbox\"]");
-				t.setAttribute("data-p-dragging", "true"), n.style.width = Ic(t) + "px", n.style.height = Zc(t) + "px", n.setAttribute("data-pc-section", "drag-image"), r.style.visibility = "hidden", i?.remove(), document.body.appendChild(n), e.dataTransfer.setDragImage(n, 0, 0), setTimeout(function() {
+				t.setAttribute("data-p-dragging", "true"), n.style.width = Pc(t) + "px", n.style.height = Yc(t) + "px", n.setAttribute("data-pc-section", "drag-image"), r.style.visibility = "hidden", i?.remove(), document.body.appendChild(n), e.dataTransfer.setDragImage(n, 0, 0), setTimeout(function() {
 					return document.body.removeChild(n);
 				}, 0), this.$pcTree.dragDropService.startDrag({
 					node: this.node,
@@ -12911,23 +12912,23 @@ var Zg = {
 			});
 		},
 		setAllNodesTabIndexes: function() {
-			var e = Uc(this.$refs.currentNode.closest("[data-pc-section=\"rootchildren\"]"), "[role=\"treeitem\"]"), t = Bg(e).some(function(e) {
+			var e = Vc(this.$refs.currentNode.closest("[data-pc-section=\"rootchildren\"]"), "[role=\"treeitem\"]"), t = Rg(e).some(function(e) {
 				return e.getAttribute("aria-selected") === "true" || e.getAttribute("aria-checked") === "true";
 			});
-			if (Bg(e).forEach(function(e) {
+			if (Rg(e).forEach(function(e) {
 				e.tabIndex = -1;
 			}), t) {
-				var n = Bg(e).filter(function(e) {
+				var n = Rg(e).filter(function(e) {
 					return e.getAttribute("aria-selected") === "true" || e.getAttribute("aria-checked") === "true";
 				});
 				n[0].tabIndex = 0;
 				return;
 			}
-			Bg(e)[0].tabIndex = 0;
+			Rg(e)[0].tabIndex = 0;
 		},
 		setTabIndexForSelectionMode: function(e, t) {
 			if (this.selectionMode !== null) {
-				var n = Bg(Uc(this.$refs.currentNode.parentElement, "[role=\"treeitem\"]"));
+				var n = Rg(Vc(this.$refs.currentNode.parentElement, "[role=\"treeitem\"]"));
 				e.currentTarget.tabIndex = t === !1 ? -1 : 0, n.every(function(e) {
 					return e.tabIndex === -1;
 				}) && (n[0].tabIndex = 0);
@@ -12939,13 +12940,13 @@ var Zg = {
 		findBeforeClickableNode: function(e) {
 			var t = e.closest("ul").closest("li");
 			if (t) {
-				var n = Wc(t, "button");
+				var n = Hc(t, "button");
 				return n && n.style.visibility !== "hidden" ? t : this.findBeforeClickableNode(e.previousElementSibling);
 			}
 			return null;
 		},
 		toggleCheckbox: function() {
-			var e = this.selectionKeys ? qg({}, this.selectionKeys) : {}, t = !this.checked;
+			var e = this.selectionKeys ? Gg({}, this.selectionKeys) : {}, t = !this.checked;
 			this.propagateDown(this.node, t, e), this.$emit("checkbox-change", {
 				node: this.node,
 				check: t,
@@ -12957,7 +12958,7 @@ var Zg = {
 				checked: !0,
 				partialChecked: !1
 			} : delete n[e.key], e.children && e.children.length) {
-				var r = zg(e.children), i;
+				var r = Lg(e.children), i;
 				try {
 					for (r.s(); !(i = r.n()).done;) {
 						var a = i.value;
@@ -12971,7 +12972,7 @@ var Zg = {
 			}
 		},
 		propagateUp: function(e) {
-			var t = e.check, n = qg({}, e.selectionKeys), r = 0, i = !1, a = zg(this.node.children), o;
+			var t = e.check, n = Gg({}, e.selectionKeys), r = 0, i = !1, a = Lg(this.node.children), o;
 			try {
 				for (a.s(); !(o = a.n()).done;) {
 					var s = o.value;
@@ -13010,7 +13011,7 @@ var Zg = {
 		},
 		getParentNodeElement: function(e) {
 			var t = e.parentElement.parentElement;
-			return Gc(t, "role") === "treeitem" ? t : null;
+			return Uc(t, "role") === "treeitem" ? t : null;
 		},
 		focusNode: function(e) {
 			e.focus();
@@ -13082,15 +13083,15 @@ var Zg = {
 		}
 	},
 	components: {
-		Checkbox: Uf,
-		ChevronDownIcon: Ep,
-		ChevronRightIcon: Tg,
-		CheckIcon: pf,
-		MinusIcon: xf,
-		SpinnerIcon: ud
+		Checkbox: Vf,
+		ChevronDownIcon: wp,
+		ChevronRightIcon: Cg,
+		CheckIcon: df,
+		MinusIcon: yf,
+		SpinnerIcon: cd
 	},
-	directives: { ripple: Xd }
-}, Qg = [
+	directives: { ripple: Jd }
+}, Xg = [
 	"aria-label",
 	"aria-selected",
 	"aria-expanded",
@@ -13099,13 +13100,13 @@ var Zg = {
 	"aria-level",
 	"aria-checked",
 	"tabindex"
-], $g = [
+], Zg = [
 	"draggable",
 	"data-p-selected",
 	"data-p-selectable"
-], e_ = ["data-p-leaf"];
-function t_(e, t, n, r, i, a) {
-	var o = F("SpinnerIcon"), s = F("Checkbox"), c = F("TreeNode", !0), l = si("ripple");
+], Qg = ["data-p-leaf"];
+function $g(e, t, n, r, i, a) {
+	var o = F("SpinnerIcon"), s = F("Checkbox"), c = F("TreeNode", !0), l = oi("ripple");
 	return R(), z("li", W({
 		ref: "currentNode",
 		class: e.cx("node"),
@@ -13159,7 +13160,7 @@ function t_(e, t, n, r, i, a) {
 			"data-p-selected": a.checkboxMode ? a.checked : a.selected,
 			"data-p-selectable": a.selectable
 		}), [
-			Vn((R(), z("button", W({
+			Bn((R(), z("button", W({
 				type: "button",
 				class: e.cx("nodeToggleButton"),
 				onClick: t[0] ||= function() {
@@ -13167,7 +13168,7 @@ function t_(e, t, n, r, i, a) {
 				},
 				tabindex: "-1",
 				"data-p-leaf": a.leaf
-			}, a.getPTOptions("nodeToggleButton")), [n.node.loading && n.loadingMode === "icon" ? (R(), z(L, { key: 0 }, [n.templates.nodetoggleicon || n.templates.nodetogglericon ? (R(), B(oi(n.templates.nodetoggleicon || n.templates.nodetogglericon), {
+			}, a.getPTOptions("nodeToggleButton")), [n.node.loading && n.loadingMode === "icon" ? (R(), z(L, { key: 0 }, [n.templates.nodetoggleicon || n.templates.nodetogglericon ? (R(), B(ai(n.templates.nodetoggleicon || n.templates.nodetogglericon), {
 				key: 0,
 				node: n.node,
 				expanded: a.expanded,
@@ -13180,7 +13181,7 @@ function t_(e, t, n, r, i, a) {
 				key: 1,
 				spin: "",
 				class: e.cx("nodeToggleIcon")
-			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"]))], 64)) : (R(), z(L, { key: 1 }, [n.templates.nodetoggleicon || n.templates.togglericon ? (R(), B(oi(n.templates.nodetoggleicon || n.templates.togglericon), {
+			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"]))], 64)) : (R(), z(L, { key: 1 }, [n.templates.nodetoggleicon || n.templates.togglericon ? (R(), B(ai(n.templates.nodetoggleicon || n.templates.togglericon), {
 				key: 0,
 				node: n.node,
 				expanded: a.expanded,
@@ -13189,13 +13190,13 @@ function t_(e, t, n, r, i, a) {
 				"node",
 				"expanded",
 				"class"
-			])) : a.expanded ? (R(), B(oi(n.node.expandedIcon ? "span" : "ChevronDownIcon"), W({
+			])) : a.expanded ? (R(), B(ai(n.node.expandedIcon ? "span" : "ChevronDownIcon"), W({
 				key: 1,
 				class: e.cx("nodeToggleIcon")
-			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"])) : (R(), B(oi(n.node.collapsedIcon ? "span" : "ChevronRightIcon"), W({
+			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"])) : (R(), B(ai(n.node.collapsedIcon ? "span" : "ChevronRightIcon"), W({
 				key: 2,
 				class: e.cx("nodeToggleIcon")
-			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"]))], 64))], 16, e_)), [[l]]),
+			}, a.getPTOptions("nodeToggleIcon")), null, 16, ["class"]))], 64))], 16, Qg)), [[l]]),
 			a.checkboxMode ? (R(), B(s, {
 				key: 0,
 				defaultValue: a.checked,
@@ -13208,7 +13209,7 @@ function t_(e, t, n, r, i, a) {
 				"data-p-partialchecked": a.partialChecked
 			}, {
 				icon: P(function(e) {
-					return [n.templates.checkboxicon ? (R(), B(oi(n.templates.checkboxicon), {
+					return [n.templates.checkboxicon ? (R(), B(ai(n.templates.checkboxicon), {
 						key: 0,
 						checked: e.checked,
 						partialChecked: a.partialChecked,
@@ -13228,7 +13229,7 @@ function t_(e, t, n, r, i, a) {
 				"pt",
 				"data-p-partialchecked"
 			])) : U("", !0),
-			n.templates.nodeicon ? (R(), B(oi(n.templates.nodeicon), W({
+			n.templates.nodeicon ? (R(), B(ai(n.templates.nodeicon), W({
 				key: 1,
 				node: n.node,
 				class: [e.cx("nodeIcon")]
@@ -13236,7 +13237,7 @@ function t_(e, t, n, r, i, a) {
 				key: 2,
 				class: [e.cx("nodeIcon"), n.node.icon]
 			}, a.getPTOptions("nodeIcon")), null, 16)),
-			V("span", W({ class: e.cx("nodeLabel") }, a.getPTOptions("nodeLabel"), { onKeydown: t[1] ||= Fs(function() {}, ["stop"]) }), [n.templates[n.node.type] || n.templates.default ? (R(), B(oi(n.templates[n.node.type] || n.templates.default), {
+			V("span", W({ class: e.cx("nodeLabel") }, a.getPTOptions("nodeLabel"), { onKeydown: t[1] ||= Ns(function() {}, ["stop"]) }), [n.templates[n.node.type] || n.templates.default ? (R(), B(ai(n.templates[n.node.type] || n.templates.default), {
 				key: 0,
 				node: n.node,
 				expanded: a.expanded,
@@ -13245,8 +13246,8 @@ function t_(e, t, n, r, i, a) {
 				"node",
 				"expanded",
 				"selected"
-			])) : (R(), z(L, { key: 1 }, [Ha(O(a.label(n.node)), 1)], 64))], 16)
-		], 16, $g),
+			])) : (R(), z(L, { key: 1 }, [Va(O(a.label(n.node)), 1)], 64))], 16)
+		], 16, Zg),
 		a.isNextDropPointActive ? (R(), z("div", {
 			key: 1,
 			class: D(e.cx("dropPoint")),
@@ -13256,7 +13257,7 @@ function t_(e, t, n, r, i, a) {
 			key: 2,
 			class: e.cx("nodeChildren"),
 			role: "group"
-		}, e.ptm("nodeChildren")), [(R(!0), z(L, null, ui(n.node.children, function(r, i) {
+		}, e.ptm("nodeChildren")), [(R(!0), z(L, null, li(n.node.children, function(r, i) {
 			return R(), B(c, {
 				key: r.key,
 				node: r,
@@ -13312,21 +13313,21 @@ function t_(e, t, n, r, i, a) {
 				"pt"
 			]);
 		}), 128))], 16)) : U("", !0)
-	], 16, Qg);
+	], 16, Xg);
 }
-Zg.render = t_;
-function n_(e) {
+Yg.render = $g;
+function e_(e) {
 	"@babel/helpers - typeof";
-	return n_ = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return e_ = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, n_(e);
+	}, e_(e);
 }
-function r_(e, t) {
+function t_(e, t) {
 	var n = typeof Symbol < "u" && e[Symbol.iterator] || e["@@iterator"];
 	if (!n) {
-		if (Array.isArray(e) || (n = o_(e)) || t) {
+		if (Array.isArray(e) || (n = i_(e)) || t) {
 			n && (e = n);
 			var r = 0, i = function() {};
 			return {
@@ -13366,31 +13367,31 @@ function r_(e, t) {
 		}
 	};
 }
-function i_(e) {
-	return c_(e) || s_(e) || o_(e) || a_();
+function n_(e) {
+	return o_(e) || a_(e) || i_(e) || r_();
 }
-function a_() {
+function r_() {
 	throw TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
 }
-function o_(e, t) {
+function i_(e, t) {
 	if (e) {
-		if (typeof e == "string") return l_(e, t);
+		if (typeof e == "string") return s_(e, t);
 		var n = {}.toString.call(e).slice(8, -1);
-		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? l_(e, t) : void 0;
+		return n === "Object" && e.constructor && (n = e.constructor.name), n === "Map" || n === "Set" ? Array.from(e) : n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? s_(e, t) : void 0;
 	}
 }
-function s_(e) {
+function a_(e) {
 	if (typeof Symbol < "u" && e[Symbol.iterator] != null || e["@@iterator"] != null) return Array.from(e);
 }
-function c_(e) {
-	if (Array.isArray(e)) return l_(e);
+function o_(e) {
+	if (Array.isArray(e)) return s_(e);
 }
-function l_(e, t) {
+function s_(e, t) {
 	(t == null || t > e.length) && (t = e.length);
 	for (var n = 0, r = Array(t); n < t; n++) r[n] = e[n];
 	return r;
 }
-function u_(e, t) {
+function c_(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -13400,42 +13401,42 @@ function u_(e, t) {
 	}
 	return n;
 }
-function d_(e) {
+function l_(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? u_(Object(n), !0).forEach(function(t) {
-			f_(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : u_(Object(n)).forEach(function(t) {
+		t % 2 ? c_(Object(n), !0).forEach(function(t) {
+			u_(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : c_(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function f_(e, t, n) {
-	return (t = p_(t)) in e ? Object.defineProperty(e, t, {
+function u_(e, t, n) {
+	return (t = d_(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function p_(e) {
-	var t = m_(e, "string");
-	return n_(t) == "symbol" ? t : t + "";
+function d_(e) {
+	var t = f_(e, "string");
+	return e_(t) == "symbol" ? t : t + "";
 }
-function m_(e, t) {
-	if (n_(e) != "object" || !e) return e;
+function f_(e, t) {
+	if (e_(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (n_(r) != "object") return r;
+		if (e_(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var h_ = {
+var p_ = {
 	name: "Tree",
-	extends: Ng,
+	extends: jg,
 	inheritAttrs: !1,
 	emits: [
 		"node-expand",
@@ -13484,7 +13485,7 @@ var h_ = {
 	methods: {
 		initDragDropService: function() {
 			var e = this;
-			this.dragDropService || (this.dragDropService = Lg(), this.dragStartCleanup = this.dragDropService.onDragStart(function(t) {
+			this.dragDropService || (this.dragDropService = Fg(), this.dragStartCleanup = this.dragDropService.onDragStart(function(t) {
 				e.dragNode = t.node, e.dragNodeSubNodes = t.subNodes, e.dragNodeIndex = t.index, e.dragNodeScope = t.scope;
 			}), this.dragStopCleanup = this.dragDropService.onDragStop(function() {
 				e.dragNode = null, e.dragNodeSubNodes = null, e.dragNodeIndex = null, e.dragNodeScope = null, e.dragHover = !1;
@@ -13495,7 +13496,7 @@ var h_ = {
 		},
 		onNodeToggle: function(e) {
 			var t = e.key;
-			this.d_expandedKeys[t] ? (delete this.d_expandedKeys[t], this.$emit("node-collapse", e)) : (this.d_expandedKeys[t] = !0, this.$emit("node-expand", e)), this.d_expandedKeys = d_({}, this.d_expandedKeys), this.$emit("update:expandedKeys", this.d_expandedKeys);
+			this.d_expandedKeys[t] ? (delete this.d_expandedKeys[t], this.$emit("node-collapse", e)) : (this.d_expandedKeys[t] = !0, this.$emit("node-expand", e)), this.d_expandedKeys = l_({}, this.d_expandedKeys), this.$emit("update:expandedKeys", this.d_expandedKeys);
 		},
 		onNodeClick: function(e) {
 			if (this.selectionMode != null && e.node.selectable !== !1) {
@@ -13508,11 +13509,11 @@ var h_ = {
 		},
 		handleSelectionWithMetaKey: function(e) {
 			var t = e.originalEvent, n = e.node, r = t.metaKey || t.ctrlKey, i = this.isNodeSelected(n), a;
-			return i && r ? (this.isSingleSelectionMode() ? a = {} : (a = d_({}, this.selectionKeys), delete a[n.key]), this.$emit("node-unselect", n)) : (this.isSingleSelectionMode() ? a = {} : this.isMultipleSelectionMode() && (a = r && this.selectionKeys ? d_({}, this.selectionKeys) : {}), a[n.key] = !0, this.$emit("node-select", n)), a;
+			return i && r ? (this.isSingleSelectionMode() ? a = {} : (a = l_({}, this.selectionKeys), delete a[n.key]), this.$emit("node-unselect", n)) : (this.isSingleSelectionMode() ? a = {} : this.isMultipleSelectionMode() && (a = r && this.selectionKeys ? l_({}, this.selectionKeys) : {}), a[n.key] = !0, this.$emit("node-select", n)), a;
 		},
 		handleSelectionWithoutMetaKey: function(e) {
 			var t = e.node, n = this.isNodeSelected(t), r;
-			return this.isSingleSelectionMode() ? n ? (r = {}, this.$emit("node-unselect", t)) : (r = {}, r[t.key] = !0, this.$emit("node-select", t)) : n ? (r = d_({}, this.selectionKeys), delete r[t.key], this.$emit("node-unselect", t)) : (r = this.selectionKeys ? d_({}, this.selectionKeys) : {}, r[t.key] = !0, this.$emit("node-select", t)), r;
+			return this.isSingleSelectionMode() ? n ? (r = {}, this.$emit("node-unselect", t)) : (r = {}, r[t.key] = !0, this.$emit("node-select", t)) : n ? (r = l_({}, this.selectionKeys), delete r[t.key], this.$emit("node-unselect", t)) : (r = this.selectionKeys ? l_({}, this.selectionKeys) : {}, r[t.key] = !0, this.$emit("node-select", t)), r;
 		},
 		isSingleSelectionMode: function() {
 			return this.selectionMode === "single";
@@ -13540,12 +13541,12 @@ var h_ = {
 			if (e) {
 				var n = !1;
 				if (e.children) {
-					var r = i_(e.children);
+					var r = n_(e.children);
 					e.children = [];
-					var i = r_(r), a;
+					var i = t_(r), a;
 					try {
 						for (i.s(); !(a = i.n()).done;) {
-							var o = a.value, s = d_({}, o);
+							var o = a.value, s = l_({}, o);
 							this.isFilterMatched(s, t) && (n = !0, e.children.push(s));
 						}
 					} catch (e) {
@@ -13558,11 +13559,11 @@ var h_ = {
 			}
 		},
 		isFilterMatched: function(e, t) {
-			var n = t.searchFields, r = t.filterText, i = t.strict, a = !1, o = r_(n), s;
+			var n = t.searchFields, r = t.filterText, i = t.strict, a = !1, o = t_(n), s;
 			try {
 				for (o.s(); !(s = o.n()).done;) {
 					var c = s.value;
-					String(ec(e, c)).toLocaleLowerCase(this.filterLocale).indexOf(r) > -1 && (a = !0);
+					String(Qs(e, c)).toLocaleLowerCase(this.filterLocale).indexOf(r) > -1 && (a = !0);
 				}
 			} catch (e) {
 				o.e(e);
@@ -13589,7 +13590,7 @@ var h_ = {
 		},
 		isDescendantOf: function(e, t) {
 			if (!e || !e.children) return !1;
-			var n = r_(e.children), r;
+			var n = t_(e.children), r;
 			try {
 				for (n.s(); !(r = n.n()).done;) {
 					var i = r.value;
@@ -13617,7 +13618,7 @@ var h_ = {
 			} else if (Array.isArray(t)) {
 				if (typeof e == "string") return t.indexOf(e) !== -1;
 				if (Array.isArray(e)) {
-					var n = r_(e), r;
+					var n = t_(e), r;
 					try {
 						for (n.s(); !(r = n.n()).done;) {
 							var i = r.value;
@@ -13663,7 +13664,7 @@ var h_ = {
 		},
 		processTreeDrop: function(e, t) {
 			this.dragNodeSubNodes.splice(t, 1);
-			var n = [].concat(i_(this.value || []), [e]);
+			var n = [].concat(n_(this.value || []), [e]);
 			this.$emit("update:value", n), this.dragDropService.stopDrag({ node: e });
 		},
 		onDrop: function(e) {
@@ -13699,10 +13700,10 @@ var h_ = {
 	},
 	computed: {
 		filteredValue: function() {
-			var e = [], t = $s(this.filterBy) ? [this.filterBy] : this.filterBy.split(","), n = this.filterValue.trim().toLocaleLowerCase(this.filterLocale), r = this.filterMode === "strict", i = r_(this.value), a;
+			var e = [], t = Zs(this.filterBy) ? [this.filterBy] : this.filterBy.split(","), n = this.filterValue.trim().toLocaleLowerCase(this.filterLocale), r = this.filterMode === "strict", i = t_(this.value), a;
 			try {
 				for (i.s(); !(a = i.n()).done;) {
-					var o = a.value, s = d_({}, o), c = {
+					var o = a.value, s = l_({}, o), c = {
 						searchFields: t,
 						filterText: n,
 						strict: r
@@ -13737,23 +13738,23 @@ var h_ = {
 		}
 	},
 	components: {
-		TreeNode: Zg,
-		InputText: $f,
-		InputIcon: Qp,
-		IconField: Xp,
-		SearchIcon: Pp,
-		SpinnerIcon: ud
+		TreeNode: Yg,
+		InputText: Zf,
+		InputIcon: Xp,
+		IconField: Jp,
+		SearchIcon: Mp,
+		SpinnerIcon: cd
 	}
 };
-function g_(e) {
+function m_(e) {
 	"@babel/helpers - typeof";
-	return g_ = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
+	return m_ = typeof Symbol == "function" && typeof Symbol.iterator == "symbol" ? function(e) {
 		return typeof e;
 	} : function(e) {
 		return e && typeof Symbol == "function" && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
-	}, g_(e);
+	}, m_(e);
 }
-function __(e, t) {
+function h_(e, t) {
 	var n = Object.keys(e);
 	if (Object.getOwnPropertySymbols) {
 		var r = Object.getOwnPropertySymbols(e);
@@ -13763,41 +13764,41 @@ function __(e, t) {
 	}
 	return n;
 }
-function v_(e) {
+function g_(e) {
 	for (var t = 1; t < arguments.length; t++) {
 		var n = arguments[t] == null ? {} : arguments[t];
-		t % 2 ? __(Object(n), !0).forEach(function(t) {
-			y_(e, t, n[t]);
-		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : __(Object(n)).forEach(function(t) {
+		t % 2 ? h_(Object(n), !0).forEach(function(t) {
+			__(e, t, n[t]);
+		}) : Object.getOwnPropertyDescriptors ? Object.defineProperties(e, Object.getOwnPropertyDescriptors(n)) : h_(Object(n)).forEach(function(t) {
 			Object.defineProperty(e, t, Object.getOwnPropertyDescriptor(n, t));
 		});
 	}
 	return e;
 }
-function y_(e, t, n) {
-	return (t = b_(t)) in e ? Object.defineProperty(e, t, {
+function __(e, t, n) {
+	return (t = v_(t)) in e ? Object.defineProperty(e, t, {
 		value: n,
 		enumerable: !0,
 		configurable: !0,
 		writable: !0
 	}) : e[t] = n, e;
 }
-function b_(e) {
-	var t = x_(e, "string");
-	return g_(t) == "symbol" ? t : t + "";
+function v_(e) {
+	var t = y_(e, "string");
+	return m_(t) == "symbol" ? t : t + "";
 }
-function x_(e, t) {
-	if (g_(e) != "object" || !e) return e;
+function y_(e, t) {
+	if (m_(e) != "object" || !e) return e;
 	var n = e[Symbol.toPrimitive];
 	if (n !== void 0) {
 		var r = n.call(e, t);
-		if (g_(r) != "object") return r;
+		if (m_(r) != "object") return r;
 		throw TypeError("@@toPrimitive must return a primitive value.");
 	}
 	return (t === "string" ? String : Number)(e);
 }
-var S_ = ["data-p"], C_ = ["data-p"], w_ = ["aria-labelledby", "aria-label"];
-function T_(e, t, n, r, i, a) {
+var b_ = ["data-p"], x_ = ["data-p"], S_ = ["aria-labelledby", "aria-label"];
+function C_(e, t, n, r, i, a) {
 	var o = F("SpinnerIcon"), s = F("InputText"), c = F("SearchIcon"), l = F("InputIcon"), u = F("IconField"), d = F("TreeNode");
 	return R(), z("div", W({
 		class: e.cx("root"),
@@ -13815,7 +13816,7 @@ function T_(e, t, n, r, i, a) {
 		},
 		"data-p": a.containerDataP
 	}, e.ptmi("root")), [
-		H(jo, { name: "p-overlay-mask" }, {
+		H(Ao, { name: "p-overlay-mask" }, {
 			default: P(function() {
 				return [e.loading && e.loadingMode === "mask" ? (R(), z("div", W({
 					key: 0,
@@ -13840,7 +13841,7 @@ function T_(e, t, n, r, i, a) {
 		e.filter ? (R(), B(u, {
 			key: 0,
 			unstyled: e.unstyled,
-			pt: v_(v_({}, e.ptm("pcFilter")), e.ptm("pcFilterContainer")),
+			pt: g_(g_({}, e.ptm("pcFilter")), e.ptm("pcFilterContainer")),
 			class: D(e.cx("pcFilterContainer"))
 		}, {
 			default: P(function() {
@@ -13894,14 +13895,14 @@ function T_(e, t, n, r, i, a) {
 				key: 1,
 				class: e.cx("emptyMessage")
 			}, e.ptm("emptyMessage")), [I(e.$slots, "empty", {}, function() {
-				return [Ha(O(a.emptyMessageText), 1)];
+				return [Va(O(a.emptyMessageText), 1)];
 			})], 16)) : U("", !0) : (R(), z("ul", W({
 				key: 0,
 				class: e.cx("rootChildren"),
 				role: "tree",
 				"aria-labelledby": e.ariaLabelledby,
 				"aria-label": e.ariaLabel
-			}, e.ptm("rootChildren")), [(R(!0), z(L, null, ui(a.valueToRender, function(t, n) {
+			}, e.ptm("rootChildren")), [(R(!0), z(L, null, li(a.valueToRender, function(t, n) {
 				return R(), B(d, {
 					key: t.key,
 					node: t,
@@ -13950,15 +13951,15 @@ function T_(e, t, n, r, i, a) {
 					"unstyled",
 					"pt"
 				]);
-			}), 128))], 16, w_)),
+			}), 128))], 16, S_)),
 			I(e.$slots, "footer", {
 				value: e.value,
 				expandedKeys: e.expandedKeys,
 				selectionKeys: e.selectionKeys
 			})
-		], 16, C_)
-	], 16, S_);
+		], 16, x_)
+	], 16, b_);
 }
-h_.render = T_;
+p_.render = C_;
 //#endregion
-export { Xt as $, Ha as A, R as B, L as C, B as D, V as E, Wn as F, Yn as G, ui as H, An as I, Vn as J, Jn as K, Zr as L, Rr as M, Xa as N, U as O, Gn as P, M as Q, Jr as R, Fs as S, ho as T, I as U, Un as V, F as W, Ae as X, ke as Y, Kt as Z, Vs as _, $m as a, j as at, Yo as b, dm as c, an as ct, Uf as d, O as dt, je as et, lf as f, Mu as g, Fu as h, Ah as i, en as it, H as j, z as k, cp as l, D as lt, Ru as m, gg as n, $t as nt, Um as o, cn as ot, wd as p, P as q, rg as r, Ut as rt, Om as s, rn as st, h_ as t, Ht as tt, $f as u, pe as ut, As as v, ur as w, Ls as x, ks as y, Qr as z };
+export { Yt as $, Va as A, R as B, L as C, B as D, V as E, Un as F, Jn as G, li as H, kn as I, Bn as J, qn as K, Xr as L, Lr as M, Ya as N, U as O, Wn as P, M as Q, qr as R, Ns as S, mo as T, I as U, Hn as V, F as W, Ae as X, ke as Y, Gt as Z, zs as _, Zm as a, j as at, Jo as b, lm as c, rn as ct, Vf as d, O as dt, je as et, sf as f, Au as g, Nu as h, Oh as i, $t as it, H as j, z as k, op as l, D as lt, Iu as m, mg as n, Qt as nt, Vm as o, sn as ot, Sd as p, P as q, tg as r, Ht as rt, Em as s, nn as st, p_ as t, Vt as tt, Zf as u, pe as ut, Os as v, lr as w, Fs as x, Ds as y, Zr as z };

--- a/dist/chunks/mjr-vue-vendor-B7WqP-K6.js
+++ b/dist/chunks/mjr-vue-vendor-B7WqP-K6.js
@@ -1,4 +1,4 @@
-import { $ as e, F as t, G as n, I as r, P as i, Q as a, T as o, X as s, Y as c, Z as l, at as u, et as d, nt as f, ot as p, tt as m } from "./mjr-primevue-n1rsQYJg.js";
+import { $ as e, F as t, G as n, I as r, P as i, Q as a, T as o, X as s, Y as c, Z as l, at as u, et as d, nt as f, ot as p, tt as m } from "./mjr-primevue-BOCpq3qH.js";
 //#region node_modules/pinia/dist/pinia.mjs
 var h = typeof window < "u", g, _ = (e) => g = e, v = () => i() && t(y) || g, y = Symbol();
 function b(e) {

--- a/dist/chunks/model3dRenderer-C365Y-Y-.js
+++ b/dist/chunks/model3dRenderer-C365Y-Y-.js
@@ -1,5 +1,5 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { m as t, mt as n, o as r, r as i } from "./events-CwzwyUFJ.js";
+import { m as t, mt as n, o as r, r as i } from "./events-C2U9lj7y.js";
 import { n as a } from "./state-DPiaUMw1.js";
 //#region ui/features/viewer/model3dCore.ts
 function o(e, t) {

--- a/dist/chunks/openMajoorSettings-D8Sa3D0W.js
+++ b/dist/chunks/openMajoorSettings-D8Sa3D0W.js
@@ -1,6 +1,6 @@
-import { A as e, E as t, J as n, R as r, S as i, Y as a, b as o, j as s, m as c } from "./events-CwzwyUFJ.js";
+import { A as e, E as t, J as n, R as r, S as i, Y as a, b as o, j as s, m as c } from "./events-C2U9lj7y.js";
 import { a as l, n as u } from "./graphTraversal-Sruu0ipL.js";
-import { J as d, b as f, v as p, x as ee, y as te } from "./SidebarWorkflowSection-B_0hBSuQ.js";
+import { J as d, b as f, v as p, x as ee, y as te } from "./SidebarWorkflowSection-2pSEjXh9.js";
 //#region ui/features/viewer/floatingViewerProgress.ts
 var m = "progress-update", h = "__MJR_MFV_PROGRESS_SERVICE__";
 function ne() {

--- a/dist/chunks/sideBySide-CEWLgiuN.js
+++ b/dist/chunks/sideBySide-CEWLgiuN.js
@@ -1,4 +1,4 @@
-import { i as e } from "./model3dRenderer-Bzlr-goo.js";
+import { i as e } from "./model3dRenderer-C365Y-Y-.js";
 import { i as t, o as n } from "./geninfoParser-D91g5NYg.js";
 //#region ui/features/viewer/sideBySide.ts
 function r(e) {

--- a/dist/chunks/viewerOpenRequest-BcaSPESm.js
+++ b/dist/chunks/viewerOpenRequest-BcaSPESm.js
@@ -1,6 +1,6 @@
 import { t as e } from "./rolldown-runtime-Dy4uBu1J.js";
-import { r as t } from "./events-CwzwyUFJ.js";
-import { t as n } from "./Viewer--Cuhs0TQ.js";
+import { r as t } from "./events-C2U9lj7y.js";
+import { t as n } from "./Viewer-pHo9CcXS.js";
 //#region ui/features/viewer/viewerOpenRequest.ts
 var r = /* @__PURE__ */ e({ requestViewerOpen: () => o });
 function i(e) {

--- a/dist/chunks/viewerRuntimeHosts-P4vwR-ik.js
+++ b/dist/chunks/viewerRuntimeHosts-P4vwR-ik.js
@@ -1,4 +1,4 @@
-import { Ct as e, St as t, _t as n, gt as r, ht as i, k as a, m as o, nt as s, o as c, tt as l, vt as u, xt as d } from "./events-CwzwyUFJ.js";
+import { Ct as e, St as t, _t as n, gt as r, ht as i, k as a, m as o, nt as s, o as c, tt as l, vt as u, xt as d } from "./events-C2U9lj7y.js";
 //#region ui/app/settingsStore.ts
 var f = "mjrSettings", p = "mjrMinimapSettings", m = new Set([
 	"POST",
@@ -395,7 +395,7 @@ function ge(e) {
 function _e(e, t, n) {
 	return e && t ? `${e}: ${t}` : t || e || n || "";
 }
-function k(e, t = "info", n = null) {
+function ve(e, t = "info", n = null) {
 	if (!e || typeof e != "object") return null;
 	let r = O(e.title || e.summary), i = O(e.detail), a = O(e.message || _e(r, i, O(e.fallbackMessage)));
 	if (!a) return null;
@@ -419,24 +419,24 @@ function k(e, t = "info", n = null) {
 		actionUrl: O(e.actionUrl)
 	};
 }
-function A() {
+function k() {
 	if (D === null) try {
 		let e = localStorage.getItem(ue), t = e ? JSON.parse(e) : [];
 		D = Array.isArray(t) ? t.map((e) => {
-			if (e && typeof e == "object") return k(e);
+			if (e && typeof e == "object") return ve(e);
 			let t = O(e);
-			return t ? k({ message: t }) : null;
+			return t ? ve({ message: t }) : null;
 		}).filter(Boolean) : [];
 	} catch {
 		D = [];
 	}
 }
-function ve() {
+function ye() {
 	try {
 		localStorage.setItem(ue, JSON.stringify(D));
 	} catch {}
 }
-function ye() {
+function A() {
 	try {
 		window.dispatchEvent(new CustomEvent(pe));
 	} catch {}
@@ -454,8 +454,8 @@ function xe(e) {
 	} catch {}
 }
 function Se(e, t, n) {
-	A();
-	let r = k(e && typeof e == "object" ? e : {
+	k();
+	let r = ve(e && typeof e == "object" ? e : {
 		message: O(e),
 		type: t,
 		durationMs: n
@@ -469,21 +469,21 @@ function Se(e, t, n) {
 			D.splice(e, 1), r.id = String(t.id || r.id || "").trim() || r.id;
 		}
 	}
-	D.unshift(r), D.length > fe && (D = D.slice(0, fe)), ve(), ye();
+	D.unshift(r), D.length > fe && (D = D.slice(0, fe)), ye(), A();
 }
 function Ce() {
-	return A(), D.map((e) => ({ ...e }));
+	return k(), D.map((e) => ({ ...e }));
 }
 function we() {
-	A();
+	k();
 	let e = be();
 	return D.filter((t) => t.createdAt > e).length;
 }
 function Te() {
-	xe(Date.now()), ye();
+	xe(Date.now()), A();
 }
 function Ee() {
-	A(), D = [], ve(), xe(Date.now()), ye();
+	k(), D = [], ye(), xe(Date.now()), A();
 }
 //#endregion
 //#region ui/app/toast.ts
@@ -491,7 +491,7 @@ function De(e) {
 	let t = String(e || "info").trim().toLowerCase();
 	return t === "warn" ? "warning" : t === "danger" ? "error" : t === "success" || t === "warning" || t === "error" ? t : "info";
 }
-function Oe(e) {
+function j(e) {
 	if (typeof e == "string") return e;
 	if (e && typeof e == "object") {
 		let t = String(e.summary || "").trim(), n = String(e.detail || e.message || "").trim();
@@ -505,7 +505,7 @@ function Oe(e) {
 		return "Unknown message";
 	}
 }
-function ke(e, t, n, r) {
+function Oe(e, t, n, r) {
 	let i = r?.history && typeof r.history == "object" ? r.history : null, a = {
 		persistent: !(Number.isFinite(Number(n)) && Number(n) > 0),
 		source: String(i?.source || r?.source || "").trim(),
@@ -517,15 +517,15 @@ function ke(e, t, n, r) {
 		actionLabel: String(i?.actionLabel || "").trim(),
 		actionUrl: String(i?.actionUrl || "").trim()
 	};
-	return e && typeof e == "object" ? (a.title = String(i?.title || e.summary || "").trim(), a.detail = String(i?.detail || e.detail || e.message || "").trim(), a.message = Oe(e), a) : (a.title = String(i?.title || "").trim(), a.detail = String(i?.detail || "").trim(), a.message = Oe(e), a);
+	return e && typeof e == "object" ? (a.title = String(i?.title || e.summary || "").trim(), a.detail = String(i?.detail || e.detail || e.message || "").trim(), a.message = j(e), a) : (a.title = String(i?.title || "").trim(), a.detail = String(i?.detail || "").trim(), a.message = j(e), a);
 }
-function Ae(e, t = "info", n, r) {
+function ke(e, t = "info", n, r) {
 	try {
-		let i = ke(e, t, n, r);
+		let i = Oe(e, t, n, r);
 		i.forceStore = !0, Se(i, t, n ?? void 0);
 	} catch {}
 }
-function je(e) {
+function Ae(e) {
 	switch (e) {
 		case "success": return 2e3;
 		case "info": return 3e3;
@@ -534,7 +534,7 @@ function je(e) {
 		default: return 5e3;
 	}
 }
-function Me(e) {
+function je(e) {
 	if (typeof e != "string") return e;
 	let t = e.trim(), n = {
 		"Failed to update rating": o("toast.ratingUpdateFailed", "Failed to update rating"),
@@ -661,9 +661,9 @@ function Me(e) {
 	}
 	return t;
 }
-function j(e, t = "info", n, r) {
-	if (t = De(t), e = Me(e), n ??= je(t), !r?.noHistory) try {
-		Se(ke(e, t, n, r), t, n ?? void 0);
+function M(e, t = "info", n, r) {
+	if (t = De(t), e = je(e), n ??= Ae(t), !r?.noHistory) try {
+		Se(Oe(e, t, n, r), t, n ?? void 0);
 	} catch {}
 	let i = !(Number.isFinite(Number(n)) && Number(n) > 0);
 	try {
@@ -697,23 +697,23 @@ function j(e, t = "info", n, r) {
 	}
 	console.warn("[Majoor Toast] Native toast API unavailable", {
 		type: t,
-		message: Oe(e),
+		message: j(e),
 		duration: i ? 0 : n
 	});
 }
 //#endregion
 //#region ui/api/clientAuth.ts
-var Ne = 2e3, Pe = 15e3, Fe = 8e3, M = "token", N = null, P = null, Ie = null, Le = "", F = E({
-	ttlMs: Ne,
+var Me = 2e3, Ne = 15e3, Pe = 8e3, N = "token", P = null, F = null, Fe = null, Ie = "", I = E({
+	ttlMs: Me,
 	maxSize: 1
 });
+function Le() {
+	return String(Ie || "").trim();
+}
+function L(e) {
+	return Ie = String(e || "").trim(), !0;
+}
 function Re() {
-	return String(Le || "").trim();
-}
-function I(e) {
-	return Le = String(e || "").trim(), !0;
-}
-function ze() {
 	try {
 		let e = localStorage?.getItem?.(f), t = e ? JSON.parse(e) : {}, n = t && typeof t == "object" ? t : {}, r = n?.data && typeof n.data == "object" ? n.data : n;
 		r?.security && typeof r.security == "object" && String(r.security.apiToken || "").trim() && (r.security.apiToken = "", localStorage?.setItem?.(f, JSON.stringify(n)));
@@ -721,23 +721,23 @@ function ze() {
 		console.debug?.(e);
 	}
 }
-function Be() {
+function ze() {
 	try {
-		F.delete(M);
+		I.delete(N);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	I(""), ze();
+	L(""), Re();
 }
-function L() {
-	let e = F.get(M);
+function R() {
+	let e = I.get(N);
 	if (e !== void 0) return e;
-	let t = Date.now(), n = Re();
-	if (n) return F.set(M, n, { at: t }), n;
+	let t = Date.now(), n = Le();
+	if (n) return I.set(N, n, { at: t }), n;
 	try {
 		let e = localStorage?.getItem?.(f), n = e ? JSON.parse(e) : null, r = n?.data && typeof n.data == "object" ? n.data : n, i = String(r?.security?.apiToken || "").trim();
 		if (i) {
-			I(i);
+			L(i);
 			try {
 				let e = n && typeof n == "object" ? n : {}, t = e?.data && typeof e.data == "object" ? e.data : e;
 				t?.security && typeof t.security == "object" && (t.security.apiToken = "", localStorage?.setItem?.(f, JSON.stringify(e)), window?.dispatchEvent?.(new CustomEvent("mjr-settings-changed", { detail: { key: "security.apiToken" } })));
@@ -745,16 +745,16 @@ function L() {
 				console.debug?.(e);
 			}
 		}
-		return F.set(M, i, { at: t }), i;
+		return I.set(N, i, { at: t }), i;
 	} catch {
-		return F.set(M, "", { at: t }), "";
+		return I.set(N, "", { at: t }), "";
 	}
 }
-function R(e) {
+function z(e) {
 	let t = String(e || "").trim();
 	if (!t) return !1;
 	try {
-		F.set(M, t), P = null, I(t), ze();
+		I.set(N, t), F = null, L(t), Re();
 		try {
 			window?.dispatchEvent?.(new CustomEvent("mjr-settings-changed", { detail: { key: "security.apiToken" } }));
 		} catch (e) {
@@ -765,43 +765,43 @@ function R(e) {
 		return !1;
 	}
 }
-var Ve = /^[A-Za-z0-9._\-~+/]+=*$/;
-function He(e) {
+var Be = /^[A-Za-z0-9._\-~+/]+=*$/;
+function Ve(e) {
 	let t = String(e || "").trim();
-	return t ? Ve.test(t) ? R(t) : (console.debug?.("[MJR auth] Rejected malformed security token (invalid characters)"), !1) : !1;
+	return t ? Be.test(t) ? z(t) : (console.debug?.("[MJR auth] Rejected malformed security token (invalid characters)"), !1) : !1;
 }
-function Ue() {
-	return !!L();
+function He() {
+	return !!R();
 }
-function z(e = {}) {
-	P = {
+function B(e = {}) {
+	F = {
 		code: String(e?.code || "").trim().toUpperCase(),
 		error: String(e?.error || "").trim(),
 		status: Number(e?.status || 0) || 0,
 		at: Date.now()
 	};
 }
-function We() {
-	let e = P;
+function Ue() {
+	let e = F;
 	if (!e) return null;
 	let t = Date.now() - (Number(e.at || 0) || 0);
-	return t < 0 || t > Pe ? (P = null, null) : e;
+	return t < 0 || t > Ne ? (F = null, null) : e;
 }
-function Ge(e) {
-	let t = We(), n = String(e?.code || "").trim().toUpperCase(), r = String(e?.error || "").trim(), i = String(t?.code || "").trim().toUpperCase(), a = String(t?.error || "").trim().toLowerCase(), s = r.toLowerCase();
+function We(e) {
+	let t = Ue(), n = String(e?.code || "").trim().toUpperCase(), r = String(e?.error || "").trim(), i = String(t?.code || "").trim().toUpperCase(), a = String(t?.error || "").trim().toLowerCase(), s = r.toLowerCase();
 	return n === "FORBIDDEN" && (s.includes("api token over insecure transport") || s.includes("allow http token transport")) ? o("toast.writeAuthInsecureTransport", "Write access is blocked because the Majoor API token is being sent over plain HTTP from a remote machine. Use HTTPS, or enable Settings -> Security -> Allow HTTP Token Transport for a trusted LAN.") : i === "FORBIDDEN" && (a.includes("already configured") || a.includes("rotate-token")) ? o("toast.writeAuthConfiguredTokenRequired", "Write access requires the Majoor API token already configured on the server. Open Settings -> Security -> API Token and enter the matching token.") : i === "AUTH_REQUIRED" && (a.includes("sign in to comfyui") || a.includes("authenticated comfyui user")) ? o("toast.writeAuthSignInRequired", "Write access is blocked. Sign in to ComfyUI first, then retry so Majoor can bootstrap the remote session token automatically.") : i === "BOOTSTRAP_DISABLED" || i === "AUTH_REQUIRED" && a.includes("bootstrap") || n === "AUTH_REQUIRED" && s.includes("api token") ? o("toast.writeAuthBootstrapHelp", "Write access is blocked. Sign in to ComfyUI and retry so Majoor can bootstrap the remote session automatically, or set a Majoor API token in Settings -> Security.") : "";
 }
-function Ke(e) {
+function Ge(e) {
 	let t = String(e || "").trim();
 	if (!t) return;
-	let n = Date.now(), r = Ie;
-	if (!(r && r.message === t && n - (Number(r.at || 0) || 0) < Fe)) {
-		Ie = {
+	let n = Date.now(), r = Fe;
+	if (!(r && r.message === t && n - (Number(r.at || 0) || 0) < Pe)) {
+		Fe = {
 			message: t,
 			at: n
 		};
 		try {
-			j({
+			M({
 				summary: o("toast.writeAuthTitle", "Majoor remote write access"),
 				detail: t
 			}, "warning", 6500, { noHistory: !0 });
@@ -810,16 +810,16 @@ function Ke(e) {
 		}
 	}
 }
-function qe(e) {
+function Ke(e) {
 	let t = String(e?.code || "").trim().toUpperCase(), n = String(e?.error || "").trim().toLowerCase(), r = t === "FORBIDDEN" && n.includes("write operation blocked");
 	if (t !== "AUTH_REQUIRED" && !r) return e;
-	let i = Ge(e);
-	return i ? (Ke(i), {
+	let i = We(e);
+	return i ? (Ge(i), {
 		...e,
 		error: i
 	}) : e;
 }
-async function Je() {
+async function qe() {
 	try {
 		let e = await fetch("/mjr/am/settings/security/bootstrap-token", {
 			method: "POST",
@@ -829,7 +829,7 @@ async function Je() {
 			},
 			body: "{}"
 		});
-		if (!(e.headers.get("content-type") || "").includes("application/json")) return z({
+		if (!(e.headers.get("content-type") || "").includes("application/json")) return B({
 			code: "INVALID_RESPONSE",
 			error: `Bootstrap token request returned non-JSON response (${e.status})`,
 			status: e.status
@@ -838,7 +838,7 @@ async function Je() {
 			token: !1
 		};
 		let t = await e.json().catch((e) => (console.debug?.("[MJR auth] JSON parse error:", e), null));
-		if (!t || typeof t != "object") return z({
+		if (!t || typeof t != "object") return B({
 			code: "INVALID_RESPONSE",
 			error: "Bootstrap token response was invalid.",
 			status: e.status
@@ -846,7 +846,7 @@ async function Je() {
 			ok: !1,
 			token: !1
 		};
-		if (!t.ok) return z({
+		if (!t.ok) return B({
 			code: t?.code,
 			error: t?.error,
 			status: e.status
@@ -856,14 +856,14 @@ async function Je() {
 		};
 		let n = String(t?.data?.token || "").trim();
 		return n ? {
-			ok: R(n),
+			ok: z(n),
 			token: !0
-		} : (P = null, {
+		} : (F = null, {
 			ok: !0,
 			token: !1
 		});
 	} catch (e) {
-		return z({
+		return B({
 			code: "NETWORK_ERROR",
 			error: e?.message || "Bootstrap token request failed.",
 			status: 0
@@ -873,141 +873,144 @@ async function Je() {
 		};
 	}
 }
-async function Ye({ force: e = !1, allowCookieRefresh: t = !1 } = {}) {
-	let n = L();
+async function Je({ force: e = !1, allowCookieRefresh: t = !1 } = {}) {
+	let n = R();
 	if (n && !e) return n;
 	let r = {
 		ok: !1,
 		token: !1
 	};
-	N ||= (async () => {
+	P ||= (async () => {
 		try {
-			return await Je();
+			return await qe();
 		} finally {
-			N = null;
+			P = null;
 		}
 	})();
 	try {
-		r = await N || r;
+		r = await P || r;
 	} catch (e) {
 		console.debug?.(e);
 	}
-	if (e && r?.ok && !r?.token && n) Be();
+	if (e && r?.ok && !r?.token && n) ze();
 	else if (e && !r?.ok) {
-		let e = We(), t = String(e?.code || "").trim().toUpperCase();
-		(!t || !["NETWORK_ERROR", "INVALID_RESPONSE"].includes(t)) && Be();
+		let e = Ue(), t = String(e?.code || "").trim().toUpperCase();
+		(!t || !["NETWORK_ERROR", "INVALID_RESPONSE"].includes(t)) && ze();
 	}
-	let i = L();
+	let i = R();
 	return !i && t && r?.ok ? !0 : i;
 }
-function Xe() {
-	F.clear();
+function Ye() {
+	I.clear();
 }
 //#endregion
 //#region ui/api/clientOps.ts
-async function Ze(e) {
+async function Xe(e) {
 	return !e || typeof e != "string" ? {
 		ok: !1,
 		error: "Missing mode",
 		code: "INVALID_INPUT"
-	} : q("/mjr/am/settings/probe-backend", { mode: e });
+	} : J("/mjr/am/settings/probe-backend", { mode: e });
 }
-async function Qe() {
-	return K(l.SETTINGS_METADATA_FALLBACK);
+async function Ze() {
+	return q(l.SETTINGS_METADATA_FALLBACK);
 }
-async function $e({ image: e, media: t } = {}) {
-	return q(l.SETTINGS_METADATA_FALLBACK, {
+async function Qe({ image: e, media: t } = {}) {
+	return J(l.SETTINGS_METADATA_FALLBACK, {
 		image: e,
 		media: t
 	});
 }
-async function et() {
-	return K(l.SETTINGS_VECTOR_SEARCH);
+async function $e() {
+	return q(l.SETTINGS_VECTOR_SEARCH);
 }
-async function tt(e = !0) {
+async function et(e = !0) {
 	if (e && typeof e == "object") {
 		let t = {};
-		return "enabled" in e && (t.enabled = !!e.enabled), "caption_on_index" in e && (t.caption_on_index = !!e.caption_on_index), "captionOnIndex" in e && (t.caption_on_index = !!e.captionOnIndex), "index_on_scan" in e && (t.index_on_scan = !!e.index_on_scan), "indexOnScan" in e && (t.index_on_scan = !!e.indexOnScan), "unload_after_use" in e && (t.unload_after_use = !!e.unload_after_use), "unloadAfterUse" in e && (t.unload_after_use = !!e.unloadAfterUse), "concurrency" in e && (t.concurrency = Number(e.concurrency) || 1), "vectorConcurrency" in e && (t.concurrency = Number(e.vectorConcurrency) || 1), q(l.SETTINGS_VECTOR_SEARCH, t);
+		return "enabled" in e && (t.enabled = !!e.enabled), "caption_on_index" in e && (t.caption_on_index = !!e.caption_on_index), "captionOnIndex" in e && (t.caption_on_index = !!e.captionOnIndex), "index_on_scan" in e && (t.index_on_scan = !!e.index_on_scan), "indexOnScan" in e && (t.index_on_scan = !!e.indexOnScan), "unload_after_use" in e && (t.unload_after_use = !!e.unload_after_use), "unloadAfterUse" in e && (t.unload_after_use = !!e.unloadAfterUse), "concurrency" in e && (t.concurrency = Number(e.concurrency) || 1), "vectorConcurrency" in e && (t.concurrency = Number(e.vectorConcurrency) || 1), J(l.SETTINGS_VECTOR_SEARCH, t);
 	}
-	return q(l.SETTINGS_VECTOR_SEARCH, { enabled: !!e });
+	return J(l.SETTINGS_VECTOR_SEARCH, { enabled: !!e });
+}
+async function tt() {
+	return J(l.SETTINGS_VECTOR_SEARCH_UNLOAD, {});
 }
 async function nt() {
-	return q(l.SETTINGS_VECTOR_SEARCH_UNLOAD, {});
+	return q(l.SETTINGS_EXECUTION_GROUPING);
 }
-async function rt() {
-	return K(l.SETTINGS_EXECUTION_GROUPING);
+async function rt(e = !0) {
+	return J(l.SETTINGS_EXECUTION_GROUPING, { enabled: !!e });
 }
 async function it(e = !0) {
-	return q(l.SETTINGS_EXECUTION_GROUPING, { enabled: !!e });
+	return J(l.SETTINGS_BROWSER_SHOW_FOLDERS, { enabled: !!e });
 }
 async function at() {
-	return K(l.SETTINGS_HUGGINGFACE);
+	return q(l.SETTINGS_HUGGINGFACE);
 }
 async function ot(e = "") {
-	return q(l.SETTINGS_HUGGINGFACE, { token: String(e ?? "").trim() });
+	return J(l.SETTINGS_HUGGINGFACE, { token: String(e ?? "").trim() });
 }
 async function st() {
-	return K(l.SETTINGS_AI_LOGGING);
+	return q(l.SETTINGS_AI_LOGGING);
 }
 async function ct(e = !1) {
-	return q(l.SETTINGS_AI_LOGGING, { enabled: !!e });
+	return J(l.SETTINGS_AI_LOGGING, { enabled: !!e });
 }
 async function lt() {
-	return K(l.SETTINGS_ROUTE_LOGGING);
+	return q(l.SETTINGS_ROUTE_LOGGING);
 }
 async function ut(e = !1) {
-	return q(l.SETTINGS_ROUTE_LOGGING, { enabled: !!e });
+	return J(l.SETTINGS_ROUTE_LOGGING, { enabled: !!e });
 }
 async function dt() {
-	return K(l.SETTINGS_STARTUP_LOGGING);
+	return q(l.SETTINGS_STARTUP_LOGGING);
 }
 async function ft(e = !1) {
-	return q(l.SETTINGS_STARTUP_LOGGING, { enabled: !!e });
+	return J(l.SETTINGS_STARTUP_LOGGING, { enabled: !!e });
 }
 async function pt() {
-	return K(l.SETTINGS_LTXAV_RGB_FALLBACK);
+	return q(l.SETTINGS_LTXAV_RGB_FALLBACK);
 }
 async function mt(e = !1) {
-	return q(l.SETTINGS_LTXAV_RGB_FALLBACK, { enabled: !!e });
+	return J(l.SETTINGS_LTXAV_RGB_FALLBACK, { enabled: !!e });
 }
 async function ht() {
-	return K(l.SETTINGS_JXL);
+	return q(l.SETTINGS_JXL);
 }
 async function gt(e = !1) {
-	return q(l.SETTINGS_JXL, { enabled: !!e });
+	return J(l.SETTINGS_JXL, { enabled: !!e });
 }
 async function _t() {
-	return K(l.SETTINGS_OUTPUT_DIRECTORY);
+	return q(l.SETTINGS_OUTPUT_DIRECTORY);
 }
 async function vt(e, t = {}) {
 	let n = String(e ?? "").trim();
-	return q(l.SETTINGS_OUTPUT_DIRECTORY, { output_directory: n }, t);
+	return J(l.SETTINGS_OUTPUT_DIRECTORY, { output_directory: n }, t);
 }
 async function yt() {
-	return K(l.SETTINGS_INDEX_DIRECTORY);
+	return q(l.SETTINGS_INDEX_DIRECTORY);
 }
 async function bt(e, t = {}) {
 	let n = String(e ?? "").trim();
-	return q(l.SETTINGS_INDEX_DIRECTORY, { index_directory: n }, t);
+	return J(l.SETTINGS_INDEX_DIRECTORY, { index_directory: n }, t);
 }
 async function xt(e = {}) {
-	return K(l.SETTINGS_WORKFLOW_ROOTS, e);
+	return q(l.SETTINGS_WORKFLOW_ROOTS, e);
 }
 async function St(e, t = {}) {
 	let n = Array.isArray(e) ? e.map((e) => String(e ?? "").trim()).filter(Boolean) : String(e ?? "").trim();
-	return q(l.SETTINGS_WORKFLOW_ROOTS, { workflow_roots: n }, t);
+	return J(l.SETTINGS_WORKFLOW_ROOTS, { workflow_roots: n }, t);
 }
 async function Ct() {
-	return K("/mjr/am/settings/security");
+	return q("/mjr/am/settings/security");
 }
 async function wt(e) {
-	return q("/mjr/am/settings/security", e && typeof e == "object" ? e : {});
+	return J("/mjr/am/settings/security", e && typeof e == "object" ? e : {});
 }
 async function Tt() {
-	let e = await q("/mjr/am/settings/security/bootstrap-token", {});
+	let e = await J("/mjr/am/settings/security/bootstrap-token", {});
 	if (e?.ok) try {
 		let t = String(e?.data?.token || "").trim();
-		t && R(t);
+		t && z(t);
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -1016,13 +1019,13 @@ async function Tt() {
 async function Et(e) {
 	if (e && typeof e == "object") {
 		let n = String(e.filepath || e.path || e?.file_info?.filepath || "").trim();
-		return n ? q("/mjr/am/open-in-folder", { filepath: n }) : q("/mjr/am/open-in-folder", { asset_id: t(e.id) });
+		return n ? J("/mjr/am/open-in-folder", { filepath: n }) : J("/mjr/am/open-in-folder", { asset_id: t(e.id) });
 	}
-	return q("/mjr/am/open-in-folder", { asset_id: t(e) });
+	return J("/mjr/am/open-in-folder", { asset_id: t(e) });
 }
 async function Dt(e) {
 	let t = "";
-	return t = e && typeof e == "object" ? String(e.filepath || e.path || e?.file_info?.filepath || "").trim() : String(e || "").trim(), t ? q(l.COLLECT_FILES, { filepath: t }) : {
+	return t = e && typeof e == "object" ? String(e.filepath || e.path || e?.file_info?.filepath || "").trim() : String(e || "").trim(), t ? J(l.COLLECT_FILES, { filepath: t }) : {
 		ok: !1,
 		data: null,
 		error: "Missing file path",
@@ -1034,7 +1037,7 @@ async function Ot({ op: e = "", path: t = "", name: n = "", destination: r = "",
 		op: String(e || "").trim().toLowerCase(),
 		path: String(t || "").trim()
 	};
-	return n != null && String(n).trim() && (o.name = String(n).trim()), r != null && String(r).trim() && (o.destination = String(r).trim()), o.op === "delete" && (o.recursive = !!i), q(l.BROWSER_FOLDER_OP, o, a);
+	return n != null && String(n).trim() && (o.name = String(n).trim()), r != null && String(r).trim() && (o.destination = String(r).trim()), o.op === "delete" && (o.recursive = !!i), J(l.BROWSER_FOLDER_OP, o, a);
 }
 async function kt(e = {}) {
 	let t = (e, t) => e == null ? t : !!e, n = String(e.scope || "output").trim().toLowerCase() || "output", r = e.customRootId ?? e.custom_root_id ?? e.rootId ?? e.root_id ?? e.customRoot ?? null, i = {
@@ -1052,52 +1055,52 @@ async function kt(e = {}) {
 		background_metadata: t(e.backgroundMetadata ?? e.background_metadata, !0),
 		maintenance_force: t(e.maintenanceForce ?? e.maintenance_force, !1)
 	};
-	return r && (i.custom_root_id = String(r)), q(l.INDEX_RESET, i);
+	return r && (i.custom_root_id = String(r)), J(l.INDEX_RESET, i);
 }
 async function At({ scope: e = "output", customRootId: t = "" } = {}) {
 	let n = String(e || "output").trim().toLowerCase() || "output", r = String(t || "").trim(), i = { scope: n };
-	return r && (i.custom_root_id = r), q(l.WATCHER_SCOPE, i);
+	return r && (i.custom_root_id = r), J(l.WATCHER_SCOPE, i);
 }
 async function jt(e = {}) {
-	return K(l.WATCHER_STATUS, e);
+	return q(l.WATCHER_STATUS, e);
 }
 async function Mt(e = !0) {
-	return q(l.WATCHER_TOGGLE, { enabled: !!e });
+	return J(l.WATCHER_TOGGLE, { enabled: !!e });
 }
 async function Nt() {
-	return K(l.WATCHER_SETTINGS);
+	return q(l.WATCHER_SETTINGS);
 }
 async function Pt(e = {}) {
-	return q(l.WATCHER_SETTINGS, e);
+	return J(l.WATCHER_SETTINGS, e);
 }
 async function Ft(e = {}) {
-	return K(l.TOOLS_STATUS, e);
+	return q(l.TOOLS_STATUS, e);
 }
 async function It(e = {}) {
-	return K(l.STATUS, e);
+	return q(l.STATUS, e);
 }
 async function Lt() {
-	return q("/mjr/am/db/force-delete", {});
+	return J("/mjr/am/db/force-delete", {});
 }
 async function Rt(e = {}) {
-	return K(l.DB_BACKUPS, e);
+	return q(l.DB_BACKUPS, e);
 }
 async function zt() {
-	return q(l.DB_BACKUP_SAVE, {});
+	return J(l.DB_BACKUP_SAVE, {});
 }
 async function Bt({ name: e = "", useLatest: t = !1 } = {}) {
 	let n = {};
-	return e && (n.name = String(e)), t && (n.use_latest = !0), q(l.DB_BACKUP_RESTORE, n);
+	return e && (n.name = String(e)), t && (n.use_latest = !0), J(l.DB_BACKUP_RESTORE, n);
 }
 async function Vt(e = 250) {
-	return q("/mjr/am/duplicates/analyze", { limit: Math.max(10, Math.min(5e3, Number(e) || 250)) });
+	return J("/mjr/am/duplicates/analyze", { limit: Math.max(10, Math.min(5e3, Number(e) || 250)) });
 }
 async function Ht({ scope: e = "output", customRootId: t = "", maxGroups: n = 6, maxPairs: r = 10 } = {}, i = {}) {
 	let a = `/mjr/am/duplicates/alerts?scope=${encodeURIComponent(String(e || "output"))}`;
-	return t && (a += `&custom_root_id=${encodeURIComponent(String(t))}`), a += `&max_groups=${encodeURIComponent(String(Math.max(1, Number(n) || 6)))}`, a += `&max_pairs=${encodeURIComponent(String(Math.max(1, Number(r) || 10)))}`, K(a, i);
+	return t && (a += `&custom_root_id=${encodeURIComponent(String(t))}`), a += `&max_groups=${encodeURIComponent(String(Math.max(1, Number(n) || 6)))}`, a += `&max_pairs=${encodeURIComponent(String(Math.max(1, Number(r) || 10)))}`, q(a, i);
 }
 async function Ut(e, t = []) {
-	return q("/mjr/am/duplicates/merge-tags", {
+	return J("/mjr/am/duplicates/merge-tags", {
 		keep_asset_id: Number(e) || 0,
 		merge_asset_ids: Array.isArray(t) ? t.map((e) => Number(e) || 0).filter((e) => e > 0) : []
 	});
@@ -1109,11 +1112,11 @@ async function Wt(e) {
 		let i = String(e.filepath || e.path || e?.file_info?.filepath || "").trim();
 		r = n ? { asset_id: n } : { filepath: i };
 	} else n = t(e), r = { asset_id: n };
-	let i = await q("/mjr/am/asset/delete", r);
+	let i = await J("/mjr/am/asset/delete", r);
 	return i?.ok && n && Kt([n]), i;
 }
 async function Gt(e) {
-	let n = Array.isArray(e) ? e.map((e) => t(e)).filter(Boolean) : [], r = await q("/mjr/am/assets/delete", { ids: n });
+	let n = Array.isArray(e) ? e.map((e) => t(e)).filter(Boolean) : [], r = await J("/mjr/am/assets/delete", { ids: n });
 	return r?.ok && Kt(n), r;
 }
 function Kt(e) {
@@ -1129,15 +1132,15 @@ async function qt(e, n) {
 	let r;
 	if (e && typeof e == "object") {
 		r = t(e.id);
-		let i = String(e.filepath || e.path || e?.file_info?.filepath || "").trim(), a = r ? await q("/mjr/am/asset/rename", {
+		let i = String(e.filepath || e.path || e?.file_info?.filepath || "").trim(), a = r ? await J("/mjr/am/asset/rename", {
 			asset_id: r,
 			new_name: n
-		}) : await q("/mjr/am/asset/rename", {
+		}) : await J("/mjr/am/asset/rename", {
 			filepath: i,
 			new_name: n
 		});
 		if (a?.ok && r) try {
-			let e = await J(r);
+			let e = await Mn(r);
 			e?.ok && e?.data && (a.data = {
 				...a.data || {},
 				asset: e.data
@@ -1148,12 +1151,12 @@ async function qt(e, n) {
 		return a;
 	}
 	r = t(e);
-	let i = await q("/mjr/am/asset/rename", {
+	let i = await J("/mjr/am/asset/rename", {
 		asset_id: r,
 		new_name: n
 	});
 	if (i?.ok && r) try {
-		let e = await J(r);
+		let e = await Mn(r);
 		e?.ok && e?.data && (i.data = {
 			...i.data || {},
 			asset: e.data
@@ -1166,29 +1169,29 @@ async function qt(e, n) {
 async function Jt() {
 	let e = typeof AbortController < "u" ? new AbortController() : null, t = null;
 	try {
-		return e && (t = setTimeout(() => e.abort(), 1e4)), await K("/mjr/am/collections", e ? { signal: e.signal } : {});
+		return e && (t = setTimeout(() => e.abort(), 1e4)), await q("/mjr/am/collections", e ? { signal: e.signal } : {});
 	} finally {
 		t && clearTimeout(t);
 	}
 }
 async function Yt(e) {
-	return q("/mjr/am/collections", { name: String(e || "").trim() });
+	return J("/mjr/am/collections", { name: String(e || "").trim() });
 }
 async function Xt(e) {
 	let t = String(e || "").trim();
-	return q(`/mjr/am/collections/${encodeURIComponent(t)}/delete`, {});
+	return J(`/mjr/am/collections/${encodeURIComponent(t)}/delete`, {});
 }
 async function Zt(e, t) {
 	let n = String(e || "").trim(), r = Array.isArray(t) ? t : [];
-	return q(`/mjr/am/collections/${encodeURIComponent(n)}/add`, { assets: r });
+	return J(`/mjr/am/collections/${encodeURIComponent(n)}/add`, { assets: r });
 }
 async function Qt(e, t) {
 	let n = String(e || "").trim(), r = Array.isArray(t) ? t : [];
-	return q(`/mjr/am/collections/${encodeURIComponent(n)}/remove`, { filepaths: r });
+	return J(`/mjr/am/collections/${encodeURIComponent(n)}/remove`, { filepaths: r });
 }
 async function $t(e) {
 	let t = String(e || "").trim();
-	return K(`/mjr/am/collections/${encodeURIComponent(t)}/assets`);
+	return q(`/mjr/am/collections/${encodeURIComponent(t)}/assets`);
 }
 async function en(e, t = 20) {
 	let n = String(e || "").trim();
@@ -1212,7 +1215,7 @@ async function en(e, t = 20) {
 		workflowId: r?.workflowId ?? null,
 		dateRange: r?.dateRange ?? null,
 		dateExact: r?.dateExact ?? null
-	}), K(c, { timeoutMs: 12e4 });
+	}), q(c, { timeoutMs: 12e4 });
 }
 async function tn(e, t = 20) {
 	let n = String(e || "").trim();
@@ -1221,29 +1224,29 @@ async function tn(e, t = 20) {
 		error: "Missing asset ID"
 	};
 	let r = t && typeof t == "object" ? t : { topK: Number(t) }, i = Math.max(1, Math.min(200, Number(r?.topK ?? 20) || 20)), a = String(r?.scope || "").trim(), o = String(r?.customRootId || "").trim(), s = `${l.VECTOR_SIMILAR}/${encodeURIComponent(n)}?top_k=${i}`;
-	return a && (s += `&scope=${encodeURIComponent(a)}`), o && (s += `&custom_root_id=${encodeURIComponent(o)}`), K(s, { dedupeKey: `vec:${n}:${i}:${a}:${o}` });
+	return a && (s += `&scope=${encodeURIComponent(a)}`), o && (s += `&custom_root_id=${encodeURIComponent(o)}`), q(s, { dedupeKey: `vec:${n}:${i}:${a}:${o}` });
 }
 async function nn(e) {
 	let t = String(e || "").trim();
-	return t ? K(`${l.VECTOR_ALIGNMENT}/${encodeURIComponent(t)}`) : {
+	return t ? q(`${l.VECTOR_ALIGNMENT}/${encodeURIComponent(t)}`) : {
 		ok: !1,
 		error: "Missing asset ID"
 	};
 }
 async function rn(e) {
 	let t = String(e || "").trim();
-	return t ? q(`${l.VECTOR_INDEX}/${encodeURIComponent(t)}`, {}) : {
+	return t ? J(`${l.VECTOR_INDEX}/${encodeURIComponent(t)}`, {}) : {
 		ok: !1,
 		error: "Missing asset ID"
 	};
 }
 async function an() {
-	return K(l.VECTOR_STATS);
+	return q(l.VECTOR_STATS);
 }
 async function on(e = 64, t = {}) {
 	let n = Math.max(1, Math.min(200, e)), r = typeof t?.onProgress == "function" ? t.onProgress : null, i = String(t?.scope || "").trim().toLowerCase(), a = String(t?.customRootId ?? t?.custom_root_id ?? "").trim(), o = `${l.VECTOR_BACKFILL}?batch_size=${n}&async=1`;
 	i && (o += `&scope=${encodeURIComponent(i)}`), a && (o += `&custom_root_id=${encodeURIComponent(a)}`);
-	let s = await q(o, {}, { timeoutMs: 3e4 });
+	let s = await J(o, {}, { timeoutMs: 3e4 });
 	if (!s?.ok) return s;
 	let c = s?.data || {}, u = String(c?.status || "").toLowerCase(), d = String(c?.backfill_id || "").trim();
 	try {
@@ -1259,7 +1262,7 @@ async function on(e = 64, t = {}) {
 	let f = Number(t?.pollIntervalMs), p = Number(t?.pollTimeoutMs), m = Number.isFinite(f) ? Math.max(500, Math.min(1e4, Math.floor(f))) : mn, h = Number.isFinite(p) ? Math.max(1e4, Math.min(gn, Math.floor(p))) : hn, g = Date.now(), _ = null;
 	for (; Date.now() - g < h;) {
 		await ee(m);
-		let e = await K(`${l.VECTOR_BACKFILL_STATUS}?backfill_id=${encodeURIComponent(d)}`, { timeoutMs: 3e4 });
+		let e = await q(`${l.VECTOR_BACKFILL_STATUS}?backfill_id=${encodeURIComponent(d)}`, { timeoutMs: 3e4 });
 		if (!e?.ok) {
 			_ = e;
 			continue;
@@ -1285,7 +1288,7 @@ async function on(e = 64, t = {}) {
 			status: 500
 		};
 	}
-	let v = await K(`${l.VECTOR_BACKFILL_STATUS}?backfill_id=${encodeURIComponent(d)}`, { timeoutMs: 3e4 }), y = v?.data || _?.data || {}, b = String(y?.status || "").toLowerCase();
+	let v = await q(`${l.VECTOR_BACKFILL_STATUS}?backfill_id=${encodeURIComponent(d)}`, { timeoutMs: 3e4 }), y = v?.data || _?.data || {}, b = String(y?.status || "").toLowerCase();
 	if (v?.ok && [
 		"queued",
 		"running",
@@ -1327,7 +1330,7 @@ async function on(e = 64, t = {}) {
 }
 async function sn(e) {
 	let t = String(e || "").trim();
-	return t ? q(`${l.VECTOR_CAPTION}/${encodeURIComponent(t)}`, {}) : {
+	return t ? J(`${l.VECTOR_CAPTION}/${encodeURIComponent(t)}`, {}) : {
 		ok: !1,
 		error: "Missing asset ID"
 	};
@@ -1354,20 +1357,20 @@ async function cn(e, { topK: t = 50, scope: n = "output", customRootId: r = "", 
 		workflowId: _,
 		dateRange: v,
 		dateExact: y
-	}), K(x, { timeoutMs: 12e4 });
+	}), q(x, { timeoutMs: 12e4 });
 }
 async function ln(e = 8) {
-	return q(l.VECTOR_SUGGEST_COLLECTIONS, { k: Math.max(2, Math.min(20, e)) });
+	return J(l.VECTOR_SUGGEST_COLLECTIONS, { k: Math.max(2, Math.min(20, e)) });
 }
 //#endregion
 //#region ui/api/client.ts
-var un = 3e4, dn = "__MJR_API_CLIENT__", fn = 2e3, pn = 200, mn = 1e3, hn = 30 * 6e4, gn = 720 * 6e4, B = "settings", _n = "available-tags", V = E({
-	ttlMs: fn,
-	maxSize: 1
-}), H = E({
+var un = 3e4, dn = "__MJR_API_CLIENT__", fn = 2e3, pn = 200, mn = 1e3, hn = 30 * 6e4, gn = 720 * 6e4, V = "settings", _n = "available-tags", H = E({
 	ttlMs: fn,
 	maxSize: 1
 }), U = E({
+	ttlMs: fn,
+	maxSize: 1
+}), W = E({
 	ttlMs: () => xn(),
 	maxSize: 1
 }), vn = new Set([
@@ -1400,13 +1403,13 @@ function xn() {
 	}
 }
 function Sn() {
-	V.clear();
-}
-function Cn() {
 	H.clear();
 }
-function W() {
+function Cn() {
 	U.clear();
+}
+function G() {
+	W.clear();
 }
 function wn(e) {
 	return String(e ?? "").trim().toLowerCase() || "";
@@ -1425,51 +1428,51 @@ try {
 	let e = typeof window < "u" ? window : null;
 	e && !e[dn] && (e[dn] = { initialized: !0 }, e.addEventListener?.("storage", (e) => {
 		try {
-			e?.key === "mjrSettings" && (Sn(), Cn(), W(), Xe());
+			e?.key === "mjrSettings" && (Sn(), Cn(), G(), Ye());
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}), e.addEventListener?.("mjr-settings-changed", () => {
-		Sn(), Cn(), W(), Xe();
+		Sn(), Cn(), G(), Ye();
 	}));
 } catch (e) {
 	console.debug?.(e);
 }
 var En = () => {
-	let e = V.get(B);
+	let e = H.get(V);
 	if (e !== void 0) return e;
 	let t = Date.now();
 	try {
 		let e = localStorage?.getItem?.(f);
-		if (!e) return V.set(B, !1, { at: t }), !1;
+		if (!e) return H.set(V, !1, { at: t }), !1;
 		let n = !!JSON.parse(e)?.observability?.enabled;
-		return V.set(B, n, { at: t }), n;
+		return H.set(V, n, { at: t }), n;
 	} catch {
-		return V.set(B, !1, { at: t }), !1;
+		return H.set(V, !1, { at: t }), !1;
 	}
 }, Dn = () => {
-	let e = H.get(B);
+	let e = U.get(V);
 	if (e !== void 0) return e;
 	let t = Date.now();
 	try {
 		let e = localStorage?.getItem?.(f);
-		if (!e) return H.set(B, !0, { at: t }), !0;
+		if (!e) return U.set(V, !0, { at: t }), !0;
 		let n = JSON.parse(e)?.ratingTagsSync?.enabled, r = n == null ? !0 : bn(n, !0);
-		return H.set(B, r, { at: t }), r;
+		return U.set(V, r, { at: t }), r;
 	} catch {
-		return H.set(B, !0, { at: t }), !0;
+		return U.set(V, !0, { at: t }), !0;
 	}
-}, G = le({
+}, K = le({
 	readObsEnabled: En,
-	readAuthToken: L,
-	ensureWriteAuthToken: Ye,
-	normalizeWriteAuthFailure: qe
-}), On = G.fetchAPI;
-async function K(e, t = {}) {
-	return G.get(e, t);
+	readAuthToken: R,
+	ensureWriteAuthToken: Je,
+	normalizeWriteAuthFailure: Ke
+}), On = K.fetchAPI;
+async function q(e, t = {}) {
+	return K.get(e, t);
 }
-async function q(e, t, n = {}) {
-	return G.post(e, t, n);
+async function J(e, t, n = {}) {
+	return K.post(e, t, n);
 }
 async function kn(n, r, i = {}) {
 	let a = Dn(), o = n && typeof n == "object" ? n : null, s = t(o ? o.id : n), c = { rating: Math.max(0, Math.min(5, Number(r) || 0)) };
@@ -1495,10 +1498,10 @@ async function An(n, r, i = {}) {
 		},
 		body: JSON.stringify(d)
 	});
-	return f?.ok && W(), f;
+	return f?.ok && G(), f;
 }
 async function jn() {
-	let e = U.get(_n);
+	let e = W.get(_n);
 	if (Array.isArray(e)) return {
 		ok: !0,
 		data: e,
@@ -1506,24 +1509,24 @@ async function jn() {
 		code: "OK",
 		meta: { cached: !0 }
 	};
-	let t = await K("/mjr/am/tags");
+	let t = await q("/mjr/am/tags");
 	if (t?.ok && Array.isArray(t.data)) {
 		let e = Tn(t.data);
-		return U.set(_n, e), {
+		return W.set(_n, e), {
 			...t,
 			data: e
 		};
 	}
 	return t;
 }
-async function J(e, n = {}) {
+async function Mn(e, n = {}) {
 	let r = encodeURIComponent(t(e));
-	return K(`/mjr/am/asset/${r}`, {
+	return q(`/mjr/am/asset/${r}`, {
 		...n,
 		dedupeKey: n?.dedupeKey || `meta:${r}`
 	});
 }
-async function Mn(e, n = {}) {
+async function Nn(e, n = {}) {
 	let r = t(e);
 	if (!r) return {
 		ok: !1,
@@ -1534,33 +1537,24 @@ async function Mn(e, n = {}) {
 	let i = `/mjr/am/viewer/info?asset_id=${encodeURIComponent(r)}`;
 	n.refresh && (i += "&refresh=1");
 	let { refresh: a, ...o } = n;
-	return K(i, o);
+	return q(i, o);
 }
-async function Nn(e, t = {}) {
+async function Pn(e, t = {}) {
 	let n = Array.isArray(e) ? e : [], r = [];
 	for (let e of n) {
 		let t = Number(e);
 		if (Number.isFinite(t) && (r.push(Math.trunc(t)), r.length >= pn)) break;
 	}
-	return r.length ? q("/mjr/am/assets/batch", { asset_ids: r }, t) : {
+	return r.length ? J("/mjr/am/assets/batch", { asset_ids: r }, t) : {
 		ok: !0,
 		data: [],
 		error: null,
 		code: "OK"
 	};
 }
-async function Pn(e, t = {}) {
-	let n = i(e);
-	return n ? K(n, t) : {
-		ok: !1,
-		data: null,
-		error: "Missing workflow filepath",
-		code: "INVALID_INPUT"
-	};
-}
 async function Fn(e, t = {}) {
-	let r = n(e);
-	return r ? K(r, t) : {
+	let n = i(e);
+	return n ? q(n, t) : {
 		ok: !1,
 		data: null,
 		error: "Missing workflow filepath",
@@ -1568,25 +1562,34 @@ async function Fn(e, t = {}) {
 	};
 }
 async function In(e, t = {}) {
+	let r = n(e);
+	return r ? q(r, t) : {
+		ok: !1,
+		data: null,
+		error: "Missing workflow filepath",
+		code: "INVALID_INPUT"
+	};
+}
+async function Ln(e, t = {}) {
 	let n = u(e);
-	return n ? K(n, t) : {
+	return n ? q(n, t) : {
 		ok: !1,
 		data: null,
 		error: "Missing workflow filepath",
 		code: "INVALID_INPUT"
 	};
 }
-async function Ln(e, t = "", n = {}) {
+async function Rn(e, t = "", n = {}) {
 	let i = r(e, t);
-	return i ? K(i, n) : {
+	return i ? q(i, n) : {
 		ok: !1,
 		data: null,
 		error: "Missing workflow filepath",
 		code: "INVALID_INPUT"
 	};
 }
-async function Rn({ workflow: e = null, name: t = "", category: n = "", overwrite: r = !1, filepath: i = "", task: a = "", model_family: o = "", provider: s = "", runs_on: c = "", notes: u = "" } = {}, d = {}) {
-	return q(l.WORKFLOWS_SAVE, {
+async function zn({ workflow: e = null, name: t = "", category: n = "", overwrite: r = !1, filepath: i = "", task: a = "", model_family: o = "", provider: s = "", runs_on: c = "", notes: u = "" } = {}, d = {}) {
+	return J(l.WORKFLOWS_SAVE, {
 		workflow: e,
 		name: t,
 		category: n,
@@ -1599,33 +1602,33 @@ async function Rn({ workflow: e = null, name: t = "", category: n = "", overwrit
 		notes: u
 	}, d);
 }
-async function zn({ filepath: e = "", name: t = "" } = {}, n = {}) {
-	return q(l.WORKFLOWS_DUPLICATE, {
+async function Bn({ filepath: e = "", name: t = "" } = {}, n = {}) {
+	return J(l.WORKFLOWS_DUPLICATE, {
 		filepath: e,
 		name: t
 	}, n);
 }
-async function Bn({ filepath: e = "", name: t = "", category: n = "" } = {}, r = {}) {
-	return q(l.WORKFLOWS_MOVE, {
+async function Vn({ filepath: e = "", name: t = "", category: n = "" } = {}, r = {}) {
+	return J(l.WORKFLOWS_MOVE, {
 		filepath: e,
 		name: t,
 		category: n
 	}, r);
 }
-async function Vn({ filepath: e = "" } = {}, t = {}) {
-	return q(l.WORKFLOWS_DELETE, { filepath: e }, t);
-}
 async function Hn({ filepath: e = "" } = {}, t = {}) {
-	return q(l.WORKFLOWS_MARK_LOADED, { filepath: e }, t);
+	return J(l.WORKFLOWS_DELETE, { filepath: e }, t);
 }
-async function Un({ filepath: e = "", favorite: t = !1 } = {}, n = {}) {
-	return q(l.WORKFLOWS_FAVORITE, {
+async function Un({ filepath: e = "" } = {}, t = {}) {
+	return J(l.WORKFLOWS_MARK_LOADED, { filepath: e }, t);
+}
+async function Wn({ filepath: e = "", favorite: t = !1 } = {}, n = {}) {
+	return J(l.WORKFLOWS_FAVORITE, {
 		filepath: e,
 		favorite: !!t
 	}, n);
 }
-async function Wn({ filepath: e = "", task: t = "", model_family: n = "", provider: r = "", runs_on: i = "", notes: a = "" } = {}, o = {}) {
-	return q(l.WORKFLOWS_INFO, {
+async function Gn({ filepath: e = "", task: t = "", model_family: n = "", provider: r = "", runs_on: i = "", notes: a = "" } = {}, o = {}) {
+	return J(l.WORKFLOWS_INFO, {
 		filepath: e,
 		task: t,
 		model_family: n,
@@ -1634,24 +1637,24 @@ async function Wn({ filepath: e = "", task: t = "", model_family: n = "", provid
 		notes: a
 	}, o);
 }
-async function Gn({ filepath: e = "", limit: t = 12 } = {}, n = {}) {
+async function Kn({ filepath: e = "", limit: t = 12 } = {}, n = {}) {
 	let r = Math.max(1, Math.min(50, Number(t) || 12));
-	return K(`${l.WORKFLOWS_THUMBNAIL_CANDIDATES}?filepath=${encodeURIComponent(String(e || "").trim())}&limit=${encodeURIComponent(String(r))}`, n);
+	return q(`${l.WORKFLOWS_THUMBNAIL_CANDIDATES}?filepath=${encodeURIComponent(String(e || "").trim())}&limit=${encodeURIComponent(String(r))}`, n);
 }
-async function Kn(e = {}) {
-	return K(l.WORKFLOWS_MODEL_FAMILIES, e);
+async function qn(e = {}) {
+	return q(l.WORKFLOWS_MODEL_FAMILIES, e);
 }
-async function qn({ q: e = "*", limit: t = 100, offset: n = 0, sort: r = "mtime" } = {}, i = {}) {
+async function Jn({ q: e = "*", limit: t = 100, offset: n = 0, sort: r = "mtime" } = {}, i = {}) {
 	let a = Math.max(1, Math.min(500, Number(t) || 100)), o = Math.max(0, Number(n) || 0);
-	return K(`${l.LIST}?scope=workflow&q=${encodeURIComponent(String(e || "*"))}&limit=${encodeURIComponent(String(a))}&offset=${encodeURIComponent(String(o))}&sort=${encodeURIComponent(String(r || "mtime"))}`, i);
+	return q(`${l.LIST}?scope=workflow&q=${encodeURIComponent(String(e || "*"))}&limit=${encodeURIComponent(String(a))}&offset=${encodeURIComponent(String(o))}&sort=${encodeURIComponent(String(r || "mtime"))}`, i);
 }
-async function Jn({ filepath: e = "", source_filepath: t = "" } = {}, n = {}) {
-	return q(l.WORKFLOWS_THUMBNAIL_SET, {
+async function Yn({ filepath: e = "", source_filepath: t = "" } = {}, n = {}) {
+	return J(l.WORKFLOWS_THUMBNAIL_SET, {
 		filepath: e,
 		source_filepath: t
 	}, n);
 }
-async function Yn({ type: e = "output", filename: t = "", subfolder: n = "", root_id: r = "", rootId: i = "", filepath: a = "" } = {}, o = {}) {
+async function Xn({ type: e = "output", filename: t = "", subfolder: n = "", root_id: r = "", rootId: i = "", filepath: a = "" } = {}, o = {}) {
 	let s = String(e || "output").trim().toLowerCase() || "output", c = String(t || "").trim(), l = String(n || "").trim(), u = String(r || i || "").trim(), d = String(a || "").trim();
 	if (!c) return {
 		ok: !1,
@@ -1660,9 +1663,9 @@ async function Yn({ type: e = "output", filename: t = "", subfolder: n = "", roo
 		code: "INVALID_INPUT"
 	};
 	let f = `/mjr/am/metadata?type=${encodeURIComponent(s)}&filename=${encodeURIComponent(c)}`;
-	return d && (f += `&filepath=${encodeURIComponent(d)}`), l && (f += `&subfolder=${encodeURIComponent(l)}`), u && (f += `&root_id=${encodeURIComponent(u)}`), K(f, o);
+	return d && (f += `&filepath=${encodeURIComponent(d)}`), l && (f += `&subfolder=${encodeURIComponent(l)}`), u && (f += `&root_id=${encodeURIComponent(u)}`), q(f, o);
 }
-async function Xn({ filepath: e = "", root_id: t = "", subfolder: n = "" } = {}, r = {}) {
+async function Zn({ filepath: e = "", root_id: t = "", subfolder: n = "" } = {}, r = {}) {
 	try {
 		if (globalThis.__mjrFolderInfoSupported === !1) return {
 			ok: !1,
@@ -1671,7 +1674,7 @@ async function Xn({ filepath: e = "", root_id: t = "", subfolder: n = "" } = {},
 			code: "UNAVAILABLE"
 		};
 		if (globalThis.__mjrFolderInfoSupported == null) {
-			let e = await K("/mjr/am/routes");
+			let e = await q("/mjr/am/routes");
 			if (e?.ok && Array.isArray(e.data)) {
 				let t = e.data.some((e) => String(e?.path || "").trim() === "/mjr/am/folder-info");
 				if (globalThis.__mjrFolderInfoSupported = !!t, !t) return {
@@ -1687,7 +1690,7 @@ async function Xn({ filepath: e = "", root_id: t = "", subfolder: n = "" } = {},
 	}
 	let i = String(e || "").trim(), a = String(t || "").trim(), o = String(n || "").trim(), s = l.FOLDER_INFO, c = [];
 	i ? (c.push(`filepath=${encodeURIComponent(i)}`), c.push("browser_mode=1")) : (a && c.push(`root_id=${encodeURIComponent(a)}`), o && c.push(`subfolder=${encodeURIComponent(o)}`)), c.length && (s += `?${c.join("&")}`);
-	let u = await K(s, r);
+	let u = await q(s, r);
 	try {
 		!u?.ok && Number(u?.status || 0) === 404 && (globalThis.__mjrFolderInfoSupported = !1);
 	} catch (e) {
@@ -1697,12 +1700,12 @@ async function Xn({ filepath: e = "", root_id: t = "", subfolder: n = "" } = {},
 }
 //#endregion
 //#region ui/utils/logging.ts
-function Zn(e, ...t) {
+function Qn(e, ...t) {
 	try {
 		c.DEBUG_VERBOSE_ERRORS && console.debug(e, ...t);
 	} catch {}
 }
-function Qn(e, t = "Majoor", { showToast: n = !1, toastType: r = "error" } = {}) {
+function $n(e, t = "Majoor", { showToast: n = !1, toastType: r = "error" } = {}) {
 	let i = e?.message || String(e || "Unknown error");
 	try {
 		c.DEBUG_VERBOSE_ERRORS ? console.error(`[Majoor][${t}]`, i, e) : console.debug(`[Majoor][${t}]`, i);
@@ -1710,7 +1713,7 @@ function Qn(e, t = "Majoor", { showToast: n = !1, toastType: r = "error" } = {})
 		console.debug?.(e);
 	}
 	if (n && c.DEBUG_VERBOSE_ERRORS) try {
-		j(`${t}: ${i}`, r, 4e3);
+		M(`${t}: ${i}`, r, 4e3);
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -1722,44 +1725,44 @@ var Y = {
 	scope: null,
 	ratingHotkeysActive: !1
 };
-function $n() {
+function er() {
 	return Y;
 }
-function er(e) {
+function tr(e) {
 	Y.scope = e == null ? null : String(e);
 }
-function tr() {
+function nr() {
 	return !!Y.suspended;
 }
-function nr(e) {
+function rr(e) {
 	Y.ratingHotkeysActive = !!e;
 }
 //#endregion
 //#region ui/features/viewer/viewerRuntimeHosts.ts
-var X = null, Z = null, rr = ".mjr-viewer-overlay", ir = ".mjr-mfv";
-function ar(e) {
+var X = null, Z = null, ir = ".mjr-viewer-overlay", ar = ".mjr-mfv";
+function or(e) {
 	return !!e && typeof e.appendChild == "function";
 }
 function Q() {
 	return typeof document > "u" ? null : document?.body || null;
 }
-function or() {
+function sr() {
 	return typeof document > "u" ? null : document?.body || document?.documentElement || null;
 }
-function sr(e) {
-	return ar(e) ? e === Q() ? !0 : typeof e?.isConnected == "boolean" ? e.isConnected : !0 : !1;
-}
 function cr(e) {
-	return ar(e) ? e : null;
-}
-function $(e) {
-	return sr(e) ? e : Q();
+	return or(e) ? e === Q() ? !0 : typeof e?.isConnected == "boolean" ? e.isConnected : !0 : !1;
 }
 function lr(e) {
-	let t = or();
-	return sr(t) ? t : $(e);
+	return or(e) ? e : null;
 }
-function ur(e, t, n = $) {
+function $(e) {
+	return cr(e) ? e : Q();
+}
+function ur(e) {
+	let t = sr();
+	return cr(t) ? t : $(e);
+}
+function dr(e, t, n = $) {
 	let r = [], i = /* @__PURE__ */ new Set();
 	for (let a of [
 		n(t),
@@ -1778,29 +1781,29 @@ function ur(e, t, n = $) {
 	}
 	return r;
 }
-function dr(e, t, n = $) {
+function fr(e, t, n = $) {
 	let r = n(t);
 	if (!r) return;
-	let i = ur(e, t, n);
+	let i = dr(e, t, n);
 	for (let e of i) if (e && e.parentNode !== r) try {
 		r.appendChild(e);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function fr(e) {
-	return X = cr(e), dr(rr, X), () => pr(e);
-}
 function pr(e) {
-	(!e || X === e) && (X = null);
+	return X = lr(e), fr(ir, X), () => mr(e);
 }
 function mr(e) {
-	return Z = cr(e), dr(ir, Z, lr), () => hr(e);
+	(!e || X === e) && (X = null);
 }
 function hr(e) {
-	(!e || Z === e) && (Z = null);
+	return Z = lr(e), fr(ar, Z, ur), () => gr(e);
 }
 function gr(e) {
+	(!e || Z === e) && (Z = null);
+}
+function _r(e) {
 	let t = $(X);
 	try {
 		t?.appendChild?.(e);
@@ -1809,8 +1812,8 @@ function gr(e) {
 	}
 	return t;
 }
-function _r(e) {
-	let t = lr(Z);
+function vr(e) {
+	let t = ur(Z);
 	try {
 		t?.appendChild?.(e);
 	} catch (e) {
@@ -1818,8 +1821,8 @@ function _r(e) {
 	}
 	return t;
 }
-function vr() {
-	return ur(rr, X);
+function yr() {
+	return dr(ir, X);
 }
 //#endregion
-export { pt as $, Ee as $t, Rn as A, ut as At, Dt as B, on as Bt, Kn as C, ot as Ct, Hn as D, $e as Dt, qn as E, mt as Et, An as F, St as Ft, Lt as G, en as Gt, Wt as H, sn as Ht, Fn as I, Vt as It, Ht as J, Ue as Jt, st as K, an as Kt, Zt as L, Mt as Lt, Wn as M, ft as Mt, Jn as N, tt as Nt, Bn as O, vt as Ot, kn as P, At as Pt, ht as Q, pe as Qt, Tt as R, nt as Rt, Pn as S, it as St, In as T, gt as Tt, Gt as U, nn as Ut, Yt as V, tn as Vt, Xt as W, rn as Wt, at as X, j as Xt, rt as Y, He as Yt, yt as Z, Ae as Zt, Nn as _, qt as _t, fr as a, f as an, dt as at, Xn as b, zt as bt, er as c, Nt as ct, Qn as d, cn as dt, we as en, Qe as et, Vn as f, Jt as ft, J as g, Qt as gt, K as h, Et as ht, mr as i, p as in, Ct as it, Un as j, wt as jt, q as k, Ze as kt, nr as l, jt as lt, zn as m, Ut as mt, gr as n, Te as nn, lt as nt, $n as o, Ft as ot, Ln as p, Rt as pt, $t as q, ln as qt, vr as r, E as rn, It as rt, tr as s, et as st, _r as t, Ce as tn, _t as tt, Zn as u, xt as ut, jn as v, kt as vt, Gn as w, bt as wt, Mn as x, ct as xt, Yn as y, Bt as yt, Ot as z, Pt as zt };
+export { pt as $, pe as $t, zn as A, Xe as At, Dt as B, Pt as Bt, qn as C, rt as Ct, Un as D, mt as Dt, Jn as E, gt as Et, An as F, At as Ft, Lt as G, rn as Gt, Wt as H, tn as Ht, In as I, St as It, Ht as J, ln as Jt, st as K, en as Kt, Zt as L, Vt as Lt, Gn as M, wt as Mt, Yn as N, ft as Nt, Vn as O, Qe as Ot, kn as P, et as Pt, ht as Q, ke as Qt, Tt as R, Mt as Rt, Fn as S, it as St, Ln as T, bt as Tt, Gt as U, sn as Ut, Yt as V, on as Vt, Xt as W, nn as Wt, at as X, Ve as Xt, nt as Y, He as Yt, yt as Z, M as Zt, Pn as _, qt as _t, pr as a, p as an, dt as at, Zn as b, zt as bt, tr as c, Nt as ct, $n as d, cn as dt, Ee as en, Ze as et, Hn as f, Jt as ft, Mn as g, Qt as gt, q as h, Et as ht, hr as i, E as in, Ct as it, Wn as j, ut as jt, J as k, vt as kt, rr as l, jt as lt, Bn as m, Ut as mt, _r as n, Ce as nn, lt as nt, er as o, f as on, Ft as ot, Rn as p, Rt as pt, $t as q, an as qt, yr as r, Te as rn, It as rt, nr as s, $e as st, vr as t, we as tn, _t as tt, Qn as u, xt as ut, jn as v, kt as vt, Kn as w, ot as wt, Nn as x, ct as xt, Xn as y, Bt as yt, Ot as z, tt as zt };

--- a/dist/entry.js
+++ b/dist/entry.js
@@ -1,13 +1,13 @@
-import { $t as e, A as t, B as n, Bt as r, C as i, D as a, E as o, Ft as s, G as c, Gt as l, H as u, It as d, J as f, Kt as p, L as m, Lt as h, M as g, N as _, O as v, Ot as y, P as b, Pt as x, Qt as S, Rt as C, S as w, U as T, V as E, Vt as D, W as O, Wt as k, Xt as A, Zt as j, _ as M, _t as N, b as ee, bt as te, c as ne, d as P, dt as F, en as re, f as ie, ft as ae, g as oe, gt as se, h as I, ht as ce, j as le, k as ue, l as de, lt as fe, m as pe, mt as me, nn as he, o as ge, ot as _e, pt as ve, q as ye, qt as be, rn as xe, s as Se, tn as Ce, u as we, vt as Te, w as Ee, wt as De, y as Oe, yt as ke, z as Ae } from "./chunks/viewerRuntimeHosts-B0n5DSKG.js";
-import { $ as je, A as Me, Ct as Ne, F as Pe, G as Fe, H as Ie, K as Le, L as Re, Q as ze, St as Be, U as Ve, W as He, X as Ue, Z as We, _ as Ge, at as Ke, bt as qe, ct as Je, dt as Ye, et as Xe, ft as Ze, g as Qe, h as $e, it as et, j as tt, lt as L, m as R, n as nt, o as z, ot as rt, pt as it, q as at, r as B, rt as ot, st, t as ct, tt as lt, ut, xt as dt, yt as ft } from "./chunks/events-CwzwyUFJ.js";
+import { $t as e, A as t, B as n, C as r, D as i, E as a, Ft as o, G as s, Gt as c, H as l, Ht as u, It as d, J as f, Jt as p, Kt as m, L as h, Lt as g, M as _, N as v, O as y, P as b, Qt as x, Rt as S, S as C, Tt as w, U as T, V as E, Vt as D, W as O, Zt as k, _ as A, _t as j, b as M, bt as N, c as ee, d as P, dt as te, en as ne, f as F, ft as re, g as ie, gt as ae, h as oe, ht as se, in as ce, j as le, k as ue, kt as de, l as fe, lt as pe, m as me, mt as he, nn as ge, o as _e, ot as ve, pt as ye, q as be, qt as xe, rn as Se, s as Ce, tn as we, u as Te, vt as Ee, w as De, y as Oe, yt as ke, z as Ae, zt as je } from "./chunks/viewerRuntimeHosts-P4vwR-ik.js";
+import { $ as Me, A as Ne, Ct as Pe, F as Fe, G as Ie, H as Le, K as Re, L as ze, Q as Be, St as Ve, U as He, W as Ue, X as We, Z as Ge, _ as Ke, at as qe, bt as Je, ct as Ye, dt as Xe, et as Ze, ft as Qe, g as $e, h as et, it as tt, j as nt, lt as I, m as L, n as rt, o as R, ot as it, pt as at, q as ot, r as z, rt as st, st as ct, t as lt, tt as B, ut, xt as dt, yt as ft } from "./chunks/events-C2U9lj7y.js";
 import { a as pt, i as mt, n as ht, t as gt } from "./chunks/graphTraversal-Sruu0ipL.js";
-import { A as _t, B as vt, C as yt, D as bt, E as xt, F as St, G as Ct, H as wt, I as Tt, J as Et, L as Dt, M as Ot, N as kt, O as At, P as jt, R as Mt, S as Nt, T as Pt, U as Ft, V as It, W as Lt, Y as Rt, _ as zt, b as Bt, d as Vt, g as Ht, j as Ut, k as Wt, q as Gt, v as Kt, x as qt, y as Jt, z as Yt } from "./chunks/Viewer--Cuhs0TQ.js";
-import { $ as Xt, A as Zt, B as Qt, C as $t, D as en, E as tn, F as nn, G as rn, H as an, I as on, J as sn, K as cn, L as ln, M as un, N as dn, O as fn, P as pn, Q as mn, R as hn, S as gn, T as _n, U as vn, V as yn, W as bn, X as xn, Y as Sn, Z as Cn, a as wn, c as Tn, d as En, f as Dn, g as On, h as kn, i as An, j as jn, k as Mn, l as Nn, m as Pn, n as Fn, o as In, p as Ln, q as Rn, s as zn, t as Bn, u as Vn, w as Hn, z as Un } from "./chunks/SidebarWorkflowSection-B_0hBSuQ.js";
-import { _ as Wn, i as Gn, n as Kn, p as qn, t as Jn } from "./chunks/openMajoorSettings-BFW5B6oQ.js";
-import { a as Yn, c as Xn, l as Zn, o as Qn, s as $n, u as er } from "./chunks/floatingViewerManager-CGdpmtv-.js";
-import { A as tr, B as V, C as H, D as nr, E as U, F as rr, G as ir, H as ar, I as or, J as sr, K as cr, L as lr, M as ur, N as dr, O as W, R as fr, S as pr, T as G, U as mr, V as hr, W as gr, b as _r, ct as K, dt as q, et as vr, it as yr, j as J, k as Y, lt as X, nt as Z, q as Q, rt as br, st as xr, tt as Sr, ut as Cr, v as wr, w as Tr, x as Er, y as Dr, z as Or } from "./chunks/mjr-primevue-n1rsQYJg.js";
-import { n as kr, r as Ar } from "./chunks/mjr-vue-vendor-D2GeV7Qd.js";
-import { t as jr } from "./chunks/TagsEditor-Ba8mdFJF.js";
+import { A as _t, B as vt, C as yt, D as bt, E as xt, F as St, G as Ct, H as wt, I as Tt, J as Et, L as Dt, M as Ot, N as kt, O as At, P as jt, R as Mt, S as Nt, T as Pt, U as Ft, V as It, W as Lt, Y as Rt, _ as zt, b as Bt, d as Vt, g as Ht, j as Ut, k as Wt, q as Gt, v as Kt, x as qt, y as Jt, z as Yt } from "./chunks/Viewer-pHo9CcXS.js";
+import { $ as Xt, A as Zt, B as Qt, C as $t, D as en, E as tn, F as nn, G as rn, H as an, I as on, J as sn, K as cn, L as ln, M as un, N as dn, O as fn, P as pn, Q as mn, R as hn, S as gn, T as _n, U as vn, V as yn, W as bn, X as xn, Y as Sn, Z as Cn, a as wn, c as Tn, d as En, f as Dn, g as On, h as kn, i as An, j as jn, k as Mn, l as Nn, m as Pn, n as Fn, o as In, p as Ln, q as Rn, s as zn, t as Bn, u as Vn, w as Hn, z as Un } from "./chunks/SidebarWorkflowSection-2pSEjXh9.js";
+import { _ as Wn, i as Gn, n as Kn, p as qn, t as Jn } from "./chunks/openMajoorSettings-D8Sa3D0W.js";
+import { a as Yn, c as Xn, l as Zn, o as Qn, s as $n, u as er } from "./chunks/floatingViewerManager-C0fDYFQu.js";
+import { A as tr, B as V, C as H, D as nr, E as U, F as rr, G as ir, H as ar, I as or, J as sr, K as cr, L as lr, M as ur, N as dr, O as W, R as fr, S as pr, T as G, U as mr, V as hr, W as gr, b as _r, ct as K, dt as q, et as vr, it as yr, j as J, k as Y, lt as X, nt as Z, q as Q, rt as br, st as xr, tt as Sr, ut as Cr, v as wr, w as Tr, x as Er, y as Dr, z as Or } from "./chunks/mjr-primevue-BOCpq3qH.js";
+import { n as kr, r as Ar } from "./chunks/mjr-vue-vendor-B7WqP-K6.js";
+import { t as jr } from "./chunks/TagsEditor-xxM6vyn1.js";
 import { app as Mr } from "../../scripts/app.js";
 function Nr(e = null) {
 	return null;
@@ -16,7 +16,7 @@ function Pr() {
 	return null;
 }
 try {
-	typeof window < "u" && lt && lt.LIST;
+	typeof window < "u" && B && B.LIST;
 } catch {}
 //#endregion
 //#region ui/integration/comfy_send_to_am.ts
@@ -63,9 +63,9 @@ function zr(e) {
 	return t;
 }
 async function Br(e) {
-	let t = tt(), n = Me(t);
+	let t = nt(), n = Ne(t);
 	if (!e.length) {
-		at({
+		ot({
 			severity: "warn",
 			summary: "Majoor Assets Manager",
 			detail: "No output to send (run the node first).",
@@ -74,7 +74,7 @@ async function Br(e) {
 		return;
 	}
 	if (!n || typeof n.fetchApi != "function") {
-		at({
+		ot({
 			severity: "error",
 			summary: "Majoor Assets Manager",
 			detail: "ComfyUI API unavailable.",
@@ -89,14 +89,14 @@ async function Br(e) {
 			body: JSON.stringify({ items: e })
 		});
 		if (!r.ok && r.status !== 404) throw Error(`HTTP ${r.status}`);
-		Ge(t, "majoor-assets"), at({
+		Ke(t, "majoor-assets"), ot({
 			severity: "success",
 			summary: "Majoor Assets Manager",
 			detail: `Sent ${e.length} item(s) to the asset grid.`,
 			life: 2500
 		});
 	} catch (e) {
-		at({
+		ot({
 			severity: "error",
 			summary: "Majoor Assets Manager",
 			detail: `Failed to send: ${e?.message || e}`,
@@ -105,7 +105,7 @@ async function Br(e) {
 	}
 }
 function Vr() {
-	let e = tt();
+	let e = nt();
 	if (!e || typeof e.registerExtension != "function") {
 		setTimeout(Vr, 100);
 		return;
@@ -139,7 +139,7 @@ function Kr() {
 	}
 }
 async function qr(e = {}) {
-	if (!z || typeof z != "object" || !z.AUTO_SCAN_ON_STARTUP || Hr) return;
+	if (!R || typeof R != "object" || !R.AUTO_SCAN_ON_STARTUP || Hr) return;
 	let t = Math.max(0, Number(e?.delayMs) || 0), n = e?.idleOnly !== !1;
 	if (t > 0) {
 		Ur && clearTimeout(Ur), Ur = setTimeout(() => {
@@ -161,8 +161,8 @@ async function qr(e = {}) {
 	}
 	Hr = !0;
 	try {
-		we("[Majoor] Starting startup scan of output directory...");
-		let e = await ue(lt.SCAN, {
+		Te("[Majoor] Starting startup scan of output directory...");
+		let e = await ue(B.SCAN, {
 			recursive: !0,
 			incremental: !0,
 			fast: !0,
@@ -170,7 +170,7 @@ async function qr(e = {}) {
 		});
 		if (e.ok) {
 			let t = e.data;
-			we(`[Majoor] Startup scan complete  -  added: ${t.added}, updated: ${t.updated}, skipped: ${t.skipped}`);
+			Te(`[Majoor] Startup scan complete  -  added: ${t.added}, updated: ${t.updated}, skipped: ${t.skipped}`);
 		} else console.warn("[Majoor] Majoor [WARN]: Startup scan failed:", e.error);
 	} catch (e) {
 		console.error("[Majoor] ERROR: Startup scan error:", e);
@@ -179,9 +179,9 @@ async function qr(e = {}) {
 async function Jr() {
 	try {
 		await Promise.allSettled([
-			I(lt.HEALTH),
-			I(`${lt.HEALTH_COUNTERS}?scope=output`),
-			I(lt.HEALTH_DB)
+			oe(B.HEALTH),
+			oe(`${B.HEALTH_COUNTERS}?scope=output`),
+			oe(B.HEALTH_DB)
 		]);
 	} catch (e) {
 		console.debug?.(e);
@@ -213,9 +213,9 @@ function Xr() {
 }
 async function Zr() {
 	try {
-		we("[Majoor] Testing API connection...");
-		let e = await I(lt.HEALTH);
-		e?.ok ? we("[Majoor] API connection successful, health:", e.data.overall) : console.error("[Majoor] ERROR: API health check failed:", e?.error);
+		Te("[Majoor] Testing API connection...");
+		let e = await oe(B.HEALTH);
+		e?.ok ? Te("[Majoor] API connection successful, health:", e.data.overall) : console.error("[Majoor] ERROR: API health check failed:", e?.error);
 	} catch (e) {
 		console.error("[Majoor] ERROR: Failed to connect to API:", e);
 	}
@@ -336,7 +336,7 @@ async function _i({ force: e = !1 } = {}) {
 	if (typeof window > "u") return null;
 	let t, n;
 	try {
-		let e = await I(lt.VERSION);
+		let e = await oe(B.VERSION);
 		if (!e?.ok) return hi({ available: !1 }), null;
 		t = si(e.data?.version), n = String(e.data?.branch || "").trim().toLowerCase();
 	} catch {
@@ -345,7 +345,7 @@ async function _i({ force: e = !1 } = {}) {
 	let r = !1;
 	try {
 		if (!e) {
-			let e = Number($e.get(ni) || 0);
+			let e = Number(et.get(ni) || 0);
 			Number.isFinite(e) && Date.now() - e < ai && (r = !0);
 		}
 	} catch {}
@@ -354,17 +354,17 @@ async function _i({ force: e = !1 } = {}) {
 		let e;
 		try {
 			e = await mi();
-			let n = String($e.get(ii) || "").trim(), r = !!(n && e && n !== e);
+			let n = String(et.get(ii) || "").trim(), r = !!(n && e && n !== e);
 			if (hi({
 				available: r,
 				current: t || "nightly",
 				latest: "nightly",
 				channel: "nightly"
-			}), r && A({
-				summary: R("msg.nightlyUpdateTitle", "Nightly update available"),
-				detail: R("msg.nightlyUpdateDetail", "A newer nightly build is available. Download it here: https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/releases/tag/nightly")
+			}), r && k({
+				summary: L("msg.nightlyUpdateTitle", "Nightly update available"),
+				detail: L("msg.nightlyUpdateDetail", "A newer nightly build is available. Download it here: https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager/releases/tag/nightly")
 			}, "info", 0), e) try {
-				$e.set(ii, e);
+				et.set(ii, e);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -372,7 +372,7 @@ async function _i({ force: e = !1 } = {}) {
 			console.warn("Unable to check Majoor nightly updates:", e), hi({ available: !1 });
 		} finally {
 			try {
-				$e.set(ni, String(Date.now()));
+				et.set(ni, String(Date.now()));
 			} catch {}
 		}
 		return null;
@@ -385,7 +385,7 @@ async function _i({ force: e = !1 } = {}) {
 		return console.warn("Unable to check Majoor updates:", e), hi({ available: !1 }), null;
 	} finally {
 		try {
-			$e.set(ni, String(Date.now()));
+			et.set(ni, String(Date.now()));
 		} catch {}
 	}
 	if (!i || !ui(i, t)) return hi({ available: !1 }), null;
@@ -395,16 +395,16 @@ async function _i({ force: e = !1 } = {}) {
 		latest: i
 	});
 	try {
-		if (String($e.get(ri) || "").trim() !== i) {
-			A({
-				summary: R("msg.newVersionTitle", "Majoor Assets Manager update available"),
-				detail: R("msg.newVersionDetail", "Version {latest} is available. You are currently using {current}.", {
+		if (String(et.get(ri) || "").trim() !== i) {
+			k({
+				summary: L("msg.newVersionTitle", "Majoor Assets Manager update available"),
+				detail: L("msg.newVersionDetail", "Version {latest} is available. You are currently using {current}.", {
 					latest: i,
 					current: t
 				})
 			}, "info", 0);
 			try {
-				$e.set(ri, i);
+				et.set(ri, i);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -466,7 +466,7 @@ function xi(e) {
 	let t = (t, n) => {
 		n ? e.classList.add(t) : e.classList.remove(t);
 	};
-	t("mjr-show-filename", z.GRID_SHOW_DETAILS_FILENAME), t("mjr-show-dimensions", z.GRID_SHOW_DETAILS_DIMENSIONS), t("mjr-show-date", z.GRID_SHOW_DETAILS_DATE), t("mjr-show-gentime", z.GRID_SHOW_DETAILS_GENTIME), t("mjr-show-hover-info", z.GRID_SHOW_HOVER_INFO), t("mjr-show-dot", z.GRID_SHOW_WORKFLOW_DOT), t("mjr-show-badges-ext", z.GRID_SHOW_BADGES_EXTENSION), t("mjr-show-badges-rating", z.GRID_SHOW_BADGES_RATING), t("mjr-show-badges-tags", z.GRID_SHOW_BADGES_TAGS), t("mjr-show-details", z.GRID_SHOW_DETAILS), e.style.setProperty("--mjr-grid-min-size", `${z.GRID_MIN_SIZE}px`), e.style.setProperty("--mjr-grid-gap", `${z.GRID_GAP}px`), e.style.setProperty("--mjr-star-active", z.BADGE_STAR_COLOR), e.style.setProperty("--mjr-badge-image", z.BADGE_IMAGE_COLOR), e.style.setProperty("--mjr-badge-video", z.BADGE_VIDEO_COLOR), e.style.setProperty("--mjr-badge-audio", z.BADGE_AUDIO_COLOR), e.style.setProperty("--mjr-badge-model3d", z.BADGE_MODEL3D_COLOR), e.style.setProperty("--mjr-badge-duplicate-alert", z.BADGE_DUPLICATE_ALERT_COLOR), e.style.setProperty("--mjr-card-hover-color", z.UI_CARD_HOVER_COLOR), e.style.setProperty("--mjr-card-selection-color", z.UI_CARD_SELECTION_COLOR), e.style.setProperty("--mjr-rating-color", z.UI_RATING_COLOR), e.style.setProperty("--mjr-tag-color", z.UI_TAG_COLOR);
+	t("mjr-show-filename", R.GRID_SHOW_DETAILS_FILENAME), t("mjr-show-dimensions", R.GRID_SHOW_DETAILS_DIMENSIONS), t("mjr-show-date", R.GRID_SHOW_DETAILS_DATE), t("mjr-show-gentime", R.GRID_SHOW_DETAILS_GENTIME), t("mjr-show-hover-info", R.GRID_SHOW_HOVER_INFO), t("mjr-show-dot", R.GRID_SHOW_WORKFLOW_DOT), t("mjr-show-badges-ext", R.GRID_SHOW_BADGES_EXTENSION), t("mjr-show-badges-rating", R.GRID_SHOW_BADGES_RATING), t("mjr-show-badges-tags", R.GRID_SHOW_BADGES_TAGS), t("mjr-show-details", R.GRID_SHOW_DETAILS), e.style.setProperty("--mjr-grid-min-size", `${R.GRID_MIN_SIZE}px`), e.style.setProperty("--mjr-grid-gap", `${R.GRID_GAP}px`), e.style.setProperty("--mjr-star-active", R.BADGE_STAR_COLOR), e.style.setProperty("--mjr-badge-image", R.BADGE_IMAGE_COLOR), e.style.setProperty("--mjr-badge-video", R.BADGE_VIDEO_COLOR), e.style.setProperty("--mjr-badge-audio", R.BADGE_AUDIO_COLOR), e.style.setProperty("--mjr-badge-model3d", R.BADGE_MODEL3D_COLOR), e.style.setProperty("--mjr-badge-duplicate-alert", R.BADGE_DUPLICATE_ALERT_COLOR), e.style.setProperty("--mjr-card-hover-color", R.UI_CARD_HOVER_COLOR), e.style.setProperty("--mjr-card-selection-color", R.UI_CARD_SELECTION_COLOR), e.style.setProperty("--mjr-rating-color", R.UI_RATING_COLOR), e.style.setProperty("--mjr-tag-color", R.UI_TAG_COLOR);
 }
 function Si(e, { applySettingsClasses: t = !0 } = {}) {
 	if (!e) return null;
@@ -1026,7 +1026,7 @@ var Ri = {
 	}
 }, zi = null;
 function Bi() {
-	return zi ||= import("./chunks/viewerOpenRequest-DeJyXX9z.js").then((e) => e.n), zi;
+	return zi ||= import("./chunks/viewerOpenRequest-BcaSPESm.js").then((e) => e.n), zi;
 }
 function Vi(e) {
 	if (!e) return "";
@@ -1061,15 +1061,15 @@ function Wi(e, t, n) {
 			Ui.delete(i);
 			let e = await b(r, t);
 			if (!e?.ok) {
-				A(e?.error || R("toast.ratingUpdateFailed"), "error");
+				k(e?.error || L("toast.ratingUpdateFailed"), "error");
 				return;
 			}
-			A(R("toast.ratingSetN", { n: t }), "success", 1500), Rt(ct, {
+			k(L("toast.ratingSetN", { n: t }), "success", 1500), Rt(lt, {
 				assetId: String(r),
 				rating: t
 			}, { warnPrefix: "[GridKeyboard]" });
 		} catch (e) {
-			console.error("[GridKeyboard] Rating update failed:", e), A(R("toast.ratingUpdateError"), "error");
+			console.error("[GridKeyboard] Rating update failed:", e), k(L("toast.ratingUpdateError"), "error");
 		}
 	}, 350);
 	Ui.set(i, a);
@@ -1080,7 +1080,7 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		unbind: () => {},
 		dispose: () => {}
 	};
-	let c = null, l = null, d = null, f = null, p = !1, m = !1, h = ({ assets: e = [], index: t = 0, mode: n = "" } = {}) => {
+	let c = null, u = null, d = null, f = null, p = !1, m = !1, h = ({ assets: e = [], index: t = 0, mode: n = "" } = {}) => {
 		Bi().then((r) => r.requestViewerOpen({
 			assets: e,
 			index: t,
@@ -1125,8 +1125,8 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		}
 	}, b = (e) => {
 		if (!e?.filepath) return !1;
-		let t = Je(e.filepath), n = document.createElement("a");
-		return n.href = t, n.download = e.filename || "download", document.body.appendChild(n), n.click(), document.body.removeChild(n), A(R("toast.downloadingFile", "Downloading {filename}...", { filename: e.filename }), "info", 3e3), !0;
+		let t = Ye(e.filepath), n = document.createElement("a");
+		return n.href = t, n.download = e.filename || "download", document.body.appendChild(n), n.click(), document.body.removeChild(n), k(L("toast.downloadingFile", "Downloading {filename}...", { filename: e.filename }), "info", 3e3), !0;
 	}, x = () => {
 		try {
 			if (Array.isArray(t?.()?.assets) && t().assets.length) return t().assets;
@@ -1221,7 +1221,7 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		return !0;
 	}, E = async (n) => {
 		let r = n.target;
-		if (r && (r.tagName === "INPUT" || r.tagName === "TEXTAREA" || r.isContentEditable) || Se() || ge().scope === "viewer") return;
+		if (r && (r.tagName === "INPUT" || r.tagName === "TEXTAREA" || r.isContentEditable) || Ce() || _e().scope === "viewer") return;
 		if (document.activeElement !== document.body) {
 			let t = document.activeElement, n = e.contains(t), r = t && t.contains && t.contains(e), i = t?.closest?.(".mjr-asset-card");
 			if (!n && !r && !i) return;
@@ -1240,12 +1240,12 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let l = _(), d = y(), f = t();
+		let u = _(), d = y(), f = t();
 		if (Hi(n, Ri.DOWNLOAD) && d?.filepath) {
 			c(), m = !0;
 			return;
 		}
-		let p = !!ge().ratingHotkeysActive;
+		let p = !!_e().ratingHotkeysActive;
 		if (!n.ctrlKey && !n.altKey && !n.metaKey && !n.shiftKey) {
 			if (!p && Hi(n, Ri.RATING_1) && d?.id) {
 				c(), Wi(d, 1, s);
@@ -1272,11 +1272,11 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 				return;
 			}
 		}
-		if ((Hi(n, Ri.OPEN_VIEWER) || Hi(n, Ri.OPEN_VIEWER_ALT)) && l.length > 0) {
+		if ((Hi(n, Ri.OPEN_VIEWER) || Hi(n, Ri.OPEN_VIEWER_ALT)) && u.length > 0) {
 			c();
 			try {
-				if (l.length >= 2 && l.length <= 4) h({
-					assets: l,
+				if (u.length >= 2 && u.length <= 4) h({
+					assets: u,
 					index: 0
 				});
 				else {
@@ -1301,11 +1301,11 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 			c(), i(d);
 			return;
 		}
-		if (Hi(n, Ri.COMPARE_AB) && l.length === 2) {
+		if (Hi(n, Ri.COMPARE_AB) && u.length === 2) {
 			c();
 			try {
 				h({
-					assets: l,
+					assets: u,
 					index: 0,
 					mode: "ab"
 				});
@@ -1314,11 +1314,11 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 			}
 			return;
 		}
-		if (Hi(n, Ri.SIDE_BY_SIDE) && l.length >= 2 && l.length <= 4) {
+		if (Hi(n, Ri.SIDE_BY_SIDE) && u.length >= 2 && u.length <= 4) {
 			c();
 			try {
 				h({
-					assets: l,
+					assets: u,
 					index: 0,
 					mode: "sidebyside"
 				});
@@ -1331,9 +1331,9 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 			c(), a(d);
 			return;
 		}
-		if (Hi(n, Ri.ADD_TO_COLLECTION) && (l.length > 0 || d)) {
+		if (Hi(n, Ri.ADD_TO_COLLECTION) && (u.length > 0 || d)) {
 			c();
-			let t = l.length > 0 ? l : [d], n = e.getBoundingClientRect();
+			let t = u.length > 0 ? u : [d], n = e.getBoundingClientRect();
 			await Bt({
 				x: n.left + n.width / 2,
 				y: n.top + n.height / 2,
@@ -1343,17 +1343,17 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		}
 		if (Hi(n, Ri.REMOVE_FROM_COLLECTION)) {
 			let e = f?.collectionId;
-			if (e && (l.length > 0 || d)) {
+			if (e && (u.length > 0 || d)) {
 				c();
 				try {
-					let t = (l.length > 0 ? l : [d]).map((e) => String(e?.filepath || e?.path || e?.file_info?.filepath || "").trim()).filter(Boolean);
+					let t = (u.length > 0 ? u : [d]).map((e) => String(e?.filepath || e?.path || e?.file_info?.filepath || "").trim()).filter(Boolean);
 					if (!t.length) {
-						A(R("toast.removeFromCollectionFailed", "No valid files to remove from collection"), "warning");
+						k(L("toast.removeFromCollectionFailed", "No valid files to remove from collection"), "warning");
 						return;
 					}
-					let n = await se(e, t);
+					let n = await ae(e, t);
 					if (!n?.ok) {
-						A(n?.error || R("toast.removeFromCollectionFailed", "Failed to remove from collection"), "error");
+						k(n?.error || L("toast.removeFromCollectionFailed", "Failed to remove from collection"), "error");
 						return;
 					}
 					try {
@@ -1361,9 +1361,9 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 					} catch (e) {
 						console.debug?.(e);
 					}
-					A(R("toast.removedFromCollection", "Removed from collection"), "success", 1400);
+					k(L("toast.removedFromCollection", "Removed from collection"), "success", 1400);
 				} catch (e) {
-					A(R("toast.removeFromCollectionError", "Error removing from collection: {error}", { error: e?.message || String(e || "") }), "error");
+					k(L("toast.removeFromCollectionError", "Error removing from collection: {error}", { error: e?.message || String(e || "") }), "error");
 				}
 				return;
 			}
@@ -1371,50 +1371,50 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		if (Hi(n, Ri.COPY_PATH) && d?.filepath) {
 			c();
 			try {
-				await navigator.clipboard.writeText(d.filepath), A(R("toast.pathCopied"), "success", 2e3);
+				await navigator.clipboard.writeText(d.filepath), k(L("toast.pathCopied"), "success", 2e3);
 			} catch {
-				A(R("toast.pathCopyFailed"), "error");
+				k(L("toast.pathCopyFailed"), "error");
 			}
 			return;
 		}
 		if (Hi(n, Ri.OPEN_IN_FOLDER) && d?.id) {
 			c();
-			let e = await ce(d.id);
-			e?.ok ? A(R("toast.openedInFolder"), "info", 2e3) : A(e?.error || R("toast.openFolderFailed"), "error");
+			let e = await se(d.id);
+			e?.ok ? k(L("toast.openedInFolder"), "info", 2e3) : k(e?.error || L("toast.openFolderFailed"), "error");
 			return;
 		}
 		if (Hi(n, Ri.RENAME) && d?.id) {
 			c();
-			let e = d.filename || "", t = bt(await Et(R("dialog.rename.title", "Rename file"), e), e);
+			let e = d.filename || "", t = bt(await Et(L("dialog.rename.title", "Rename file"), e), e);
 			if (t && t !== e) {
 				let e = At(t);
 				if (!e.valid) {
-					A(e.reason, "error");
+					k(e.reason, "error");
 					return;
 				}
 				try {
-					let e = await N(d, t);
+					let e = await j(d, t);
 					if (e?.ok) {
 						let n = e?.data?.asset;
-						n && typeof n == "object" ? Object.assign(d, n) : (d.filename = t, d.filepath = d.filepath?.replace(/[^\\/]+$/, t), d.path &&= String(d.path).replace(/[^\\/]+$/, t), d.file_info && typeof d.file_info == "object" && (d.file_info.filename = t, d.file_info.filepath && (d.file_info.filepath = String(d.file_info.filepath).replace(/[^\\/]+$/, t)), d.file_info.path && (d.file_info.path = String(d.file_info.path).replace(/[^\\/]+$/, t)))), A(R("toast.fileRenamedSuccess"), "success");
+						n && typeof n == "object" ? Object.assign(d, n) : (d.filename = t, d.filepath = d.filepath?.replace(/[^\\/]+$/, t), d.path &&= String(d.path).replace(/[^\\/]+$/, t), d.file_info && typeof d.file_info == "object" && (d.file_info.filename = t, d.file_info.filepath && (d.file_info.filepath = String(d.file_info.filepath).replace(/[^\\/]+$/, t)), d.file_info.path && (d.file_info.path = String(d.file_info.path).replace(/[^\\/]+$/, t)))), k(L("toast.fileRenamedSuccess"), "success");
 						try {
 							window.dispatchEvent(new CustomEvent("mjr:reload-grid", { detail: { reason: "rename-keyboard" } }));
 						} catch (e) {
 							console.debug?.(e);
 						}
 						s();
-					} else A(e?.error || R("toast.fileRenameFailed"), "error");
+					} else k(e?.error || L("toast.fileRenameFailed"), "error");
 				} catch (e) {
-					A(R("toast.errorRenaming", "Error renaming file: {error}", { error: e?.message || String(e || "") }), "error");
+					k(L("toast.errorRenaming", "Error renaming file: {error}", { error: e?.message || String(e || "") }), "error");
 				}
 			}
 			return;
 		}
-		if ((Hi(n, Ri.DELETE) || Hi(n, Ri.DELETE_ALT)) && (d?.id || l.length > 0)) {
+		if ((Hi(n, Ri.DELETE) || Hi(n, Ri.DELETE_ALT)) && (d?.id || u.length > 0)) {
 			c();
-			let t = l.length > 0 ? l : [d], n = 0, r = 0, i = [];
+			let t = u.length > 0 ? u : [d], n = 0, r = 0, i = [];
 			for (let e of t) if (e?.id) try {
-				(await u(e.id))?.ok ? (n++, i.push(String(e.id))) : r++;
+				(await l(e.id))?.ok ? (n++, i.push(String(e.id))) : r++;
 			} catch {
 				r++;
 			}
@@ -1425,13 +1425,13 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 			} catch (e) {
 				console.debug?.(e);
 			}
-			r === 0 ? A(R("toast.filesDeletedShort", "{n} files deleted", { n }), "success") : A(R("toast.filesDeletedShortPartial", "{success} deleted, {failed} failed", {
+			r === 0 ? k(L("toast.filesDeletedShort", "{n} files deleted", { n }), "success") : k(L("toast.filesDeletedShortPartial", "{success} deleted, {failed} failed", {
 				success: n,
 				failed: r
 			}), "warning");
 			try {
 				if (typeof e?._mjrSetSelection == "function") {
-					let t = l.filter((e) => !i.includes(String(e?.id || ""))).map((e) => String(e?.id || "")).filter(Boolean);
+					let t = u.filter((e) => !i.includes(String(e?.id || ""))).map((e) => String(e?.id || "")).filter(Boolean);
 					e._mjrSetSelection(t, t[0] || "");
 				}
 			} catch (e) {
@@ -1480,16 +1480,16 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 			return;
 		}
 	}, D = (e) => {
-		if (String(e?.key || "").toLowerCase() !== "s" || !m || (m = !1, Se()) || ge().scope === "viewer") return;
+		if (String(e?.key || "").toLowerCase() !== "s" || !m || (m = !1, Ce()) || _e().scope === "viewer") return;
 		let t = y();
 		t?.filepath && (e.preventDefault?.(), e.stopPropagation?.(), e.stopImmediatePropagation?.(), b(t));
 	}, O = () => {
 		m = !1;
-	}, k = () => {
-		p ||= (c = E, l = D, d = O, f = () => g(), document.addEventListener("keydown", c, !0), document.addEventListener("keyup", l, !0), document.addEventListener("dragstart", d, !0), e.addEventListener("pointerdown", f, !0), e.addEventListener("focusin", f, !0), !0);
-	}, j = () => {
+	}, A = () => {
+		p ||= (c = E, u = D, d = O, f = () => g(), document.addEventListener("keydown", c, !0), document.addEventListener("keyup", u, !0), document.addEventListener("dragstart", d, !0), e.addEventListener("pointerdown", f, !0), e.addEventListener("focusin", f, !0), !0);
+	}, M = () => {
 		if (!(!p || !c)) {
-			document.removeEventListener("keydown", c, !0), l && document.removeEventListener("keyup", l, !0), d && document.removeEventListener("dragstart", d, !0), f && (e.removeEventListener("pointerdown", f, !0), e.removeEventListener("focusin", f, !0)), c = null, l = null, d = null, f = null, m = !1;
+			document.removeEventListener("keydown", c, !0), u && document.removeEventListener("keyup", u, !0), d && document.removeEventListener("dragstart", d, !0), f && (e.removeEventListener("pointerdown", f, !0), e.removeEventListener("focusin", f, !0)), c = null, u = null, d = null, f = null, m = !1;
 			try {
 				Xn(e);
 			} catch (e) {
@@ -1510,10 +1510,10 @@ function Gi({ gridContainer: e, getState: t = () => ({}), getSelectedAssets: n =
 		}
 	};
 	return {
-		bind: k,
-		unbind: j,
+		bind: A,
+		unbind: M,
 		dispose: () => {
-			j();
+			M();
 			for (let e of Ui.values()) try {
 				clearTimeout(e);
 			} catch (e) {
@@ -1543,10 +1543,10 @@ function Yi() {
 //#region ui/features/contextmenu/GridContextMenu.ts
 var Xi = 1, Zi = null, Qi = null;
 function $i() {
-	return Zi ||= import("./chunks/viewerOpenRequest-DeJyXX9z.js").then((e) => e.n), Zi;
+	return Zi ||= import("./chunks/viewerOpenRequest-BcaSPESm.js").then((e) => e.n), Zi;
 }
 function ea() {
-	return Qi ||= import("./chunks/floatingViewerManager-CGdpmtv-.js").then((e) => e.n), Qi;
+	return Qi ||= import("./chunks/floatingViewerManager-C0fDYFQu.js").then((e) => e.n), Qi;
 }
 function ta(e) {
 	let t = String(e || "").trim().toLowerCase();
@@ -1634,7 +1634,7 @@ async function aa(e) {
 	let t = String(e?.filepath || e?.path || e?.full_path || "").trim();
 	if (!t) return e;
 	try {
-		let n = await w(t, { timeoutMs: 25e3 }), r = n?.data?.workflow || n?.workflow || null, i = n?.data?.prompt || n?.prompt || null;
+		let n = await C(t, { timeoutMs: 25e3 }), r = n?.data?.workflow || n?.workflow || null, i = n?.data?.prompt || n?.prompt || null;
 		return !r && !i ? e : {
 			...e,
 			workflow: r || e?.workflow,
@@ -1663,7 +1663,7 @@ var oa = (e) => {
 		filename: t,
 		subfolder: e.subfolder || "",
 		type: String(e.type || e.source || "output").toLowerCase(),
-		root_id: Ne(e) || void 0,
+		root_id: Pe(e) || void 0,
 		kind: String(e.kind || "").toLowerCase()
 	} : null;
 }, ca = (e) => {
@@ -1673,7 +1673,7 @@ var oa = (e) => {
 		filename: t,
 		subfolder: e.subfolder || "",
 		type: String(e.type || e.source || "output").toLowerCase(),
-		root_id: Ne(e) || void 0
+		root_id: Pe(e) || void 0
 	} : null;
 };
 function la(e, t = "") {
@@ -1684,28 +1684,28 @@ function la(e, t = "") {
 async function ua(e) {
 	let t = (Array.isArray(e) ? e.filter((e) => !Ca(e)) : []).map(ca).filter(Boolean);
 	if (t.length < 2) {
-		A("Select at least two files to download a ZIP.", "warning", 2600);
+		k("Select at least two files to download a ZIP.", "warning", 2600);
 		return;
 	}
 	let n = "";
 	try {
-		n = qe("mjr_", 24);
+		n = Je("mjr_", 24);
 	} catch (e) {
-		P(e, "[GridContextMenu] Batch ZIP token", { showToast: z.DEBUG_VERBOSE_ERRORS }), A("Could not create a secure ZIP token.", "error");
+		P(e, "[GridContextMenu] Batch ZIP token", { showToast: R.DEBUG_VERBOSE_ERRORS }), k("Could not create a secure ZIP token.", "error");
 		return;
 	}
-	A(`Preparing ZIP for ${t.length} files...`, "info", 1800);
-	let r = await ue(lt.BATCH_ZIP_CREATE, {
+	k(`Preparing ZIP for ${t.length} files...`, "info", 1800);
+	let r = await ue(B.BATCH_ZIP_CREATE, {
 		token: n,
 		items: t,
 		strip_metadata: !1
 	});
 	if (!r?.ok) {
-		A(r?.error || "Failed to create ZIP.", "error");
+		k(r?.error || "Failed to create ZIP.", "error");
 		return;
 	}
 	let i = r?.data?.filename || `Majoor_Batch_${t.length}.zip`;
-	la(et(n), i), A(`Downloading ${i}...`, "info", 3e3);
+	la(tt(n), i), k(`Downloading ${i}...`, "info", 3e3);
 }
 async function da(e) {
 	let t = Array.isArray(e) ? e.filter(Boolean) : [], n = await Promise.all(t.map(async (e) => {
@@ -1713,7 +1713,7 @@ async function da(e) {
 		if (!t) return null;
 		let n = (await $t({
 			post: ue,
-			endpoint: lt.STAGE_TO_INPUT,
+			endpoint: B.STAGE_TO_INPUT,
 			payload: t,
 			index: !1
 		}))?.relativePath;
@@ -1724,7 +1724,7 @@ async function da(e) {
 		} : null;
 	}));
 	return Hn({
-		app: tt(),
+		app: nt(),
 		items: n.filter(Boolean),
 		event: null
 	});
@@ -1840,7 +1840,7 @@ async function ya(e, t) {
 		ok: !1,
 		error: "Missing filename"
 	};
-	let r = await ue(lt.INDEX_FILES, {
+	let r = await ue(B.INDEX_FILES, {
 		files: [n],
 		incremental: !1
 	});
@@ -1849,7 +1849,7 @@ async function ya(e, t) {
 		error: "Index refresh failed"
 	};
 	if (e?.id != null) try {
-		let t = await oe(e.id);
+		let t = await ie(e.id);
 		if (t?.ok && t?.data && typeof t.data == "object") {
 			Object.assign(e, t.data);
 			let n = _a(e, t.data), r = n?.querySelector?.(".mjr-workflow-dot");
@@ -1884,23 +1884,24 @@ function ba(e, t, n) {
 			errorMessage: "Failed to update rating",
 			warnPrefix: "[GridContextMenu]",
 			onSuccess: () => {
-				Rt(ct, {
+				Rt(lt, {
 					assetId: String(r),
 					rating: t
 				}, { warnPrefix: "[GridContextMenu]" });
 			},
 			onFailure: (e) => {
-				P(e, "[GridContextMenu] Rating update", { showToast: z.DEBUG_VERBOSE_ERRORS });
+				P(e, "[GridContextMenu] Rating update", { showToast: R.DEBUG_VERBOSE_ERRORS });
 			}
 		});
 		return;
 	}
 	b(e, t).catch((e) => {
-		P(e, "[GridContextMenu] Rating update", { showToast: z.DEBUG_VERBOSE_ERRORS });
+		P(e, "[GridContextMenu] Rating update", { showToast: R.DEBUG_VERBOSE_ERRORS });
 	});
 }
 function xa(e) {
-	return String(e?.scope || "").toLowerCase() === "custom";
+	let t = String(e?.scope || "").toLowerCase();
+	return t === "custom" || t === "input" || t === "output";
 }
 function Sa(e) {
 	return String(e?.scope || "").toLowerCase() === "workflow";
@@ -1939,7 +1940,7 @@ async function Ea(e) {
 	let n = e?.id;
 	if (n == null || n === "") return null;
 	try {
-		let t = await oe(n, { timeoutMs: 3e4 }), r = t?.data;
+		let t = await ie(n, { timeoutMs: 3e4 }), r = t?.data;
 		if (t?.ok && r && typeof r == "object") return Object.assign(e, r), qn(e);
 	} catch (e) {
 		console.debug?.(e);
@@ -1949,46 +1950,46 @@ async function Ea(e) {
 async function Da(e) {
 	let t = await Ea(e);
 	if (!t || typeof t != "object") {
-		A(R("toast.assetWorkflowMissing", "No embedded ComfyUI workflow was found for this asset."), "warn", 2600);
+		k(L("toast.assetWorkflowMissing", "No embedded ComfyUI workflow was found for this asset."), "warn", 2600);
 		return;
 	}
-	let n = Pe(t, tt());
+	let n = Fe(t, nt());
 	if (!n.ok) {
-		A(R("toast.workflowImportUnavailable", "ComfyUI workflow import is unavailable in this frontend."), "error");
+		k(L("toast.workflowImportUnavailable", "ComfyUI workflow import is unavailable in this frontend."), "error");
 		return;
 	}
-	A(n.mode === "new-tab" ? R("toast.workflowLoadedNewTab", "Workflow loaded in a new ComfyUI tab.") : R("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
+	k(n.mode === "new-tab" ? L("toast.workflowLoadedNewTab", "Workflow loaded in a new ComfyUI tab.") : L("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
 }
 async function Oa(e) {
 	let t = String(e?.filepath || e?.path || e?.full_path || "").trim();
 	if (!t) {
-		A(R("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+		k(L("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 		return;
 	}
-	let n = tt();
-	if (Re(n) === !0 && !await Gt(R("dialog.workflowLoadReplaceDirty", "Current canvas has unsaved changes. Replace it with this workflow?"), R("tab.workflow", "Workflow"))) return;
-	let r = await w(t, { timeoutMs: 3e4 }), i = r?.data?.workflow || r?.workflow || null;
-	if (!r?.ok || !i || typeof i != "object") {
-		A(r?.error || R("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+	let n = nt();
+	if (ze(n) === !0 && !await Gt(L("dialog.workflowLoadReplaceDirty", "Current canvas has unsaved changes. Replace it with this workflow?"), L("tab.workflow", "Workflow"))) return;
+	let r = await C(t, { timeoutMs: 3e4 }), a = r?.data?.workflow || r?.workflow || null;
+	if (!r?.ok || !a || typeof a != "object") {
+		k(r?.error || L("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 		return;
 	}
-	let o = Pe(i, n);
+	let o = Fe(a, n);
 	if (!o.ok) {
-		let e = Je(t, { inline: !0 });
+		let e = Ye(t, { inline: !0 });
 		try {
 			e && typeof window < "u" && window.open(e, "_blank", "noopener,noreferrer");
 		} catch (e) {
 			console.debug?.(e);
 		}
-		A(R("toast.workflowImportFallback", "ComfyUI workflow import is unavailable in this frontend. Opened workflow JSON for manual import."), "warn"), o.mode === "new-tab" && A(R("toast.workflowLoadedNewTab", "Workflow loaded in a new ComfyUI tab."), "success");
+		k(L("toast.workflowImportFallback", "ComfyUI workflow import is unavailable in this frontend. Opened workflow JSON for manual import."), "warn"), o.mode === "new-tab" && k(L("toast.workflowLoadedNewTab", "Workflow loaded in a new ComfyUI tab."), "success");
 		return;
 	}
 	try {
-		await a({ filepath: t }, { timeoutMs: 1e4 });
+		await i({ filepath: t }, { timeoutMs: 1e4 });
 	} catch (e) {
 		console.debug?.(e);
 	}
-	A(R("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
+	k(L("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
 }
 function ka(e) {
 	try {
@@ -1998,94 +1999,94 @@ function ka(e) {
 	}
 }
 async function Aa(e) {
-	let t = await pe({ filepath: String(e?.filepath || "").trim() }, { timeoutMs: 3e4 });
+	let t = await me({ filepath: String(e?.filepath || "").trim() }, { timeoutMs: 3e4 });
 	if (!t?.ok) {
-		A(t?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+		k(t?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 		return;
 	}
-	A(R("toast.workflowSaved", "Workflow saved"), "success", 1800), ka("workflow-duplicate");
+	k(L("toast.workflowSaved", "Workflow saved"), "success", 1800), ka("workflow-duplicate");
 }
 async function ja(e) {
-	let t = String(e?.filepath || "").trim(), n = String(e?.display_name || e?.filename || "").replace(/\.json$/i, ""), r = await Et(R("ctx.renameWorkflow", "Rename workflow"), n, R("tab.workflow", "Workflow")), i = String(r || "").trim();
+	let t = String(e?.filepath || "").trim(), n = String(e?.display_name || e?.filename || "").replace(/\.json$/i, ""), r = await Et(L("ctx.renameWorkflow", "Rename workflow"), n, L("tab.workflow", "Workflow")), i = String(r || "").trim();
 	if (!i) return;
-	let a = await v({
+	let a = await y({
 		filepath: t,
 		name: i
 	}, { timeoutMs: 3e4 });
 	if (!a?.ok) {
-		A(a?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+		k(a?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 		return;
 	}
-	A(R("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-rename");
+	k(L("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-rename");
 }
 async function Ma(e) {
-	let t = String(e?.filepath || "").trim(), n = String(e?.subfolder || "").trim(), r = await Et(R("dialog.workflowCategory", "Workflow category"), n, R("tab.workflow", "Workflow"));
+	let t = String(e?.filepath || "").trim(), n = String(e?.subfolder || "").trim(), r = await Et(L("dialog.workflowCategory", "Workflow category"), n, L("tab.workflow", "Workflow"));
 	if (r == null) return;
-	let i = await v({
+	let i = await y({
 		filepath: t,
 		category: String(r || "")
 	}, { timeoutMs: 3e4 });
 	if (!i?.ok) {
-		A(i?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+		k(i?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 		return;
 	}
-	A(R("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-categorize");
+	k(L("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-categorize");
 }
 async function Na(e) {
 	let t = String(e?.filepath || "").trim();
 	if (!t) {
-		A(R("toast.noFilePath"), "error");
+		k(L("toast.noFilePath"), "error");
 		return;
 	}
-	let n = await Ee({
+	let n = await De({
 		filepath: t,
 		limit: 12
 	}, { timeoutMs: 15e3 });
 	if (!n?.ok) {
-		A(n?.error || R("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+		k(n?.error || L("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 		return;
 	}
 	let r = Array.isArray(n.data) ? n.data : [];
 	if (!r.length) {
-		A(R("toast.workflowThumbnailNoCandidates", "No linked outputs are available for this workflow yet."), "warning", 2600);
+		k(L("toast.workflowThumbnailNoCandidates", "No linked outputs are available for this workflow yet."), "warning", 2600);
 		return;
 	}
 	let i = await Pn({
-		title: R("ctx.setWorkflowThumbnail", "Set workflow thumbnail"),
+		title: L("ctx.setWorkflowThumbnail", "Set workflow thumbnail"),
 		workflow: e,
 		items: r
 	});
 	if (!i?.filepath) return;
-	let a = await _({
+	let a = await v({
 		filepath: t,
 		source_filepath: i.filepath
 	}, { timeoutMs: 3e4 });
 	if (!a?.ok) {
-		A(a?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+		k(a?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 		return;
 	}
-	A(R("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-thumbnail");
+	k(L("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-thumbnail");
 }
 async function Pa(e) {
 	let t = String(e?.filepath || "").trim();
 	if (!t) {
-		A(R("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+		k(L("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 		return;
 	}
-	let n = await w(t, { timeoutMs: 3e4 });
+	let n = await C(t, { timeoutMs: 3e4 });
 	if (!n?.ok) {
-		A(n?.error || R("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+		k(n?.error || L("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 		return;
 	}
 	let r = n?.data?.workflow || n?.workflow || null;
 	if (!r || typeof r != "object") {
-		A(R("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+		k(L("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 		return;
 	}
 	let i = String(e?.filename || e?.display_name || "workflow.json").replace(/[\\/:*?"<>|]+/g, "_").replace(/\.json$/i, "") || "workflow", a = new Blob([`${JSON.stringify(r, null, 2)}\n`], { type: "application/json" }), o = URL.createObjectURL(a);
 	try {
 		let e = document.createElement("a");
-		e.href = o, e.download = `${i}.json`, e.rel = "noopener", document.body.appendChild(e), e.click(), e.remove(), A(R("toast.workflowExported", "Workflow exported"), "success", 1800);
+		e.href = o, e.download = `${i}.json`, e.rel = "noopener", document.body.appendChild(e), e.click(), e.remove(), k(L("toast.workflowExported", "Workflow exported"), "success", 1800);
 	} finally {
 		setTimeout(() => URL.revokeObjectURL(o), 5e3);
 	}
@@ -2093,48 +2094,48 @@ async function Pa(e) {
 async function Fa(e) {
 	let t = String(e?.filepath || "").trim();
 	if (!t) {
-		A(R("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+		k(L("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 		return;
 	}
-	let n = await ce({ filepath: t });
+	let n = await se({ filepath: t });
 	if (!n?.ok) {
-		A(n?.error || R("toast.openFolderFailed", "Failed to open folder."), "error");
+		k(n?.error || L("toast.openFolderFailed", "Failed to open folder."), "error");
 		return;
 	}
-	A(R("toast.openedInFolder", "Opened in folder"), "success", 1600);
+	k(L("toast.openedInFolder", "Opened in folder"), "success", 1600);
 }
 async function Ia(e) {
 	let t = oa(e);
 	if (!t) {
-		A(R("toast.noFilePath"), "error");
+		k(L("toast.noFilePath"), "error");
 		return;
 	}
 	let n = await kn({
-		title: R("ctx.assignAsWorkflowThumbnail", "Use as workflow thumbnail"),
+		title: L("ctx.assignAsWorkflowThumbnail", "Use as workflow thumbnail"),
 		sourceAsset: e
 	}), r = String(n?.filepath || "").trim();
 	if (!r) return;
 	let i = String(e?.kind || "").toLowerCase() === "video" || /\.(mp4|webm|mov|mkv|avi|m4v)$/i.test(t);
-	A(i ? R("toast.workflowThumbnailConverting", "Preparing a 5 second animated workflow thumbnail...") : R("toast.workflowThumbnailApplying", "Applying workflow thumbnail..."), "info", 2200);
-	let a = await _({
+	k(i ? L("toast.workflowThumbnailConverting", "Preparing a 5 second animated workflow thumbnail...") : L("toast.workflowThumbnailApplying", "Applying workflow thumbnail..."), "info", 2200);
+	let a = await v({
 		filepath: r,
 		source_filepath: t
 	}, { timeoutMs: i ? 75e3 : 3e4 });
 	if (!a?.ok) {
-		A(a?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+		k(a?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 		return;
 	}
-	A(R("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-thumbnail-assign");
+	k(L("toast.workflowUpdated", "Workflow updated"), "success", 1800), ka("workflow-thumbnail-assign");
 }
 async function La(e) {
 	let t = String(e?.filepath || "").trim();
-	if (!await Gt(R("dialog.deleteWorkflowConfirm", "Delete this workflow JSON and its adjacent thumbnail files?"), R("ctx.deleteWorkflow", "Delete workflow"))) return;
-	let n = await ie({ filepath: t }, { timeoutMs: 3e4 });
+	if (!await Gt(L("dialog.deleteWorkflowConfirm", "Delete this workflow JSON and its adjacent thumbnail files?"), L("ctx.deleteWorkflow", "Delete workflow"))) return;
+	let n = await F({ filepath: t }, { timeoutMs: 3e4 });
 	if (!n?.ok) {
-		A(n?.error || R("toast.fileDeleteFailed", "Failed to delete file."), "error");
+		k(n?.error || L("toast.fileDeleteFailed", "Failed to delete file."), "error");
 		return;
 	}
-	A(R("toast.workflowDeleted", "Workflow deleted"), "success", 1800), ka("workflow-delete");
+	k(L("toast.workflowDeleted", "Workflow deleted"), "success", 1800), ka("workflow-delete");
 }
 function Ra(e) {
 	let t = ra(e), n = ia(e), r = n.length || t.size;
@@ -2167,33 +2168,39 @@ function za(e, t) {
 			ba(e, 1, () => r(1));
 		}, { disabled: !t }),
 		na(),
-		$(R("ctx.resetRating", "Reset rating"), "pi pi-star", "0", async () => {
+		$(L("ctx.resetRating", "Reset rating"), "pi pi-star", "0", async () => {
 			ba(e, 0, () => r(0));
 		}, { disabled: !t })
 	];
 }
-function Ba({ currentPath: e, gridContainer: t } = {}) {
-	return [$(R("ctx.createFolderHere", "Create folder here..."), "pi pi-plus", null, async () => {
+function Ba(e, t) {
+	let n = String(t?.dataset?.mjrScope || "").toLowerCase();
+	if (n !== "input" && n !== "output") return e;
+	let r = String(e || "").trim().replaceAll("\\", "/");
+	return r ? `mjr://${n}/${r}` : `mjr://${n}`;
+}
+function Va({ currentPath: e, gridContainer: t } = {}) {
+	return [$(L("ctx.createFolderHere", "Create folder here..."), "pi pi-plus", null, async () => {
 		try {
-			let n = await Et(R("dialog.newFolderName", "New folder name"), ""), r = String(n || "").trim();
+			let n = await Et(L("dialog.newFolderName", "New folder name"), ""), r = String(n || "").trim();
 			if (!r) return;
 			let i = await Ae({
 				op: "create",
-				path: e,
+				path: Ba(e, t),
 				name: r
 			});
 			if (!i?.ok) {
-				A(i?.error || "Failed to create folder", "error");
+				k(i?.error || "Failed to create folder", "error");
 				return;
 			}
-			va(t), A(R("toast.folderCreated", "Folder created: {name}", { name: r }), "success");
+			va(t), k(L("toast.folderCreated", "Folder created: {name}", { name: r }), "success");
 		} catch (e) {
-			A(R("toast.createFolderFailedDetail", "Create folder failed: {error}", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.createFolderFailedDetail", "Create folder failed: {error}", { error: e?.message || String(e || "") }), "error");
 		}
 	})];
 }
-function Va({ asset: e, gridContainer: t, panelState: n } = {}) {
-	let r = String(e?.filepath || "").trim(), i = [$(R("ctx.openFolder", "Open folder"), "pi pi-folder-open", null, () => {
+function Ha({ asset: e, gridContainer: t, panelState: n } = {}) {
+	let r = String(e?.filepath || "").trim(), i = [$(L("ctx.openFolder", "Open folder"), "pi pi-folder-open", null, () => {
 		try {
 			t.dispatchEvent(new CustomEvent("mjr:open-folder-asset", {
 				bubbles: !0,
@@ -2202,29 +2209,29 @@ function Va({ asset: e, gridContainer: t, panelState: n } = {}) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}), $(R("ctx.pinAsBrowserRoot"), "pi pi-bookmark", null, async () => {
+	}), $(L("ctx.pinAsBrowserRoot"), "pi pi-bookmark", null, async () => {
 		if (!r) {
-			A(R("toast.unableResolveFolderPath"), "error");
+			k(L("toast.unableResolveFolderPath"), "error");
 			return;
 		}
-		let t = await Et(R("dialog.browserRootLabelOptional"), String(e?.filename || "")), n = await ue(lt.CUSTOM_ROOTS, {
+		let t = await Et(L("dialog.browserRootLabelOptional"), String(e?.filename || "")), n = await ue(B.CUSTOM_ROOTS, {
 			path: r,
 			label: String(t || "").trim() || void 0
 		});
 		if (!n?.ok) {
-			A(n?.error || R("toast.pinFolderFailed"), "error");
+			k(n?.error || L("toast.pinFolderFailed"), "error");
 			return;
 		}
-		A(R("toast.folderPinnedAsBrowserRoot"), "success");
+		k(L("toast.folderPinnedAsBrowserRoot"), "success");
 		try {
 			window.dispatchEvent(new CustomEvent("mjr:custom-roots-changed", { detail: { preferredId: String(n?.data?.id || "") } }));
 		} catch (e) {
 			console.debug?.(e);
 		}
 	})];
-	return xa(n) && r && i.push(na(), $(R("ctx.createFolderHere"), "pi pi-plus", null, async () => {
+	return xa(n) && r && i.push(na(), $(L("ctx.createFolderHere"), "pi pi-plus", null, async () => {
 		try {
-			let e = await Et(R("dialog.newFolderName"), ""), n = String(e || "").trim();
+			let e = await Et(L("dialog.newFolderName"), ""), n = String(e || "").trim();
 			if (!n) return;
 			let i = await Ae({
 				op: "create",
@@ -2232,16 +2239,16 @@ function Va({ asset: e, gridContainer: t, panelState: n } = {}) {
 				name: n
 			});
 			if (!i?.ok) {
-				A(i?.error || R("toast.createFolderFailed"), "error");
+				k(i?.error || L("toast.createFolderFailed"), "error");
 				return;
 			}
-			va(t), A(R("toast.folderCreated", { name: n }), "success");
+			va(t), k(L("toast.folderCreated", { name: n }), "success");
 		} catch (e) {
-			A(R("toast.createFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.createFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
 		}
-	}), $(R("ctx.renameFolder"), "pi pi-pencil", null, async () => {
+	}), $(L("ctx.renameFolder"), "pi pi-pencil", null, async () => {
 		try {
-			let n = String(e?.filename || "").trim(), i = await Et(R("dialog.renameFolder"), n), a = String(i || "").trim();
+			let n = String(e?.filename || "").trim(), i = await Et(L("dialog.renameFolder"), n), a = String(i || "").trim();
 			if (!a || a === n) return;
 			let o = await Ae({
 				op: "rename",
@@ -2249,16 +2256,16 @@ function Va({ asset: e, gridContainer: t, panelState: n } = {}) {
 				name: a
 			});
 			if (!o?.ok) {
-				A(o?.error || R("toast.renameFolderFailed"), "error");
+				k(o?.error || L("toast.renameFolderFailed"), "error");
 				return;
 			}
-			va(t), A(R("toast.folderRenamed"), "success");
+			va(t), k(L("toast.folderRenamed"), "success");
 		} catch (e) {
-			A(R("toast.renameFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.renameFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
 		}
-	}), $(R("ctx.moveFolder"), "pi pi-arrow-right", null, async () => {
+	}), $(L("ctx.moveFolder"), "pi pi-arrow-right", null, async () => {
 		try {
-			let e = await Et(R("dialog.destinationDirectoryPath"), ""), n = String(e || "").trim();
+			let e = await Et(L("dialog.destinationDirectoryPath"), ""), n = String(e || "").trim();
 			if (!n) return;
 			let i = await Ae({
 				op: "move",
@@ -2266,39 +2273,39 @@ function Va({ asset: e, gridContainer: t, panelState: n } = {}) {
 				destination: n
 			});
 			if (!i?.ok) {
-				A(i?.error || R("toast.moveFolderFailed"), "error");
+				k(i?.error || L("toast.moveFolderFailed"), "error");
 				return;
 			}
-			va(t), A(R("toast.folderMoved"), "success");
+			va(t), k(L("toast.folderMoved"), "success");
 		} catch (e) {
-			A(R("toast.moveFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.moveFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
 		}
-	}), $(R("ctx.deleteFolder"), "pi pi-trash", null, async () => {
+	}), $(L("ctx.deleteFolder"), "pi pi-trash", null, async () => {
 		try {
-			if (!await Gt(R("dialog.deleteFolderRecursive", { name: String(e?.filename || R("label.thisFolder", "this folder")) }))) return;
+			if (!await Gt(L("dialog.deleteFolderRecursive", { name: String(e?.filename || L("label.thisFolder", "this folder")) }))) return;
 			let n = await Ae({
 				op: "delete",
 				path: r,
 				recursive: !0
 			});
 			if (!n?.ok) {
-				A(n?.error || R("toast.deleteFolderFailed"), "error");
+				k(n?.error || L("toast.deleteFolderFailed"), "error");
 				return;
 			}
-			va(t), A(R("toast.folderDeleted"), "success");
+			va(t), k(L("toast.folderDeleted"), "success");
 		} catch (e) {
-			A(R("toast.deleteFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.deleteFolderFailedDetail", { error: e?.message || String(e || "") }), "error");
 		}
 	})), i;
 }
-function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, pointerY: o, selection: s } = {}) {
-	let { selectedAssetsNow: c, effectiveSelectionCount: l, isMultiSelected: d, hasSelection: f } = s, p = [], m = Sa(i), h = ({ assets: e = [], index: t = 0, mode: n = "" } = {}) => $i().then((r) => r.requestViewerOpen({
+function Ua({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, pointerY: o, selection: s } = {}) {
+	let { selectedAssetsNow: c, effectiveSelectionCount: u, isMultiSelected: d, hasSelection: f } = s, p = [], m = Sa(i), h = ({ assets: e = [], index: t = 0, mode: n = "" } = {}) => $i().then((r) => r.requestViewerOpen({
 		assets: e,
 		index: t,
 		mode: n
 	})).catch((e) => console.debug?.(e));
 	if (wa(e)) {
-		if (p.push($(R("ctx.loadWorkflow", "Load workflow"), "pi pi-sitemap", null, () => Oa(e)), $(R("ctx.duplicateWorkflow", "Duplicate workflow"), "pi pi-copy", null, () => Aa(e)), $(R("ctx.renameWorkflow", "Rename workflow"), "pi pi-pencil", null, () => ja(e)), $(R("ctx.categorizeWorkflow", "Set workflow category"), "pi pi-folder", null, () => Ma(e)), $(R("ctx.setWorkflowThumbnail", "Set workflow thumbnail"), "pi pi-image", null, () => Na(e)), $(R("ctx.editWorkflowInfo", "Edit infos"), "pi pi-info-circle", null, () => Ji(e)), $(R("ctx.exportWorkflow", "Export workflow"), "pi pi-download", null, () => Pa(e)), $(R("ctx.showInExplorer", "Show in Explorer"), "pi pi-folder-open", null, () => Fa(e)), $(R("ctx.deleteWorkflow", "Delete workflow"), "pi pi-trash", null, () => La(e)), na()), m) return p.push($("Open Graph Map", "pi pi-sitemap", null, async () => {
+		if (p.push($(L("ctx.loadWorkflow", "Load workflow"), "pi pi-sitemap", null, () => Oa(e)), $(L("ctx.duplicateWorkflow", "Duplicate workflow"), "pi pi-copy", null, () => Aa(e)), $(L("ctx.renameWorkflow", "Rename workflow"), "pi pi-pencil", null, () => ja(e)), $(L("ctx.categorizeWorkflow", "Set workflow category"), "pi pi-folder", null, () => Ma(e)), $(L("ctx.setWorkflowThumbnail", "Set workflow thumbnail"), "pi pi-image", null, () => Na(e)), $(L("ctx.editWorkflowInfo", "Edit infos"), "pi pi-info-circle", null, () => Ji(e)), $(L("ctx.exportWorkflow", "Export workflow"), "pi pi-download", null, () => Pa(e)), $(L("ctx.showInExplorer", "Show in Explorer"), "pi pi-folder-open", null, () => Fa(e)), $(L("ctx.deleteWorkflow", "Delete workflow"), "pi pi-trash", null, () => La(e)), na()), m) return p.push($("Open Graph Map", "pi pi-sitemap", null, async () => {
 			try {
 				let t = await aa(e), { floatingViewerManager: n } = await ea();
 				await n.openAssets({
@@ -2349,7 +2356,7 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 		}
 	}), $("Load Asset", "pi pi-upload", "L / L+Drop", async () => {
 		let t = (f ? ia(r) : []).filter((e) => !Ca(e));
-		await da(t.length ? t : [e]) || A("Failed to create a loader node for this asset.", "error");
+		await da(t.length ? t : [e]) || k("Failed to create a loader node for this asset.", "error");
 	}), $("Open Graph Map", "pi pi-sitemap", null, async () => {
 		try {
 			let t = await aa(e), { floatingViewerManager: n } = await ea();
@@ -2361,7 +2368,7 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}), $(R("ctx.showMetadataPanel", "Show metadata panel"), "pi pi-info-circle", Ki("METADATA_PANEL"), () => {
+	}), $(L("ctx.showMetadataPanel", "Show metadata panel"), "pi pi-info-circle", Ki("METADATA_PANEL"), () => {
 		try {
 			pa(r, t, e, i);
 			let n = r?._mjrOpenDetails;
@@ -2369,7 +2376,7 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 		} catch (e) {
 			console.debug?.(e);
 		}
-	})), Ta(e) && p.push($(R("ctx.assignAsWorkflowThumbnail", "Use as workflow thumbnail"), "pi pi-image", null, () => Ia(e)));
+	})), Ta(e) && p.push($(L("ctx.assignAsWorkflowThumbnail", "Use as workflow thumbnail"), "pi pi-image", null, () => Ia(e)));
 	let g = (f ? c : []).filter((e) => !Ca(e)), _ = g.length;
 	_ === 2 && p.push($("Compare A/B (2 selected)", "pi pi-clone", Ki("COMPARE_AB"), () => {
 		try {
@@ -2391,36 +2398,36 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 		} catch (e) {
 			console.debug?.(e);
 		}
-	})), p.push($(R("ctx.openInFolder", "Open in folder"), "pi pi-folder-open", Ki("OPEN_IN_FOLDER"), async () => {
-		let t = await ce(e);
-		t?.ok ? A(R("toast.openedInFolder"), "info", 2e3) : A(t?.error || R("toast.openFolderFailed"), "error");
-	}, { disabled: !(e?.id || oa(e)) }), $(R("ctx.collectFiles", "Collect files"), "pi pi-box", null, async () => {
-		A(R("toast.collectingFiles", "Collecting files..."), "info", 2500);
+	})), p.push($(L("ctx.openInFolder", "Open in folder"), "pi pi-folder-open", Ki("OPEN_IN_FOLDER"), async () => {
+		let t = await se(e);
+		t?.ok ? k(L("toast.openedInFolder"), "info", 2e3) : k(t?.error || L("toast.openFolderFailed"), "error");
+	}, { disabled: !(e?.id || oa(e)) }), $(L("ctx.collectFiles", "Collect files"), "pi pi-box", null, async () => {
+		k(L("toast.collectingFiles", "Collecting files..."), "info", 2500);
 		let t = await n(e);
 		if (!t?.ok) {
-			A(t?.error || R("toast.collectFilesFailed", "Collect files failed"), "error");
+			k(t?.error || L("toast.collectFilesFailed", "Collect files failed"), "error");
 			return;
 		}
-		let r = t?.data || {}, i = Array.isArray(r.missing) ? r.missing.length : 0, a = r.fallback_used ? R("toast.collectFallbackDir", "output folder (source folder not writable)") : R("toast.collectSameDir", "asset folder"), o = R("toast.collectedFiles", "Collected {name} in {where}", {
+		let r = t?.data || {}, i = Array.isArray(r.missing) ? r.missing.length : 0, a = r.fallback_used ? L("toast.collectFallbackDir", "output folder (source folder not writable)") : L("toast.collectSameDir", "asset folder"), o = L("toast.collectedFiles", "Collected {name} in {where}", {
 			name: String(r.zip_name || "zip"),
 			where: a
 		});
-		i > 0 && (o += ` — ${i} ${R("toast.collectMissingInputs", "input(s) missing")}`), A(o, i > 0 ? "warning" : "success", 6e3);
-	}, { disabled: !oa(e) }), $(R("ctx.copyPath", "Copy path"), "pi pi-copy", Ki("COPY_PATH"), async () => {
+		i > 0 && (o += ` — ${i} ${L("toast.collectMissingInputs", "input(s) missing")}`), k(o, i > 0 ? "warning" : "success", 6e3);
+	}, { disabled: !oa(e) }), $(L("ctx.copyPath", "Copy path"), "pi pi-copy", Ki("COPY_PATH"), async () => {
 		let t = e?.filepath ? String(e.filepath) : "";
 		if (!t) {
-			A(R("toast.noFilePath"), "error");
+			k(L("toast.noFilePath"), "error");
 			return;
 		}
 		try {
-			await navigator.clipboard.writeText(t), A(R("toast.pathCopied"), "success", 2e3);
+			await navigator.clipboard.writeText(t), k(L("toast.pathCopied"), "success", 2e3);
 		} catch (e) {
-			console.warn(R("log.clipboardCopyFailed", "Clipboard copy failed"), e), A(R("toast.pathCopyFailed"), "error");
+			console.warn(L("log.clipboardCopyFailed", "Clipboard copy failed"), e), k(L("toast.pathCopyFailed"), "error");
 		}
-	}), $(R("ctx.download", "Download"), "pi pi-download", Ki("DOWNLOAD"), () => {
+	}), $(L("ctx.download", "Download"), "pi pi-download", Ki("DOWNLOAD"), () => {
 		if (!e?.filepath) return;
-		let t = Je(e.filepath), n = e.filename || "download";
-		la(t, n), A(R("toast.downloadingFile", "Downloading {filename}...", { filename: n }), "info", 3e3);
+		let t = Ye(e.filepath), n = e.filename || "download";
+		la(t, n), k(L("toast.downloadingFile", "Downloading {filename}...", { filename: n }), "info", 3e3);
 	}, { disabled: !e?.filepath }), $(`Download selected as ZIP (${_})`, "pi pi-file-zip", null, async () => {
 		await ua(g);
 	}, { disabled: _ < 2 }), $("Add to collection...", "pi pi-bookmark", Ki("ADD_TO_COLLECTION"), async () => {
@@ -2436,49 +2443,49 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 		let t = ia(r), n = (t.length ? t : [e]).map(oa).filter(Boolean), i = n.length > 1 ? `Remove from collection (${n.length})` : "Remove from collection";
 		p.push($(i, "pi pi-bookmark", null, async () => {
 			if (!n.length) {
-				A(R("toast.noFilePath"), "error");
+				k(L("toast.noFilePath"), "error");
 				return;
 			}
-			let e = await se(v, n);
+			let e = await ae(v, n);
 			if (!e?.ok) {
-				A(e?.error || R("toast.removeFromCollectionFailed"), "error");
+				k(e?.error || L("toast.removeFromCollectionFailed"), "error");
 				return;
 			}
 			va(r);
 		}));
 	}
 	let y = !!(e?.id || oa(e));
-	return p.push(na(), $(R("ctx.editTags", "Edit tags"), "pi pi-tags", Ki("EDIT_TAGS"), () => {
-		Ua(a + 6, o + 6, e, () => {
+	return p.push(na(), $(L("ctx.editTags", "Edit tags"), "pi pi-tags", Ki("EDIT_TAGS"), () => {
+		Wa(a + 6, o + 6, e, () => {
 			_a(e, { tags: Array.isArray(e?.tags) ? [...e.tags] : [] });
 		});
-	}, { closeOnSelect: !1 }), na(), $(R("ctx.setRating", "Set rating"), "pi pi-star", "1-5 >", null, {
+	}, { closeOnSelect: !1 }), na(), $(L("ctx.setRating", "Set rating"), "pi pi-star", "1-5 >", null, {
 		disabled: !y,
 		closeOnSelect: !1,
 		submenu: za(e, y)
-	}), na(), $(R("ctx.resetIndexFile", "Reset index (this file)"), "pi pi-refresh", null, async () => {
+	}), na(), $(L("ctx.resetIndexFile", "Reset index (this file)"), "pi pi-refresh", null, async () => {
 		if (e?.filename || e?.id) {
-			A(R("toast.rescanningFile", "Rescanning file..."), "info", 1600);
+			k(L("toast.rescanningFile", "Rescanning file..."), "info", 1600);
 			try {
 				let t = await ya(e, r);
-				t?.ok ? A(R("toast.metadataRefreshed", "Metadata refreshed{suffix}", { suffix: "" }), "success", 1800) : A(t?.error || R("toast.resetFailed", "Failed to reset index"), "error");
+				t?.ok ? k(L("toast.metadataRefreshed", "Metadata refreshed{suffix}", { suffix: "" }), "success", 1800) : k(t?.error || L("toast.resetFailed", "Failed to reset index"), "error");
 			} catch (e) {
-				A(`${R("toast.resetFailed", "Failed to reset index")}: ${e?.message || String(e || "")}`, "error");
+				k(`${L("toast.resetFailed", "Failed to reset index")}: ${e?.message || String(e || "")}`, "error");
 			}
 		}
 	}, { disabled: !(e?.filename || e?.id) }), $("Rename...", "pi pi-pencil", Ki("RENAME"), async () => {
 		if (!(e?.id || oa(e))) return;
-		let t = e.filename || "", n = bt(await Et(R("dialog.rename.title", "Rename file"), t), t);
+		let t = e.filename || "", n = bt(await Et(L("dialog.rename.title", "Rename file"), t), t);
 		if (!n || n === t) return;
 		let i = At(n);
 		if (!i.valid) {
-			A(i.reason, "error");
+			k(i.reason, "error");
 			return;
 		}
 		try {
-			let t = await N(e, n);
+			let t = await j(e, n);
 			if (!t?.ok) {
-				A(t?.error || R("toast.fileRenameFailed"), "error");
+				k(t?.error || L("toast.fileRenameFailed"), "error");
 				return;
 			}
 			let i = t?.data?.asset;
@@ -2489,43 +2496,43 @@ function Ha({ asset: e, card: t, gridContainer: r, panelState: i, pointerX: a, p
 				file_info: e.file_info
 			}));
 			let a = ga(e.id)?.querySelector?.(".mjr-filename");
-			a && (a.textContent = e.filename || n), A(R("toast.fileRenamedSuccess"), "success"), va(r);
+			a && (a.textContent = e.filename || n), k(L("toast.fileRenamedSuccess"), "success"), va(r);
 		} catch (e) {
-			A(R("toast.errorRenaming", "Error renaming file: {error}", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.errorRenaming", "Error renaming file: {error}", { error: e?.message || String(e || "") }), "error");
 		}
-	}, { disabled: !(e?.id || oa(e)) })), d ? p.push($(`Delete ${l} files...`, "pi pi-trash", Ki("DELETE"), async () => {
-		if (await yt(Number(l) || 0)) try {
+	}, { disabled: !(e?.id || oa(e)) })), d ? p.push($(`Delete ${u} files...`, "pi pi-trash", Ki("DELETE"), async () => {
+		if (await yt(Number(u) || 0)) try {
 			let t = 0, n = 0, a = [], o = 0, s = c.length ? c : [e];
-			for (let e of s) (await u(e))?.ok ? (t += 1, e?.id == null ? o += 1 : a.push(String(e.id))) : n += 1;
+			for (let e of s) (await l(e))?.ok ? (t += 1, e?.id == null ? o += 1 : a.push(String(e.id))) : n += 1;
 			if (a.length) {
 				let e = Mi(r, a);
 				i && Array.isArray(e?.selectedIds) && (i.selectedAssetIds = e.selectedIds, i.activeAssetId = e.selectedIds[0] || "");
 			}
-			o > 0 && va(r), n === 0 ? A(R("toast.filesDeletedSuccessN", "{n} files deleted successfully!", { n: t }), "success") : A(R("toast.filesDeletedPartial", "{success} files deleted, {failed} failed.", {
+			o > 0 && va(r), n === 0 ? k(L("toast.filesDeletedSuccessN", "{n} files deleted successfully!", { n: t }), "success") : k(L("toast.filesDeletedPartial", "{success} files deleted, {failed} failed.", {
 				success: t,
 				failed: n
 			}), "warning");
 		} catch (e) {
-			A(R("toast.errorDeleting", "Error deleting file: {error}", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.errorDeleting", "Error deleting file: {error}", { error: e?.message || String(e || "") }), "error");
 		}
-	})) : p.push($(R("ctx.delete", "Delete"), "pi pi-trash", Ki("DELETE"), async () => {
+	})) : p.push($(L("ctx.delete", "Delete"), "pi pi-trash", Ki("DELETE"), async () => {
 		if (await yt(1, e?.filename)) try {
-			let t = await u(e);
+			let t = await l(e);
 			if (!t?.ok) {
-				A(t?.error || R("toast.fileDeleteFailed"), "error");
+				k(t?.error || L("toast.fileDeleteFailed"), "error");
 				return;
 			}
 			if (e?.id) {
 				let t = Mi(r, [String(e.id)]);
 				i && Array.isArray(t?.selectedIds) && (i.selectedAssetIds = t.selectedIds, i.activeAssetId = t.selectedIds[0] || "");
 			} else va(r);
-			A(R("toast.fileDeletedSuccess"), "success");
+			k(L("toast.fileDeletedSuccess"), "success");
 		} catch (e) {
-			A(R("toast.errorDeleting", "Error deleting file: {error}", { error: e?.message || String(e || "") }), "error");
+			k(L("toast.errorDeleting", "Error deleting file: {error}", { error: e?.message || String(e || "") }), "error");
 		}
 	}, { disabled: !(e?.id || oa(e)) })), p;
 }
-function Ua(e, t, n, r) {
+function Wa(e, t, n, r) {
 	n && cn({
 		x: e,
 		y: t,
@@ -2533,7 +2540,7 @@ function Ua(e, t, n, r) {
 		onChanged: r
 	});
 }
-function Wa({ gridContainer: e, getState: t = () => ({}) } = {}) {
+function Ga({ gridContainer: e, getState: t = () => ({}) } = {}) {
 	if (!e) return;
 	if (e._mjrGridContextMenuBound && typeof e._mjrGridContextMenuUnbind == "function") return e._mjrGridContextMenuUnbind;
 	let n = async (n) => {
@@ -2546,13 +2553,13 @@ function Wa({ gridContainer: e, getState: t = () => ({}) } = {}) {
 		})(), i = Pt(n.target, ".mjr-asset-card");
 		if (!i) {
 			if (!xa(r)) return;
-			let t = String(e?.dataset?.mjrSubfolder || "").trim();
-			if (!t) return;
+			let t = String(e?.dataset?.mjrScope || "").toLowerCase(), i = String(e?.dataset?.mjrSubfolder || "").trim();
+			if (!i && t !== "input" && t !== "output") return;
 			n.preventDefault(), n.stopPropagation(), bn({
 				x: n.clientX,
 				y: n.clientY,
-				items: Ba({
-					currentPath: t,
+				items: Va({
+					currentPath: i,
 					gridContainer: e
 				})
 			});
@@ -2561,11 +2568,11 @@ function Wa({ gridContainer: e, getState: t = () => ({}) } = {}) {
 		n.preventDefault(), n.stopPropagation();
 		let a = i._mjrAsset;
 		if (!a) return;
-		let o = Ra(e), s = Ca(a) ? Va({
+		let o = Ra(e), s = Ca(a) ? Ha({
 			asset: a,
 			gridContainer: e,
 			panelState: r
-		}) : Ha({
+		}) : Ua({
 			asset: a,
 			card: i,
 			gridContainer: e,
@@ -2617,8 +2624,8 @@ function Wa({ gridContainer: e, getState: t = () => ({}) } = {}) {
 }
 //#endregion
 //#region ui/features/panel/controllers/ratingHotkeysController.ts
-var Ga = ct;
-function Ka(e) {
+var Ka = lt;
+function qa(e) {
 	let t = String(e ?? "");
 	try {
 		if (typeof CSS < "u" && typeof CSS.escape == "function") return CSS.escape(t);
@@ -2627,7 +2634,7 @@ function Ka(e) {
 	}
 	return t.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 }
-function qa(e, t = null) {
+function Ja(e, t = null) {
 	if (!e) return [];
 	try {
 		let t = Array.from(Yn(e));
@@ -2643,14 +2650,14 @@ function qa(e, t = null) {
 	}
 	return [];
 }
-function Ja(e, t) {
+function Ya(e, t) {
 	try {
-		return e?.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${Ka(t)}"]`);
+		return e?.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${qa(t)}"]`);
 	} catch (e) {
 		return console.debug?.(e), null;
 	}
 }
-function Ya(e, t, n) {
+function Xa(e, t, n) {
 	if (!e) return;
 	let r = e._mjrAsset;
 	r && (r.rating = n);
@@ -2663,7 +2670,7 @@ function Ya(e, t, n) {
 		console.debug?.(e);
 	}
 }
-async function Xa(e, t, n = 5) {
+async function Za(e, t, n = 5) {
 	let r = Math.max(1, Number(n) || 1), i = 0, a = [], o = async () => {
 		for (; i < e.length;) {
 			let n = i;
@@ -2678,22 +2685,22 @@ async function Xa(e, t, n = 5) {
 	for (let t = 0; t < Math.min(r, e.length); t += 1) a.push(o());
 	await Promise.all(a);
 }
-function Za({ gridContainer: e, createRatingBadge: t } = {}) {
+function Qa({ gridContainer: e, createRatingBadge: t } = {}) {
 	let n = !1, r = null, i = null, a = async (e, t) => {
 		if (e != null) {
 			try {
 				let n = await b(e, t);
 				if (!n?.ok) {
-					A(n?.error || R("toast.ratingUpdateFailed"), "error");
+					k(n?.error || L("toast.ratingUpdateFailed"), "error");
 					return;
 				}
-				A(R("toast.ratingSetN", { n: t }), "success", 1500);
+				k(L("toast.ratingSetN", { n: t }), "success", 1500);
 			} catch {
-				A(R("toast.ratingUpdateError"), "error");
+				k(L("toast.ratingUpdateError"), "error");
 				return;
 			}
 			try {
-				window.dispatchEvent(new CustomEvent(Ga, { detail: {
+				window.dispatchEvent(new CustomEvent(Ka, { detail: {
 					assetId: String(e),
 					rating: t
 				} }));
@@ -2705,8 +2712,8 @@ function Za({ gridContainer: e, createRatingBadge: t } = {}) {
 	return {
 		bind: () => {
 			if (!(n || !e)) {
-				n = !0, de(!0), r = async (t) => {
-					if (Se() || ge().scope === "viewer" || t.defaultPrevented) return;
+				n = !0, fe(!0), r = async (t) => {
+					if (Ce() || _e().scope === "viewer" || t.defaultPrevented) return;
 					let n = String(t.key || "");
 					if (n !== "0" && n !== "1" && n !== "2" && n !== "3" && n !== "4" && n !== "5") return;
 					let r = document.querySelector(".mjr-viewer-overlay");
@@ -2715,13 +2722,13 @@ function Za({ gridContainer: e, createRatingBadge: t } = {}) {
 					if (!i && !o && !s) return;
 					let c = n === "0" ? 0 : Number(n);
 					if (!Number.isFinite(c)) return;
-					let l = qa(e, t.target);
-					l.length && (t.preventDefault(), t.stopPropagation(), t.stopImmediatePropagation?.(), await Xa(l, (e) => a(e, c), 5));
+					let l = Ja(e, t.target);
+					l.length && (t.preventDefault(), t.stopPropagation(), t.stopImmediatePropagation?.(), await Za(l, (e) => a(e, c), 5));
 				}, i = (n) => {
 					let r = n?.detail || {}, i = r.assetId ?? r.id ?? null, a = Number(r.rating);
 					if (!i || !Number.isFinite(a)) return;
-					let o = Ja(e, i);
-					o && Ya(o, t, a);
+					let o = Ya(e, i);
+					o && Xa(o, t, a);
 				};
 				try {
 					window.addEventListener("keydown", r, { capture: !0 });
@@ -2729,7 +2736,7 @@ function Za({ gridContainer: e, createRatingBadge: t } = {}) {
 					console.debug?.(e);
 				}
 				try {
-					window.addEventListener(Ga, i);
+					window.addEventListener(Ka, i);
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -2737,14 +2744,14 @@ function Za({ gridContainer: e, createRatingBadge: t } = {}) {
 		},
 		dispose: () => {
 			if (n) {
-				n = !1, de(!1);
+				n = !1, fe(!1);
 				try {
 					window.removeEventListener("keydown", r, { capture: !0 });
 				} catch (e) {
 					console.debug?.(e);
 				}
 				try {
-					window.removeEventListener(Ga, i);
+					window.removeEventListener(Ka, i);
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -2755,7 +2762,7 @@ function Za({ gridContainer: e, createRatingBadge: t } = {}) {
 }
 //#endregion
 //#region ui/features/grid/StackGroupCards.ts
-function Qa(e) {
+function $a(e) {
 	if (!e || e.dataset?.mjrOverlayButtonBound === "1") return e;
 	try {
 		e.dataset.mjrOverlayButtonBound = "1";
@@ -2774,7 +2781,7 @@ function Qa(e) {
 	};
 	return e.addEventListener("pointerdown", t), e.addEventListener("mousedown", n), e.addEventListener("touchstart", t, { passive: !0 }), e.addEventListener("dblclick", t), e.addEventListener("keydown", t), e.addEventListener("dragstart", n), e;
 }
-function $a(e, t, n = null, r = "mjr-stack-group-button-count") {
+function eo(e, t, n = null, r = "mjr-stack-group-button-count") {
 	e.textContent = "";
 	let i = document.createElement("span");
 	if (i.className = t, e.appendChild(i), n != null) {
@@ -2782,24 +2789,24 @@ function $a(e, t, n = null, r = "mjr-stack-group-button-count") {
 		t.className = r, t.textContent = String(n), e.appendChild(t);
 	}
 }
-function eo(e) {
+function to(e) {
 	return String(e?.dataset?.mjrGroupStacks || "") === "1";
 }
-function to(e) {
+function no(e) {
 	let t = String(e?.stack_id || "").trim();
 	return t ? `stack:${t}` : "";
 }
-function no(e, t, n) {
-	return eo(e) && to(t) || n;
+function ro(e, t, n) {
+	return to(e) && no(t) || n;
 }
-function ro(e) {
+function io(e) {
 	try {
 		e._mjrStackMembersCache?.clear?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function io(e, t, n) {
+function ao(e, t, n) {
 	if (!t || !n || t._mjrIsVue) return;
 	let r = !!n._mjrDupStack, i = Number(n._mjrDupCount || 0) || 0;
 	if (!r || i < 2) {
@@ -2809,13 +2816,13 @@ function io(e, t, n) {
 	}
 	t.dataset.mjrDupStacked = "true", t.dataset.mjrDupCount = String(i);
 	let a = t.querySelector(".mjr-dup-stack-button");
-	a || (a = document.createElement("button"), a.type = "button", a.className = "mjr-dup-stack-button", a.setAttribute("aria-label", "Show all duplicates"), Qa(a), a.addEventListener("click", (e) => {
+	a || (a = document.createElement("button"), a.type = "button", a.className = "mjr-dup-stack-button", a.setAttribute("aria-label", "Show all duplicates"), $a(a), a.addEventListener("click", (e) => {
 		if (e.preventDefault(), e.stopPropagation(), a.dataset?.mjrStackOpening !== "1") try {
 			a.dataset.mjrStackOpening = "1", a.disabled = !0;
 			let e = a?._mjrGridContainer, t = a?._mjrAsset;
 			if (!e || !t) return;
 			let n = Array.isArray(t._mjrDupMembers) ? t._mjrDupMembers : [t], r = n.length;
-			e.dispatchEvent(new CustomEvent(B.OPEN_STACK_GROUP, {
+			e.dispatchEvent(new CustomEvent(z.OPEN_STACK_GROUP, {
 				bubbles: !0,
 				detail: {
 					asset: t,
@@ -2835,22 +2842,22 @@ function io(e, t, n) {
 		}
 	}), t.appendChild(a)), a._mjrGridContainer = e, a._mjrAsset = n;
 	let o = `${i} duplicate${i > 1 ? "s" : ""}`;
-	a.title = `${o} - click to compare all copies`, $a(a, "pi pi-copy", i, "mjr-dup-stack-count");
+	a.title = `${o} - click to compare all copies`, eo(a, "pi pi-copy", i, "mjr-dup-stack-count");
 }
 //#endregion
 //#region ui/features/dnd/utils/log.ts
-var ao = () => {
+var oo = () => {
 	try {
 		return !!window?.MJR_DND_DEBUG;
 	} catch {
 		return !1;
 	}
-}, oo = (...e) => {
-	ao() && console.debug("[Majoor.DnD]", ...e);
-}, so = (e, { buildCustomViewURL: t, buildViewURL: n }) => {
+}, so = (...e) => {
+	oo() && console.debug("[Majoor.DnD]", ...e);
+}, co = (e, { buildCustomViewURL: t, buildViewURL: n }) => {
 	let r = String(e?.type || "output").toLowerCase();
-	return r === "custom" ? t(e?.filename || "", e?.subfolder || "", Ne(e)) : r === "input" ? n(e?.filename || "", e?.subfolder || "", "input") : r === "temp" ? n(e?.filename || "", e?.subfolder || "", "temp") : n(e?.filename || "", e?.subfolder || "", "output");
-}, co = (e) => {
+	return r === "custom" ? t(e?.filename || "", e?.subfolder || "", Pe(e)) : r === "input" ? n(e?.filename || "", e?.subfolder || "", "input") : r === "temp" ? n(e?.filename || "", e?.subfolder || "", "temp") : n(e?.filename || "", e?.subfolder || "", "output");
+}, lo = (e) => {
 	if (!e || typeof e != "object") return null;
 	let t = String(e.filename || "").trim();
 	if (!t || t.includes("/") || t.includes("\\") || t.includes("\0")) return null;
@@ -2863,42 +2870,42 @@ var ao = () => {
 		kind: o || void 0,
 		filepath: o === "workflow" && s ? s : void 0
 	};
-}, lo = co, uo = (e, t) => {
+}, uo = lo, fo = (e, t) => {
 	let n = e?.dataTransfer?.getData?.(t);
 	if (!n) return null;
 	try {
-		return co(JSON.parse(n));
+		return lo(JSON.parse(n));
 	} catch {
 		return null;
 	}
-}, fo = /* @__PURE__ */ new WeakMap(), po = !1;
-function mo(e) {
-	return e && fo.get(e) || null;
+}, po = /* @__PURE__ */ new WeakMap(), mo = !1;
+function ho(e) {
+	return e && po.get(e) || null;
 }
-function ho(e, t) {
-	return e ? typeof t == "function" ? (fo.set(e, t), t) : (fo.delete(e), null) : null;
+function go(e, t) {
+	return e ? typeof t == "function" ? (po.set(e, t), t) : (po.delete(e), null) : null;
 }
-function go(e) {
-	e && fo.delete(e);
-}
-function _o() {
-	po = !0;
+function _o(e) {
+	e && po.delete(e);
 }
 function vo() {
-	return po ? (po = !1, !0) : !1;
+	mo = !0;
 }
 function yo() {
-	po = !1;
+	return mo ? (mo = !1, !0) : !1;
+}
+function bo() {
+	mo = !1;
 }
 //#endregion
 //#region ui/features/dnd/out/DragOut.ts
-var bo = (e) => {
+var xo = (e) => {
 	try {
 		return new URL(String(e || ""), window.location.href).href;
 	} catch {
 		return String(e || "");
 	}
-}, xo = () => qe("mjr_", 24), So = (e) => {
+}, So = () => Je("mjr_", 24), Co = (e) => {
 	let t = e && typeof e == "object" ? e : null;
 	if (!t) return null;
 	let n = t.filename || t.name;
@@ -2906,9 +2913,9 @@ var bo = (e) => {
 		filename: n,
 		subfolder: t.subfolder || "",
 		type: String(t.type || "output").toLowerCase(),
-		root_id: Ne(t) || void 0
+		root_id: Pe(t) || void 0
 	} : null;
-}, Co = (e, t) => {
+}, wo = (e, t) => {
 	let n = [];
 	if (!e || !t) return n;
 	let r = t?.dataset?.mjrAssetId ? String(t.dataset.mjrAssetId) : "";
@@ -2958,25 +2965,25 @@ var bo = (e) => {
 		!t || typeof t != "object" || n.push(t);
 	}
 	return n;
-}, wo = (e) => {
+}, To = (e) => {
 	if (!e || typeof e != "object") return "";
 	let t = e.filepath || e.path || e?.file_info?.filepath || "";
 	return t ? String(t) : "";
-}, To = ({ dt: e, asset: t, containerEl: n, card: r, viewUrl: i, stripMetadata: a = !1 }) => {
+}, Eo = ({ dt: e, asset: t, containerEl: n, card: r, viewUrl: i, stripMetadata: a = !1 }) => {
 	if (!e || !t) return;
-	let o = Co(n, r);
+	let o = wo(n, r);
 	if (Array.isArray(o) && o.length > 1) {
-		let t = o.map(So).filter(Boolean);
+		let t = o.map(Co).filter(Boolean);
 		if (t.length > 1) {
 			let n = "";
 			try {
-				n = xo();
+				n = So();
 			} catch (e) {
 				console.warn("[DragOut] failed to create secure batch token", e);
 			}
 			if (n) {
 				try {
-					ue(lt.BATCH_ZIP_CREATE, {
+					ue(B.BATCH_ZIP_CREATE, {
 						token: n,
 						items: t,
 						strip_metadata: !!a
@@ -2984,9 +2991,9 @@ var bo = (e) => {
 				} catch (e) {
 					console.debug?.(e);
 				}
-				let r = bo(et(n)), i = a ? `Majoor_Clean_Batch_${t.length}.zip` : `Majoor_Batch_${t.length}.zip`;
+				let r = xo(tt(n)), i = a ? `Majoor_Clean_Batch_${t.length}.zip` : `Majoor_Batch_${t.length}.zip`;
 				try {
-					e.setData("text/uri-list", r), e.setData("DownloadURL", `application/zip:${i}:${r}`), e.effectAllowed = "copy";
+					e.setData("text/uri-list", r), e.setData("DownloadURL", `application/zip:${i}:${r}`), e.effectAllowed = "copyMove";
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -2996,38 +3003,38 @@ var bo = (e) => {
 	}
 	let s = t.filename || t.name;
 	if (!s) return;
-	let c = a ? wo(t) : "", l = bo((c ? Ke(c) : "") || i), u = pn(s);
+	let c = a ? To(t) : "", l = xo((c ? qe(c) : "") || i), u = pn(s);
 	try {
-		e.setData("text/uri-list", l), e.setData("DownloadURL", `${u}:${s}:${l}`), e.effectAllowed = "copy";
+		e.setData("text/uri-list", l), e.setData("DownloadURL", `${u}:${s}:${l}`), e.effectAllowed = "copyMove";
 	} catch (e) {
 		console.debug?.(e);
 	}
-}, Eo = (e, { asset: t, containerEl: n, card: r }) => {
+}, Do = (e, { asset: t, containerEl: n, card: r }) => {
 	if (!(!e || !t)) try {
 		let t = e?.dataTransfer?.dropEffect;
-		!t || t === "none" || vo();
+		!t || t === "none" || yo();
 		return;
 	} catch (e) {
 		console.debug?.(e);
 	}
-}, Do = () => {
-	let e = tt();
+}, Oo = () => {
+	let e = nt();
 	return e && typeof e == "object" ? e : null;
-}, Oo = (e) => so(e, {
-	buildCustomViewURL: rt,
-	buildViewURL: it
-}), ko = !1, Ao = !1, jo = (e) => {
+}, ko = (e) => co(e, {
+	buildCustomViewURL: it,
+	buildViewURL: at
+}), Ao = !1, jo = !1, Mo = (e) => {
 	try {
 		return !!e?.closest?.("input, textarea, select, [contenteditable='true']");
 	} catch {
 		return !1;
 	}
-}, Mo = () => ko === !0, No = () => Ao === !0, Po = (e) => [
+}, No = () => Ao === !0, Po = () => jo === !0, Fo = (e) => [
 	String(e?.type || "output"),
 	String(e?.filename || ""),
 	String(e?.subfolder || ""),
-	String(Ne(e) || "")
-].join("\n"), Fo = (e, t) => {
+	String(Pe(e) || "")
+].join("\n"), Io = (e, t) => {
 	if (String(e?.type || e?.file_info?.type || "").toLowerCase() === "custom") return null;
 	let n = ft(String(e?.filepath || e?.path || e?.fullpath || e?.full_path || e?.file_info?.filepath || e?.file_info?.path || "")).trim();
 	if (!n || !t) return null;
@@ -3057,20 +3064,20 @@ var bo = (e) => {
 		};
 	}
 	return null;
-}, Io = (e) => {
+}, Lo = (e) => {
 	if (!e || typeof e != "object") return null;
 	let t = String(e.filename || "").trim();
 	if (!t) return null;
-	let n = Fo(e, t);
+	let n = Io(e, t);
 	return {
 		filename: t,
 		subfolder: n?.subfolder ?? e.subfolder ?? "",
 		type: n?.type ?? String(e.type || "output").toLowerCase(),
-		root_id: Ne(e) || void 0,
+		root_id: Pe(e) || void 0,
 		kind: String(e.kind || "").toLowerCase(),
 		filepath: String(e.filepath || e.path || e?.file_info?.filepath || "").trim() || void 0
 	};
-}, Lo = (e, t, n) => {
+}, Ro = (e, t, n) => {
 	if (!e || !t || n == null) return !1;
 	let r = String(n);
 	try {
@@ -3084,10 +3091,10 @@ var bo = (e) => {
 		console.debug?.(e);
 	}
 	return !1;
-}, Ro = ({ dt: e, asset: t, payload: n, viewUrl: r }) => {
+}, zo = ({ dt: e, asset: t, payload: n, viewUrl: r }) => {
 	if (!e || !t || !n) return;
 	let i = String(n.kind || "").toLowerCase() === "model3d" ? "3D" : n.kind, a = {
-		id: t.id == null ? Po(n) : String(t.id),
+		id: t.id == null ? Fo(n) : String(t.id),
 		name: t.filename || n.filename,
 		display_name: t.filename || n.filename,
 		filename: n.filename,
@@ -3103,46 +3110,46 @@ var bo = (e) => {
 		},
 		tags: Array.isArray(t.tags) ? t.tags : []
 	};
-	Lo(e, on, JSON.stringify(a)), r && Lo(e, "text/uri-list", r);
-}, zo = (e) => {
+	Ro(e, on, JSON.stringify(a)), r && Ro(e, "text/uri-list", r);
+}, Bo = (e) => {
 	let t = e && typeof e == "object" ? e : null;
 	if (!t) return [];
 	try {
 		let e = window?.__MJR_LAST_SELECTION_GRID__, n = typeof e?._mjrGetSelectedAssets == "function" ? e._mjrGetSelectedAssets() : [];
 		if (Array.isArray(n) && n.length > 1) {
-			let e = n.map(Io).filter(nn), r = Po(t);
-			if (e.some((e) => Po(e) === r)) return e;
+			let e = n.map(Lo).filter(nn), r = Fo(t);
+			if (e.some((e) => Fo(e) === r)) return e;
 		}
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return [t];
-}, Bo = (e, t) => {
+}, Vo = (e, t) => {
 	try {
 		let n = typeof e?._mjrGetSelectedAssets == "function" ? e._mjrGetSelectedAssets() : [];
 		if (!Array.isArray(n) || n.length <= 1) return [];
-		let r = n.map(Io).filter(nn), i = Po(t);
-		return r.some((e) => Po(e) === i) ? r : [];
+		let r = n.map(Lo).filter(nn), i = Fo(t);
+		return r.some((e) => Fo(e) === i) ? r : [];
 	} catch (e) {
 		return console.debug?.(e), [];
 	}
-}, Vo = (e, t) => {
+}, Ho = (e, t) => {
 	try {
 		let t = e?.dataTransfer?.getData?.("application/x-mjr-assets") || "";
 		if (t) {
-			let e = JSON.parse(t), n = (Array.isArray(e?.items) ? e.items : Array.isArray(e) ? e : []).map(lo).filter(nn);
+			let e = JSON.parse(t), n = (Array.isArray(e?.items) ? e.items : Array.isArray(e) ? e : []).map(uo).filter(nn);
 			if (n.length) return n;
 		}
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return zo(t);
-}, Ho = async (e) => {
+	return Bo(t);
+}, Uo = async (e) => {
 	let t = Array.isArray(e) ? e.filter(Boolean) : [];
 	return t.length ? (await Promise.all(t.map(async (e) => {
 		let t = (await $t({
 			post: ue,
-			endpoint: lt.STAGE_TO_INPUT,
+			endpoint: B.STAGE_TO_INPUT,
 			payload: e,
 			index: !1
 		}))?.relativePath;
@@ -3152,43 +3159,43 @@ var bo = (e) => {
 			droppedExt: String(e?.filename || "").split(".").pop() || ""
 		} : null;
 	}))).filter(Boolean) : [];
-}, Uo = /* @__PURE__ */ new Map(), Wo = 6e4, Go = 20, Ko = 5 * 1024 * 1024, qo = 5e3, Jo = 2e4, Yo = 256, Xo = 5e5, Zo = /[\u0000-\u001f\u007f]/, Qo = /\u0000/, $o = (e) => Zo.test(String(e || "")), es = (e) => Qo.test(String(e || "")), ts = (e) => {
+}, Wo = /* @__PURE__ */ new Map(), Go = 6e4, Ko = 20, qo = 5 * 1024 * 1024, Jo = 5e3, Yo = 2e4, Xo = 256, Zo = 5e5, Qo = /[\u0000-\u001f\u007f]/, $o = /\u0000/, es = (e) => Qo.test(String(e || "")), ts = (e) => $o.test(String(e || "")), ns = (e) => {
 	if (!e || typeof e != "object" || Array.isArray(e)) return !1;
 	let t = Number(e.id);
 	if (!Number.isFinite(t)) return !1;
 	let n = e.type == null ? "" : String(e.type);
-	if (n && (n.length > Yo || $o(n))) return !1;
+	if (n && (n.length > Xo || es(n))) return !1;
 	let r = e.widgets_values;
 	if (Array.isArray(r)) {
-		for (let e of r) if (typeof e == "string" && (e.length > Xo || es(e))) return !1;
+		for (let e of r) if (typeof e == "string" && (e.length > Zo || ts(e))) return !1;
 	}
 	return !0;
-}, ns = (e) => {
+}, rs = (e) => {
 	if (Array.isArray(e)) return e.length >= 4;
 	if (e && typeof e == "object") {
 		let t = Number(e.id);
 		return !!Number.isFinite(t);
 	}
 	return !1;
-}, rs = (e) => {
-	if (!e || typeof e != "object" || !Array.isArray(e.nodes) || !Array.isArray(e.links) || e.nodes.length > qo || e.links.length > Jo || !e.nodes.every(ts) || !e.links.every(ns)) return !1;
+}, is = (e) => {
+	if (!e || typeof e != "object" || !Array.isArray(e.nodes) || !Array.isArray(e.links) || e.nodes.length > Jo || e.links.length > Yo || !e.nodes.every(ns) || !e.links.every(rs)) return !1;
 	try {
 		let t = JSON.stringify(e).length;
-		if (!Number.isFinite(t) || t <= 0 || t > Ko) return !1;
+		if (!Number.isFinite(t) || t <= 0 || t > qo) return !1;
 	} catch {
 		return !1;
 	}
 	return !0;
-}, is = () => {
+}, as = () => {
 	let e = Date.now();
-	for (let [t, n] of Uo.entries()) e - (n?.at || 0) > Wo && Uo.delete(t);
-	Uo.size > Go && Array.from(Uo.entries()).sort((e, t) => (e[1]?.at || 0) - (t[1]?.at || 0)).slice(0, Uo.size - Go).forEach(([e]) => Uo.delete(e));
-}, as = async (e, t = null) => {
-	let n = e && typeof e == "object" ? e : null, r = Ne(n), i = Do(), a = n?.filename ? `${n.type || "output"}:${n.filename}:${n.subfolder || ""}:${r}` : t ? `path:${t}` : null;
+	for (let [t, n] of Wo.entries()) e - (n?.at || 0) > Go && Wo.delete(t);
+	Wo.size > Ko && Array.from(Wo.entries()).sort((e, t) => (e[1]?.at || 0) - (t[1]?.at || 0)).slice(0, Wo.size - Ko).forEach(([e]) => Wo.delete(e));
+}, os = async (e, t = null) => {
+	let n = e && typeof e == "object" ? e : null, r = Pe(n), i = Oo(), a = n?.filename ? `${n.type || "output"}:${n.filename}:${n.subfolder || ""}:${r}` : t ? `path:${t}` : null;
 	if (a) {
-		let e = Uo.get(a);
-		if (e && Date.now() - (e.at || 0) < Wo) {
-			if (e.workflow && rs(e.workflow)) try {
+		let e = Wo.get(a);
+		if (e && Date.now() - (e.at || 0) < Go) {
+			if (e.workflow && is(e.workflow)) try {
 				if (typeof i?.loadGraphData == "function") return i.loadGraphData(e.workflow), !0;
 				if (typeof i?.canvas?.graph?.configure == "function") {
 					i.canvas.graph.configure(e.workflow);
@@ -3209,22 +3216,22 @@ var bo = (e) => {
 	try {
 		let e = null, o = null;
 		if (String(n?.kind || "").toLowerCase() === "workflow" && n?.filepath) {
-			let e = await w(String(n.filepath), { timeoutMs: 3e4 });
+			let e = await C(String(n.filepath), { timeoutMs: 3e4 });
 			o = e?.ok && (e?.data?.workflow || e?.workflow) || null;
 		} else if (n?.filename) {
-			let t = await I(`${lt.WORKFLOW_QUICK}?type=${encodeURIComponent(n.type || "output")}&filename=${encodeURIComponent(n.filename)}&subfolder=${encodeURIComponent(n.subfolder || "")}` + (r ? `&root_id=${encodeURIComponent(r)}` : ""));
-			t?.ok && t.workflow && (o = t.workflow), o || (e = `${lt.METADATA}?workflow_only=1&type=${encodeURIComponent(n.type || "output")}&filename=${encodeURIComponent(n.filename)}&subfolder=${encodeURIComponent(n.subfolder || "")}&root_id=${encodeURIComponent(r)}`);
-		} else t && (e = `${lt.METADATA}?workflow_only=1&path=${encodeURIComponent(String(t))}`);
+			let t = await oe(`${B.WORKFLOW_QUICK}?type=${encodeURIComponent(n.type || "output")}&filename=${encodeURIComponent(n.filename)}&subfolder=${encodeURIComponent(n.subfolder || "")}` + (r ? `&root_id=${encodeURIComponent(r)}` : ""));
+			t?.ok && t.workflow && (o = t.workflow), o || (e = `${B.METADATA}?workflow_only=1&type=${encodeURIComponent(n.type || "output")}&filename=${encodeURIComponent(n.filename)}&subfolder=${encodeURIComponent(n.subfolder || "")}&root_id=${encodeURIComponent(r)}`);
+		} else t && (e = `${B.METADATA}?workflow_only=1&path=${encodeURIComponent(String(t))}`);
 		if (!o && e) {
-			let t = await I(e);
+			let t = await oe(e);
 			if (!t?.ok || !t.data) return !1;
 			o = t.data?.workflow;
 		}
-		if (!rs(o)) return !1;
-		if (a && (Uo.set(a, {
+		if (!is(o)) return !1;
+		if (a && (Wo.set(a, {
 			workflow: o,
 			at: Date.now()
-		}), is()), typeof i?.loadGraphData == "function") return i.loadGraphData(o), !0;
+		}), as()), typeof i?.loadGraphData == "function") return i.loadGraphData(o), !0;
 		if (typeof i?.canvas?.graph?.configure == "function") {
 			i.canvas.graph.configure(o);
 			try {
@@ -3240,7 +3247,7 @@ var bo = (e) => {
 	}
 	return !1;
 };
-function os(e) {
+function ss(e) {
 	return (t) => {
 		let n = t?.dataTransfer;
 		if (!n) return;
@@ -3248,26 +3255,26 @@ function os(e) {
 		if (!r) return;
 		let i = r._mjrAsset;
 		if (!i || typeof i != "object") return;
-		let a = String(i?.kind || "").toLowerCase(), o = Fo(i, String(i.filename || "")), s = o?.type ?? String(i?.type || "output").toLowerCase(), c = {
+		let a = String(i?.kind || "").toLowerCase(), o = Io(i, String(i.filename || "")), s = o?.type ?? String(i?.type || "output").toLowerCase(), c = {
 			filename: i.filename,
 			subfolder: o?.subfolder ?? i.subfolder ?? "",
 			type: s,
-			root_id: Ne(i) || void 0,
+			root_id: Pe(i) || void 0,
 			kind: a,
 			filepath: String(i.filepath || i.path || i?.file_info?.filepath || "").trim() || void 0
 		};
 		try {
-			let t = Mo();
-			Lo(n, ln, JSON.stringify(c));
-			let o = Bo(e, c);
-			o.length > 1 && Lo(n, hn, JSON.stringify({ items: o })), Lo(n, "text/plain", String(i.filename || ""));
-			let s = a === "workflow" ? "" : Oo(c);
-			Ro({
+			let t = No();
+			Ro(n, ln, JSON.stringify(c));
+			let o = Vo(e, c);
+			o.length > 1 && Ro(n, hn, JSON.stringify({ items: o })), Ro(n, "text/plain", String(i.filename || ""));
+			let s = a === "workflow" ? "" : ko(c);
+			zo({
 				dt: n,
 				asset: i,
 				payload: c,
 				viewUrl: s
-			}), To({
+			}), Eo({
 				dt: n,
 				asset: i,
 				containerEl: e,
@@ -3280,7 +3287,7 @@ function os(e) {
 		}
 		try {
 			r.addEventListener("dragend", (t) => {
-				Eo(t, {
+				Do(t, {
 					asset: i,
 					containerEl: e,
 					card: r
@@ -3297,30 +3304,30 @@ function os(e) {
 		}
 	};
 }
-var ss = (e) => {
+var cs = (e) => {
 	if (!e) return () => {};
-	let t = mo(e);
+	let t = ho(e);
 	if (typeof t == "function") return t;
-	let n = os(e);
-	return e.addEventListener("dragstart", n, !0), ho(e, () => {
+	let n = ss(e);
+	return e.addEventListener("dragstart", n, !0), go(e, () => {
 		try {
 			e.removeEventListener("dragstart", n, !0);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		go(e);
+		_o(e);
 	});
-}, cs = null, ls = 0;
-function us() {
+}, ls = null, us = 0;
+function ds() {
 	let e = (e) => {
-		if (jo(e?.target)) return;
+		if (Mo(e?.target)) return;
 		let t = String(e?.key || "").toLowerCase();
-		t === "s" ? ko = !0 : t === "l" && (Ao = !0);
+		t === "s" ? Ao = !0 : t === "l" && (jo = !0);
 	}, t = (e) => {
 		let t = String(e?.key || "").toLowerCase();
-		t === "s" ? ko = !1 : t === "l" && (Ao = !1);
+		t === "s" ? Ao = !1 : t === "l" && (jo = !1);
 	}, n = () => {
-		ko = !1, Ao = !1;
+		Ao = !1, jo = !1;
 	}, r = new Set([
 		"mp3",
 		"wav",
@@ -3396,12 +3403,12 @@ function us() {
 		e._ghostSegmentId = null, e._ghostTrack = null, e._ghostInitialTimeline = null, e._previewSegments = null, e.render?.();
 		let s = String(n || "").toLowerCase(), c = r.has(s), l = await $t({
 			post: ue,
-			endpoint: lt.STAGE_TO_INPUT,
+			endpoint: B.STAGE_TO_INPUT,
 			payload: t,
 			index: !1
 		});
 		if (!l?.name) {
-			A(`Failed to stage: "${t?.filename}"`, "error");
+			k(`Failed to stage: "${t?.filename}"`, "error");
 			return;
 		}
 		let { name: u, subfolder: d = "" } = l, f = d ? `${d}/${u}` : u, p = `/view?filename=${encodeURIComponent(u)}&type=input&subfolder=${encodeURIComponent(d)}`;
@@ -3439,15 +3446,15 @@ function us() {
 					waveformPeaks: l
 				};
 				if (!e.timeline?.audioSegments) {
-					oo("ltxdirector inject: no audioSegments", {});
+					so("ltxdirector inject: no audioSegments", {});
 					return;
 				}
-				e.timeline.audioSegments.push(h), e.timeline.audioSegments.sort((e, t) => e.start - t.start), e.selectionType = "audio", e.selectedIndex = e.timeline.audioSegments.findIndex((e) => e.id === m), e.updateUIFromSelection?.(), e.commitChanges?.(!0), e.render?.(), A(`Added audio to LTX Director: ${u}`, "success", 3e3), oo("drop ltxdirector inject audio", {
+				e.timeline.audioSegments.push(h), e.timeline.audioSegments.sort((e, t) => e.start - t.start), e.selectionType = "audio", e.selectedIndex = e.timeline.audioSegments.findIndex((e) => e.id === m), e.updateUIFromSelection?.(), e.commitChanges?.(!0), e.render?.(), k(`Added audio to LTX Director: ${u}`, "success", 3e3), so("drop ltxdirector inject audio", {
 					file: u,
 					start: d
 				});
 			} catch (e) {
-				console.error("[Majoor] LTX Director audio inject failed", e), A(`Audio decode failed for: ${u}`, "error");
+				console.error("[Majoor] LTX Director audio inject failed", e), k(`Audio decode failed for: ${u}`, "error");
 			}
 			return;
 		}
@@ -3485,7 +3492,7 @@ function us() {
 			imageB64: p
 		};
 		if (!e.timeline?.segments) {
-			oo("ltxdirector inject: no timeline", {});
+			so("ltxdirector inject: no timeline", {});
 			return;
 		}
 		if (e.timeline.segments.push(y), e.timeline.segments.sort((e, t) => e.start - t.start), h) try {
@@ -3500,7 +3507,7 @@ function us() {
 			}, t.src = p;
 		}
 		let b = e.timeline.segments.findIndex((e) => e.id === v), x = h ? e.timeline.segments.findIndex((e) => e.id === y.id) : b;
-		x >= 0 && (e.selectionType = "image", e.selectedIndex = x, e.updateUIFromSelection?.()), e.commitChanges?.(!0), e.render?.(), A(`Added ${h ? "video" : "image"} to LTX Director: ${u}`, "success", 3e3), oo("drop ltxdirector inject", {
+		x >= 0 && (e.selectionType = "image", e.selectedIndex = x, e.updateUIFromSelection?.()), e.commitChanges?.(!0), e.render?.(), k(`Added ${h ? "video" : "image"} to LTX Director: ${u}`, "success", 3e3), so("drop ltxdirector inject", {
 			file: u,
 			start: _,
 			ext: s,
@@ -3512,16 +3519,16 @@ function us() {
 		onKeyUp: t,
 		onWindowBlur: n,
 		onDragOver: (e) => {
-			let t = Do();
+			let t = Oo();
 			if (!Array.from(e?.dataTransfer?.types || []).includes("application/x-mjr-asset")) return;
-			let n = uo(e, ln);
+			let n = fo(e, ln);
 			if (!nn(n)) return;
 			let r = un(t, e.clientX, e.clientY), i = r ? jn(t, r, e.clientX, e.clientY) : null, a = String(n?.filename || "").split(".").pop() || "", o = r && !i ? dn(r, n, a) : null, s = r && !i && !o && !!r._timelineEditor;
 			if (r && (i || o || s)) {
-				e.preventDefault(), s || (e.stopImmediatePropagation?.(), e.stopPropagation()), Mn(t, r, fn), e.dataTransfer.dropEffect = "copy", i ? oo("dragover slot", {
+				e.preventDefault(), s || (e.stopImmediatePropagation?.(), e.stopPropagation()), Mn(t, r, fn), e.dataTransfer.dropEffect = "copy", i ? so("dragover slot", {
 					node: r?.title,
 					slot: i.input?.name
-				}) : s ? oo("dragover ltxdirector", { node: r?.title }) : oo("dragover widget", {
+				}) : s ? so("dragover ltxdirector", { node: r?.title }) : so("dragover widget", {
 					node: r?.title,
 					widget: o?.name
 				});
@@ -3530,17 +3537,20 @@ function us() {
 			Zt(t, fn), en(t, e) && (e.preventDefault(), e.dataTransfer.dropEffect = "copy");
 		},
 		onDrop: async (e) => {
-			let t = Do();
+			let t = Oo();
 			if (!Array.from(e?.dataTransfer?.types || []).includes("application/x-mjr-asset")) return;
-			let n = uo(e, ln);
+			try {
+				if ((e?.target)?.closest?.(".mjr-folder-card")) return;
+			} catch {}
+			let n = fo(e, ln);
 			if (!nn(n) || !en(t, e)) return;
-			_o();
-			let r = No(), i = r ? Vo(e, n) : [n], a = un(t, e.clientX, e.clientY), o = a ? jn(t, a, e.clientX, e.clientY) : null, c = String(n?.filename || "").split(".").pop() || "", l = a && !o ? dn(a, n, c) : null;
+			vo();
+			let r = Po(), i = r ? Ho(e, n) : [n], a = un(t, e.clientX, e.clientY), o = a ? jn(t, a, e.clientX, e.clientY) : null, c = String(n?.filename || "").split(".").pop() || "", l = a && !o ? dn(a, n, c) : null;
 			if (a && o) {
 				e.preventDefault(), e.stopImmediatePropagation?.(), e.stopPropagation(), Zt(t, fn);
 				let r = await gn({
 					post: ue,
-					endpoint: lt.STAGE_TO_INPUT,
+					endpoint: B.STAGE_TO_INPUT,
 					payload: n,
 					index: !1
 				});
@@ -3553,14 +3563,14 @@ function us() {
 					inputSlotIndex: o.index,
 					event: e
 				})) {
-					oo("drop slot created and connected loader", {
+					so("drop slot created and connected loader", {
 						node: a?.title,
 						slot: o.input?.name,
 						value: r
 					});
 					return;
 				}
-				A(`Staged to input: ${r}`, "success", 4e3);
+				k(`Staged to input: ${r}`, "success", 4e3);
 				return;
 			}
 			if (a && !o && !l && a._timelineEditor && !r) {
@@ -3571,40 +3581,40 @@ function us() {
 				if (Zt(t, fn), e.preventDefault(), e.stopImmediatePropagation?.(), e.stopPropagation(), r) {
 					let r = Hn({
 						app: t,
-						items: await Ho(i),
+						items: await Uo(i),
 						event: e
 					});
 					if (r > 0) {
-						oo("drop canvas created loaders", { count: r });
+						so("drop canvas created loaders", { count: r });
 						return;
 					}
-					A(`Failed to load file: "${n?.filename}". Staging failed.`, "error");
+					k(`Failed to load file: "${n?.filename}". Staging failed.`, "error");
 					return;
 				}
 				if (String(n?.kind || "").toLowerCase() === "workflow") {
-					if (await as(n)) {
-						oo("drop canvas loaded workflow", { file: n?.filename });
+					if (await os(n)) {
+						so("drop canvas loaded workflow", { file: n?.filename });
 						return;
 					}
-					A(`Failed to load workflow: "${n?.filename}".`, "error");
+					k(`Failed to load workflow: "${n?.filename}".`, "error");
 					return;
 				}
 				let o = !a && !r, s = $t({
 					post: ue,
-					endpoint: lt.STAGE_TO_INPUT,
+					endpoint: B.STAGE_TO_INPUT,
 					payload: n,
 					index: !1
-				}), l = o ? as(n) : Promise.resolve(!1), [u, d] = await Promise.all([l, s]);
+				}), l = o ? os(n) : Promise.resolve(!1), [u, d] = await Promise.all([l, s]);
 				if (u) {
-					oo("drop canvas loaded workflow", { file: n?.filename });
+					so("drop canvas loaded workflow", { file: n?.filename });
 					return;
 				}
 				let f = d?.relativePath;
 				if (!f) {
-					oo("drop canvas stage failed"), A(`Failed to load file: "${n?.filename}". Staging failed.`, "error");
+					so("drop canvas stage failed"), k(`Failed to load file: "${n?.filename}". Staging failed.`, "error");
 					return;
 				}
-				if (oo("drop canvas staged", { value: f }), Hn({
+				if (so("drop canvas staged", { value: f }), Hn({
 					app: t,
 					items: [{
 						payload: n,
@@ -3613,75 +3623,75 @@ function us() {
 					}],
 					event: e
 				})) {
-					oo("drop canvas created loader", { value: f });
+					so("drop canvas created loader", { value: f });
 					return;
 				}
-				A(`Staged to input: ${f}`, "success", 4e3);
+				k(`Staged to input: ${f}`, "success", 4e3);
 				return;
 			}
 			e.preventDefault(), e.stopImmediatePropagation?.(), e.stopPropagation(), Zt(t, fn);
 			let u = await gn({
 				post: ue,
-				endpoint: lt.STAGE_TO_INPUT,
+				endpoint: B.STAGE_TO_INPUT,
 				payload: n,
 				index: !1
 			});
-			u && (tn(l, u), fn(t), oo("drop inject", {
+			u && (tn(l, u), fn(t), so("drop inject", {
 				node: a?.title,
 				widget: l?.name,
 				value: u
 			}));
 		},
 		onDragLeave: () => {
-			Zt(Do(), fn), oo("dragleave");
+			Zt(Oo(), fn), so("dragleave");
 		}
 	};
 }
-function ds() {
+function fs() {
 	if (typeof window > "u" || !window?.addEventListener) return { dispose() {} };
-	let { onKeyDown: e, onKeyUp: t, onWindowBlur: n, onDragOver: r, onDrop: i, onDragLeave: a } = us();
+	let { onKeyDown: e, onKeyUp: t, onWindowBlur: n, onDragOver: r, onDrop: i, onDragLeave: a } = ds();
 	return window.addEventListener("keydown", e, !0), window.addEventListener("keyup", t, !0), window.addEventListener("blur", n, !0), window.addEventListener("dragover", r, !0), window.addEventListener("drop", i, !0), window.addEventListener("dragleave", a, !0), { dispose: () => {
 		try {
 			window.removeEventListener("keydown", e, !0), window.removeEventListener("keyup", t, !0), window.removeEventListener("blur", n, !0), window.removeEventListener("dragover", r, !0), window.removeEventListener("drop", i, !0), window.removeEventListener("dragleave", a, !0);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		ko = !1, Ao = !1;
+		Ao = !1, jo = !1;
 		try {
-			Zt(Do(), fn);
+			Zt(Oo(), fn);
 		} catch (e) {
 			console.debug?.(e);
 		}
 	} };
 }
-function fs() {
-	cs || (cs = ds(), ls = 0), ls += 1;
+function ps() {
+	ls || (ls = fs(), us = 0), us += 1;
 	let e = !1;
 	return ({ force: t = !1 } = {}) => {
-		e || (e = !0, ps({ force: t }));
+		e || (e = !0, ms({ force: t }));
 	};
 }
-function ps({ force: e = !1 } = {}) {
-	if (!cs) {
-		ls = 0, yo();
+function ms({ force: e = !1 } = {}) {
+	if (!ls) {
+		us = 0, bo();
 		return;
 	}
-	if (!e && ls > 1) {
-		--ls;
+	if (!e && us > 1) {
+		--us;
 		return;
 	}
-	ls = 0;
+	us = 0;
 	try {
-		cs.dispose?.();
+		ls.dispose?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
-	cs = null, yo();
+	ls = null, bo();
 }
 //#endregion
 //#region ui/features/grid/MediaBlobCache.ts
-var ms = "__MJR_MEDIA_BLOB_CACHE__", hs = 384, gs = 300 * 1e3, _s = 30 * 1e3, vs = 15 * 1e3, ys = 6, bs = 192, xs = 3;
-function Ss() {
+var hs = "__MJR_MEDIA_BLOB_CACHE__", gs = 384, _s = 300 * 1e3, vs = 30 * 1e3, ys = 15 * 1e3, bs = 6, xs = 192, Ss = 3;
+function Cs() {
 	let e = /* @__PURE__ */ new Map(), t = null, n = 0, r = [];
 	function i() {
 		try {
@@ -3693,10 +3703,10 @@ function Ss() {
 		return !1;
 	}
 	function a() {
-		return i() ? bs : hs;
+		return i() ? xs : gs;
 	}
 	function o() {
-		return i() ? xs : ys;
+		return i() ? Ss : bs;
 	}
 	async function s(e) {
 		n >= o() && await new Promise((e) => r.push(e)), n += 1;
@@ -3709,7 +3719,7 @@ function Ss() {
 		}
 	}
 	function c() {
-		t ||= setInterval(l, vs);
+		t ||= setInterval(l, ys);
 	}
 	function l() {
 		try {
@@ -3731,7 +3741,7 @@ function Ss() {
 		for (let [r, i] of e) i.refcount > 0 || i.expiresAt < n && (n = i.expiresAt, t = r);
 		t && (u(e.get(t)), e.delete(t));
 	}
-	function f(e, t = gs) {
+	function f(e, t = _s) {
 		e.expiresAt = Date.now() + t;
 	}
 	function p() {
@@ -3755,7 +3765,7 @@ function Ss() {
 			r ? (r.hasError = !0, f(r)) : (e.size >= a() && d(), e.set(n, {
 				blobUrl: null,
 				refcount: 0,
-				expiresAt: Date.now() + _s,
+				expiresAt: Date.now() + vs,
 				hasError: !0
 			}), p(), c());
 		} catch (e) {
@@ -3789,7 +3799,7 @@ function Ss() {
 			return e.size >= a() && d(), e.set(r, {
 				blobUrl: g,
 				refcount: 1,
-				expiresAt: Date.now() + gs,
+				expiresAt: Date.now() + _s,
 				hasError: !1
 			}), p(), c(), g;
 		} catch (e) {
@@ -3801,7 +3811,7 @@ function Ss() {
 			let n = m(t);
 			if (!n) return;
 			let r = e.get(n);
-			r && (r.refcount = Math.max(0, r.refcount - 1), r.refcount <= 0 && f(r, _s)), l(), p();
+			r && (r.refcount = Math.max(0, r.refcount - 1), r.refcount <= 0 && f(r, vs)), l(), p();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -3828,26 +3838,26 @@ function Ss() {
 		dispose: y
 	};
 }
-function Cs() {
+function ws() {
 	try {
-		if (window[ms]) return window[ms];
+		if (window[hs]) return window[hs];
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		window[ms]?.dispose?.();
+		window[hs]?.dispose?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let e = Ss();
+	let e = Cs();
 	try {
-		window[ms] = e;
+		window[hs] = e;
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return e;
 }
-var ws = Cs(), Ts = ["title"], Es = {
+var Ts = ws(), Es = ["title"], Ds = {
 	__name: "RatingBadge",
 	props: { rating: {
 		type: [Number, String],
@@ -3858,7 +3868,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 		}
 	} },
 	setup(e) {
-		let t = e, n = G(() => Math.max(0, Math.min(5, Number(t.rating) || 0))), r = G(() => n.value > 0), i = G(() => R("rating.title", "Rating: {n} star{n, plural, one {} other {s}}", { n: n.value }));
+		let t = e, n = G(() => Math.max(0, Math.min(5, Number(t.rating) || 0))), r = G(() => n.value > 0), i = G(() => L("rating.title", "Rating: {n} star{n, plural, one {} other {s}}", { n: n.value }));
 		return (e, t) => r.value ? (V(), Y("div", {
 			key: 0,
 			class: "mjr-rating-badge",
@@ -3869,9 +3879,9 @@ var ws = Cs(), Ts = ["title"], Es = {
 				color: "var(--mjr-rating-color, var(--mjr-star-active, #FFD45A))",
 				marginRight: e < n.value ? "2px" : "0"
 			})
-		}, " ★ ", 4))), 128))], 8, Ts)) : W("", !0);
+		}, " ★ ", 4))), 128))], 8, Es)) : W("", !0);
 	}
-}, Ds = ["title"], Os = {
+}, Os = ["title"], ks = {
 	__name: "TagsBadge",
 	props: { tags: {
 		type: [Array, String],
@@ -3891,7 +3901,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 				}
 			}
 			return [];
-		}), r = G(() => n.value.length > 0), i = G(() => R("tags.title", "Tags: {tags}", { tags: n.value.join(", ") })), a = G(() => {
+		}), r = G(() => n.value.length > 0), i = G(() => L("tags.title", "Tags: {tags}", { tags: n.value.join(", ") })), a = G(() => {
 			let e = n.value;
 			return e.length <= 5 ? e.join(", ") : e.slice(0, 5).join(", ") + ` +${e.length - 5}`;
 		});
@@ -3900,9 +3910,9 @@ var ws = Cs(), Ts = ["title"], Es = {
 			class: "mjr-tags-badge",
 			title: i.value,
 			style: { color: "var(--mjr-tag-color, #90CAF9)" }
-		}, q(a.value), 9, Ds)) : W("", !0);
+		}, q(a.value), 9, Os)) : W("", !0);
 	}
-}, ks = ["title"], As = {
+}, As = ["title"], js = {
 	__name: "GenTimeBadge",
 	props: { genTimeMs: {
 		type: [Number, String],
@@ -3915,22 +3925,22 @@ var ws = Cs(), Ts = ["title"], Es = {
 			class: "mjr-gentime-badge",
 			title: i.value.title,
 			style: Cr({ color: a.value })
-		}, q(i.value.text), 13, ks)) : W("", !0);
+		}, q(i.value.text), 13, As)) : W("", !0);
 	}
-}, js = {
+}, Ms = {
 	key: 0,
 	class: "mjr-live-placeholder-wash",
 	"aria-hidden": "true"
-}, Ms = ["title", "aria-label"], Ns = ["alt", "src"], Ps = { class: "mjr-workflow-thumb-title" }, Fs = { class: "mjr-workflow-thumb-meta" }, Is = { key: 0 }, Ls = { key: 1 }, Rs = { key: 2 }, zs = {
+}, Ns = ["title", "aria-label"], Ps = ["alt", "src"], Fs = { class: "mjr-workflow-thumb-title" }, Is = { class: "mjr-workflow-thumb-meta" }, Ls = { key: 0 }, Rs = { key: 1 }, zs = { key: 2 }, Bs = {
 	key: 3,
 	class: "mjr-workflow-missing-chip"
-}, Bs = ["alt", "src"], Vs = {
+}, Vs = ["alt", "src"], Hs = {
 	key: 1,
 	class: "mjr-media-error-placeholder"
-}, Hs = ["data-src", "poster"], Us = ["src"], Ws = { class: "mjr-audio-thumb-head" }, Gs = { class: "mjr-audio-thumb-kind" }, Ks = {
+}, Us = ["data-src", "poster"], Ws = ["src"], Gs = { class: "mjr-audio-thumb-head" }, Ks = { class: "mjr-audio-thumb-kind" }, qs = {
 	class: "mjr-audio-thumb-waveform",
 	"aria-hidden": "true"
-}, qs = { class: "mjr-audio-thumb-meta" }, Js = { class: "mjr-audio-thumb-title" }, Ys = { class: "mjr-audio-thumb-subtitle" }, Xs = ["src", "alt"], Zs = {
+}, Js = { class: "mjr-audio-thumb-meta" }, Ys = { class: "mjr-audio-thumb-title" }, Xs = { class: "mjr-audio-thumb-subtitle" }, Zs = ["src", "alt"], Qs = {
 	key: 1,
 	class: "mjr-model3d-thumb-icon",
 	style: {
@@ -3941,23 +3951,23 @@ var ws = Cs(), Ts = ["title"], Es = {
 		"justify-content": "center",
 		color: "rgba(255,255,255,0.7)"
 	}
-}, Qs = [
+}, $s = [
 	"data-mjr-ext",
 	"data-mjr-badge-bg",
 	"title"
-], $s = ["title"], ec = {
+], ec = ["title"], tc = {
 	key: 7,
 	class: "mjr-card-hover-info"
-}, tc = {
+}, nc = {
 	key: 0,
 	class: "mjr-hover-prompt"
-}, nc = {
+}, rc = {
 	key: 1,
 	class: "mjr-hover-prompt mjr-hover-workflow-notes"
-}, rc = {
+}, ic = {
 	key: 2,
 	class: "mjr-hover-gentime"
-}, ic = ["data-mjr-kind"], ac = ["title"], oc = {
+}, ac = ["data-mjr-kind"], oc = ["title"], sc = {
 	class: "mjr-card-meta-row",
 	style: {
 		"font-size": "0.85em",
@@ -3968,7 +3978,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 		"text-overflow": "ellipsis",
 		"padding-right": "16px"
 	}
-}, sc = ["title"], cc = ["title"], lc = ["title"], uc = {
+}, cc = ["title"], lc = ["title"], uc = ["title"], dc = {
 	key: 0,
 	class: "mjr-meta-separator",
 	"aria-hidden": "true",
@@ -3976,7 +3986,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 		opacity: "0.55",
 		margin: "0 3px"
 	}
-}, dc = ["title"], fc = { class: "mjr-stack-group-button-count" }, pc = { class: "mjr-dup-stack-count" }, mc = {
+}, fc = ["title"], pc = { class: "mjr-stack-group-button-count" }, mc = { class: "mjr-dup-stack-count" }, hc = {
 	__name: "AssetCardInner",
 	props: { asset: {
 		type: Object,
@@ -4004,7 +4014,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 		async function i(e, t = {}) {
 			if (!e) return null;
 			try {
-				return ws.hasError(e) ? null : await ws.acquireUrl(e, t) || null;
+				return Ts.hasError(e) ? null : await Ts.acquireUrl(e, t) || null;
 			} catch {
 				return null;
 			}
@@ -4017,13 +4027,13 @@ var ws = Cs(), Ts = ["title"], Es = {
 				let t = String(e.dataset?.src || "").trim();
 				if (!t || e.getAttribute("src")) return;
 				let n = (Number(e._mjrVideoLoadRequestId || 0) || 0) + 1;
-				if (e._mjrVideoLoadRequestId = n, ws.hasError(t)) {
+				if (e._mjrVideoLoadRequestId = n, Ts.hasError(t)) {
 					e.src = t, e._mjrSourceKey = t;
 					return;
 				}
-				let r = await ws.acquireUrl(t);
+				let r = await Ts.acquireUrl(t);
 				if (e._mjrVideoLoadRequestId !== n || !e.isConnected) {
-					r && ws.releaseUrl(t);
+					r && Ts.releaseUrl(t);
 					return;
 				}
 				r ? (e.src = r, e._mjrCachedSrc = t, e._mjrSourceKey = t) : (e.src = t, e._mjrSourceKey = t), e.load?.();
@@ -4044,7 +4054,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 				}
 				try {
 					let t = String(e._mjrCachedSrc || "").trim();
-					t && ws.releaseUrl(t), e._mjrCachedSrc = "", e._mjrSourceKey = "";
+					t && Ts.releaseUrl(t), e._mjrCachedSrc = "", e._mjrSourceKey = "";
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -4115,46 +4125,46 @@ var ws = Cs(), Ts = ["title"], Es = {
 		function f(e) {
 			e && (u(e), s(e));
 		}
-		let p = e, m = t, h = G(() => String(p.asset.kind || "image").toLowerCase()), g = G(() => h.value === "workflow"), _ = G(() => h.value === "image"), v = G(() => h.value === "video"), y = G(() => h.value === "audio"), b = G(() => h.value === "model3d"), x = G(() => ot(p.asset) || ""), S = G(() => String(p.asset.thumbnail_url || p.asset.graph_map_thumbnail_url || p.asset.thumb_url || p.asset.poster || "").trim()), C = G(() => !!String(p.asset.thumbnail_url || p.asset.thumb_url || p.asset.poster || "").trim()), w = G(() => g.value && !C.value && !!String(p.asset.graph_map_thumbnail_url || "").trim()), T = G(() => String(p.asset.preview_url || p.asset.previewUrl || p.asset.url || "").trim()), E = G(() => x.value), D = G(() => T.value || x.value), O = G(() => !v.value && !g.value ? "" : Ze(p.asset, 384)), k = G(() => S.value || O.value), A = G(() => String(p.asset.filename || "")), j = G(() => String(p.asset.display_name || p.asset.displayName || p.asset.name || A.value || "").trim()), M = G(() => {
+		let p = e, m = t, h = G(() => String(p.asset.kind || "image").toLowerCase()), g = G(() => h.value === "workflow"), _ = G(() => h.value === "image"), v = G(() => h.value === "video"), y = G(() => h.value === "audio"), b = G(() => h.value === "model3d"), x = G(() => st(p.asset) || ""), S = G(() => String(p.asset.thumbnail_url || p.asset.graph_map_thumbnail_url || p.asset.thumb_url || p.asset.poster || "").trim()), C = G(() => !!String(p.asset.thumbnail_url || p.asset.thumb_url || p.asset.poster || "").trim()), w = G(() => g.value && !C.value && !!String(p.asset.graph_map_thumbnail_url || "").trim()), T = G(() => String(p.asset.preview_url || p.asset.previewUrl || p.asset.url || "").trim()), E = G(() => x.value), D = G(() => T.value || x.value), O = G(() => !v.value && !g.value ? "" : Qe(p.asset, 384)), k = G(() => S.value || O.value), A = G(() => String(p.asset.filename || "")), j = G(() => String(p.asset.display_name || p.asset.displayName || p.asset.name || A.value || "").trim()), M = G(() => {
 			let e = A.value;
 			return e.includes(".") ? e.split(".").pop().toUpperCase() : "";
 		}), N = G(() => {
 			let e = j.value || A.value;
 			return e.includes(".") ? e.slice(0, e.lastIndexOf(".")) : e;
-		}), ee = G(() => String(p.asset.notes || "").trim()), te = G(() => r(`${p.asset.id || ""}:${A.value}:${p.asset.duration || ""}`)), ne = G(() => N.value || A.value || "Audio"), P = G(() => [pe.value, M.value].filter(Boolean).join(" / ") || "Audio"), F = G(() => {
+		}), ee = G(() => String(p.asset.notes || "").trim()), P = G(() => r(`${p.asset.id || ""}:${A.value}:${p.asset.duration || ""}`)), te = G(() => N.value || A.value || "Audio"), ne = G(() => [me.value, M.value].filter(Boolean).join(" / ") || "Audio"), F = G(() => {
 			let e = [A.value || j.value], t = String(p.asset.subfolder || p.asset.file_info?.subfolder || "").trim(), n = String(p.asset.type || p.asset.source || p.asset.file_info?.type || "").trim();
 			return t && e.push(`Subfolder: ${t}`), n && e.push(`Type: ${n}`), ee.value && e.push(`Notes: ${ee.value}`), e.filter(Boolean).join("\n");
-		}), re = G(() => Number(p.asset.rating) || 0), ie = G(() => p.asset.tags || []), ae = G(() => St(p.asset.generation_time_ms ?? p.asset.metadata?.generation_time_ms ?? 0)), oe = G(() => ae.value > 0), se = G(() => kt(ae.value)), I = G(() => jt(ae.value)), ce = G(() => String(p.asset.positive_prompt || "").trim()), le = G(() => p.asset?._mjrLivePlaceholder === !0 || p.asset?.is_live_placeholder === !0 || String(p.asset?.id || "").trim().toLowerCase().startsWith("live:")), ue = G(() => String(p.asset?._mjrLiveLabel || "In progress").trim() || "In progress"), de = G(() => `${ue.value}: waiting for indexed asset data`), fe = G(() => {
+		}), re = G(() => Number(p.asset.rating) || 0), ie = G(() => p.asset.tags || []), ae = G(() => St(p.asset.generation_time_ms ?? p.asset.metadata?.generation_time_ms ?? 0)), oe = G(() => ae.value > 0), se = G(() => kt(ae.value)), ce = G(() => jt(ae.value)), le = G(() => String(p.asset.positive_prompt || "").trim()), ue = G(() => p.asset?._mjrLivePlaceholder === !0 || p.asset?.is_live_placeholder === !0 || String(p.asset?.id || "").trim().toLowerCase().startsWith("live:")), de = G(() => String(p.asset?._mjrLiveLabel || "In progress").trim() || "In progress"), fe = G(() => `${de.value}: waiting for indexed asset data`), pe = G(() => {
 			let { width: e, height: t } = p.asset;
 			return e && t ? `${e}x${t}` : "";
-		}), pe = G(() => p.asset.duration ? Tn(p.asset.duration) : ""), me = G(() => String(p.asset.task || p.asset.workflow_task || "").trim()), he = G(() => String(p.asset.model_family || p.asset.modelFamily || "").trim()), ge = G(() => String(p.asset.runs_on || p.asset.runsOn || "").trim()), _e = G(() => Number(p.asset.node_count || p.asset.nodeCount || 0) || 0), ve = G(() => !!p.asset.favorite), ye = G(() => Number(p.asset.subgraph_count || p.asset.subgraphCount || 0) || 0), be = G(() => Number(p.asset.missing_nodes_count || p.asset.missingNodesCount || 0) || 0), xe = G(() => Number(p.asset.missing_models_count || p.asset.missingModelsCount || 0) || 0), Se = G(() => be.value > 0 || xe.value > 0), Ce = G(() => {
-			if (!Se.value) return "";
+		}), me = G(() => p.asset.duration ? Tn(p.asset.duration) : ""), he = G(() => String(p.asset.task || p.asset.workflow_task || "").trim()), ge = G(() => String(p.asset.model_family || p.asset.modelFamily || "").trim()), _e = G(() => String(p.asset.runs_on || p.asset.runsOn || "").trim()), ve = G(() => Number(p.asset.node_count || p.asset.nodeCount || 0) || 0), ye = G(() => !!p.asset.favorite), be = G(() => Number(p.asset.subgraph_count || p.asset.subgraphCount || 0) || 0), xe = G(() => Number(p.asset.missing_nodes_count || p.asset.missingNodesCount || 0) || 0), Se = G(() => Number(p.asset.missing_models_count || p.asset.missingModelsCount || 0) || 0), Ce = G(() => xe.value > 0 || Se.value > 0), we = G(() => {
+			if (!Ce.value) return "";
 			let e = [];
-			return be.value > 0 && e.push(`${be.value} node`), xe.value > 0 && e.push(`${xe.value} model`), `Missing: ${e.join(" / ")}`;
-		}), we = G(() => p.asset.generation_time || p.asset.file_creation_time || p.asset.mtime || p.asset.created_at), Te = G(() => we.value ? zn(we.value) : ""), Ee = G(() => we.value ? Nn(we.value) : ""), De = G(() => [
-			fe.value ? {
+			return xe.value > 0 && e.push(`${xe.value} node`), Se.value > 0 && e.push(`${Se.value} model`), `Missing: ${e.join(" / ")}`;
+		}), Te = G(() => p.asset.generation_time || p.asset.file_creation_time || p.asset.mtime || p.asset.created_at), Ee = G(() => Te.value ? zn(Te.value) : ""), De = G(() => Te.value ? Nn(Te.value) : ""), Oe = G(() => [
+			pe.value ? {
 				key: "resolution",
 				className: "mjr-meta-res",
-				title: `Resolution: ${fe.value}`,
-				text: fe.value
-			} : null,
-			pe.value ? {
-				key: "duration",
-				className: "mjr-meta-duration",
-				title: `Duration: ${pe.value}`,
+				title: `Resolution: ${pe.value}`,
 				text: pe.value
 			} : null,
-			Te.value ? {
-				key: "date",
-				className: "mjr-meta-date",
-				title: `Date: ${Te.value}`,
-				text: Te.value
+			me.value ? {
+				key: "duration",
+				className: "mjr-meta-duration",
+				title: `Duration: ${me.value}`,
+				text: me.value
 			} : null,
 			Ee.value ? {
+				key: "date",
+				className: "mjr-meta-date",
+				title: `Date: ${Ee.value}`,
+				text: Ee.value
+			} : null,
+			De.value ? {
 				key: "time",
 				className: "mjr-meta-date mjr-meta-time-val",
-				title: `Time: ${Ee.value}`,
-				text: Ee.value
+				title: `Time: ${De.value}`,
+				text: De.value
 			} : null,
 			oe.value ? {
 				key: "gentime",
@@ -4162,33 +4172,21 @@ var ws = Cs(), Ts = ["title"], Es = {
 				title: se.value.title,
 				text: se.value.text,
 				style: {
-					color: I.value,
+					color: ce.value,
 					fontWeight: "500"
 				}
 			} : null
-		].filter(Boolean)), Oe = G(() => !!p.asset._mjrNameCollision && !p.asset._mjrDupStack), ke = G(() => Oe.value ? "var(--mjr-badge-duplicate-alert, #ff1744)" : {
+		].filter(Boolean)), ke = G(() => !!p.asset._mjrNameCollision && !p.asset._mjrDupStack), Ae = G(() => ke.value ? "var(--mjr-badge-duplicate-alert, #ff1744)" : {
 			image: "var(--mjr-badge-image, #2196F3)",
 			video: "var(--mjr-badge-video, #F44336)",
 			audio: "var(--mjr-badge-audio, #4CAF50)",
 			model3d: "var(--mjr-badge-model3d, #9C27B0)"
-		}[h.value] || "var(--mjr-badge-image, #888)"), Ae = rr("mjrStackService", null), je = G(() => !Ae || !String(p.asset.stack_id || "").trim() ? !1 : Number(p.asset.stack_asset_count || p.asset._mjrFeedGroupCount || 0) > 1), Me = G(() => Number(p.asset.stack_asset_count || p.asset._mjrFeedGroupCount || 0) || 0), Ne = G(() => !!p.asset._mjrDupStack && Number(p.asset._mjrDupCount || 0) >= 2), Pe = G(() => Number(p.asset._mjrDupCount || 0) || 0), Fe = G(() => Ne.value && !je.value), Ie = Z(!1), Le = Z(!1);
-		async function Re(e) {
-			if (e.preventDefault(), e.stopPropagation(), !Ie.value) {
-				Ie.value = !0;
-				try {
-					await Ae?.openStackGroup?.(p.asset);
-				} catch (e) {
-					console.debug?.(e);
-				} finally {
-					Ie.value = !1;
-				}
-			}
-		}
-		function ze(e) {
+		}[h.value] || "var(--mjr-badge-image, #888)"), je = rr("mjrStackService", null), Me = G(() => !je || !String(p.asset.stack_id || "").trim() ? !1 : Number(p.asset.stack_asset_count || p.asset._mjrFeedGroupCount || 0) > 1), Ne = G(() => Number(p.asset.stack_asset_count || p.asset._mjrFeedGroupCount || 0) || 0), Pe = G(() => !!p.asset._mjrDupStack && Number(p.asset._mjrDupCount || 0) >= 2), Fe = G(() => Number(p.asset._mjrDupCount || 0) || 0), Ie = G(() => Pe.value && !Me.value), Le = Z(!1), Re = Z(!1);
+		async function ze(e) {
 			if (e.preventDefault(), e.stopPropagation(), !Le.value) {
 				Le.value = !0;
 				try {
-					Ae?.openDupGroup?.(p.asset);
+					await je?.openStackGroup?.(p.asset);
 				} catch (e) {
 					console.debug?.(e);
 				} finally {
@@ -4196,67 +4194,79 @@ var ws = Cs(), Ts = ["title"], Es = {
 				}
 			}
 		}
-		let Be = Z(null), Ve = Z(null), He = Z(null), Ue = Z(null), We = Z(!1), Ge = Z(!1), Ke = Z(""), qe = 0, Je = "", Ye = "", Xe = "";
-		function Qe() {
+		function Be(e) {
+			if (e.preventDefault(), e.stopPropagation(), !Re.value) {
+				Re.value = !0;
+				try {
+					je?.openDupGroup?.(p.asset);
+				} catch (e) {
+					console.debug?.(e);
+				} finally {
+					Re.value = !1;
+				}
+			}
+		}
+		let Ve = Z(null), He = Z(null), Ue = Z(null), We = Z(null), Ge = Z(!1), Ke = Z(!1), qe = Z(""), Je = 0, Ye = "", Xe = "", Ze = "";
+		function $e() {
 			try {
-				Je && ws.releaseUrl(Je);
+				Ye && Ts.releaseUrl(Ye);
 			} catch (e) {
 				console.debug?.(e);
 			}
-			Je = "";
+			Ye = "";
 		}
 		ir(() => g.value ? S.value : _.value ? E.value : "", (e) => {
 			let t = String(e || "").trim();
-			!t || t === Ye || (We.value = !1, Ye = "");
+			!t || t === Xe || (Ge.value = !1, Xe = "");
 		}, { immediate: !0 }), ir(() => b.value ? k.value : "", (e) => {
 			let t = String(e || "").trim();
-			!t || t === Xe || (Ge.value = !1, Xe = "");
-		}, { immediate: !0 }), ir(() => [_.value ? He.value : null, _.value ? E.value : ""], async ([e, t], n, r) => {
-			if (!e || !t || We.value) return;
-			let o = qe += 1, s = new AbortController(), c = !1;
+			!t || t === Ze || (Ke.value = !1, Ze = "");
+		}, { immediate: !0 }), ir(() => [_.value ? Ue.value : null, _.value ? E.value : ""], async ([e, t], n, r) => {
+			if (!e || !t || Ge.value) return;
+			let o = Je += 1, s = new AbortController(), c = !1;
 			r(() => {
 				c = !0, s.abort();
 			});
 			try {
-				let n = Je || String(e.dataset?.mjrSourceKey || "");
-				if (Ke.value && n === t || (e.dataset.mjrSourceKey = t, await a(), c || o !== qe || !e.isConnected)) return;
+				let n = Ye || String(e.dataset?.mjrSourceKey || "");
+				if (qe.value && n === t || (e.dataset.mjrSourceKey = t, await a(), c || o !== Je || !e.isConnected)) return;
 				let r = await i(t, { signal: s.signal });
-				if (c || o !== qe || !e.isConnected) {
-					r && r !== t && ws.releaseUrl(t);
+				if (c || o !== Je || !e.isConnected) {
+					r && r !== t && Ts.releaseUrl(t);
 					return;
 				}
-				if (r && r !== Ke.value) {
-					let e = Je;
-					Ke.value = r, Je = r === t ? "" : t, e && e !== Je && ws.releaseUrl(e);
-				} else !r && Je && Je !== t && (Qe(), Ke.value = "");
+				if (r && r !== qe.value) {
+					let e = Ye;
+					qe.value = r, Ye = r === t ? "" : t, e && e !== Ye && Ts.releaseUrl(e);
+				} else !r && Ye && Ye !== t && ($e(), qe.value = "");
 			} catch {}
 		}, { immediate: !0 });
-		let $e = Z(z.GRID_VIDEO_AUTOPLAY_MODE || "hover");
-		function et() {
-			$e.value = z.GRID_VIDEO_AUTOPLAY_MODE || "hover";
+		let et = Z(R.GRID_VIDEO_AUTOPLAY_MODE || "hover");
+		function tt() {
+			et.value = R.GRID_VIDEO_AUTOPLAY_MODE || "hover";
 		}
 		fr(() => {
-			window.addEventListener("mjr-settings-changed", et);
-		}), ir(Ve, (e, t) => {
+			window.addEventListener("mjr-settings-changed", tt);
+		}), ir(He, (e, t) => {
 			if (t) try {
 				f(t);
 			} catch {}
-			if (e && Be.value) try {
-				d(Be.value, e, $e.value);
+			if (e && Ve.value) try {
+				d(Ve.value, e, et.value);
 			} catch {}
-		}), ir($e, (e) => {
-			let t = Ve.value, n = Be.value;
+		}), ir(et, (e) => {
+			let t = He.value, n = Ve.value;
 			t && n && d(n, t, e);
 		}), lr(() => {
-			window.removeEventListener("mjr-settings-changed", et), qe += 1, Qe();
-			let e = Ve.value;
+			window.removeEventListener("mjr-settings-changed", tt), Je += 1, $e();
+			let e = He.value;
 			if (e) try {
 				f(e);
 			} catch {}
 		}), Or(() => {
-			window.removeEventListener("mjr-settings-changed", et);
+			window.removeEventListener("mjr-settings-changed", tt);
 		}), cr(() => {
-			let e = Ue.value;
+			let e = We.value;
 			if (!e) return;
 			let t = p.asset;
 			t?.has_workflow ?? t?.hasWorkflow, t?.has_generation_data ?? t?.hasGenerationData, t?.has_ai_info ?? t?.hasAiInfo ?? t?.ai_indexed, t?.has_ai_auto_tags ?? t?.hasAiAutoTags ?? t?.auto_tags ?? t?.autoTags, t?.has_ai_enhanced_caption ?? t?.hasAiEnhancedCaption ?? t?.enhanced_caption ?? t?.enhancedCaption, t?.has_ai_vector ?? t?.hasAiVector ?? t?.vector_indexed ?? t?.vectorIndexed;
@@ -4266,18 +4276,18 @@ var ws = Cs(), Ts = ["title"], Es = {
 				n && e.appendChild(n);
 			} catch {}
 		});
-		function tt(e) {
-			We.value = !0;
+		function nt(e) {
+			Ge.value = !0;
 			try {
 				let e = g.value ? S.value : E.value;
-				Ye = String(e || "").trim(), ws.markError(e);
+				Xe = String(e || "").trim(), Ts.markError(e);
 			} catch {}
 		}
-		function L() {
-			Ge.value = !0, Xe = String(k.value || "").trim();
+		function I() {
+			Ke.value = !0, Ze = String(k.value || "").trim();
 		}
-		function R(e) {
-			if (!Oe.value) return;
+		function L(e) {
+			if (!ke.value) return;
 			e.preventDefault(), e.stopPropagation();
 			let t = e.target?.closest?.(".mjr-asset-card");
 			t && t.dispatchEvent(new CustomEvent("mjr:badge-duplicates-focus", {
@@ -4290,7 +4300,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 				}
 			}));
 		}
-		function nt(e, t) {
+		function rt(e, t) {
 			try {
 				t?.preventDefault?.(), t?.stopPropagation?.();
 			} catch (e) {
@@ -4308,9 +4318,9 @@ var ws = Cs(), Ts = ["title"], Es = {
 				U("div", {
 					class: X(["mjr-thumb", { "mjr-thumb-workflow": g.value }]),
 					ref_key: "thumbRef",
-					ref: Be
+					ref: Ve
 				}, [
-					le.value ? (V(), Y("div", js)) : W("", !0),
+					ue.value ? (V(), Y("div", Ms)) : W("", !0),
 					g.value ? (V(), Y(H, { key: 1 }, [
 						U("div", {
 							class: "mjr-workflow-card-actions",
@@ -4318,46 +4328,46 @@ var ws = Cs(), Ts = ["title"], Es = {
 							onDblclick: n[2] ||= pr(() => {}, ["stop"])
 						}, [U("button", {
 							type: "button",
-							class: X(["mjr-workflow-action-btn", { "is-active": ve.value }]),
-							title: ve.value ? "Remove favorite" : "Add favorite",
-							"aria-label": ve.value ? "Remove favorite" : "Add favorite",
-							onClick: n[0] ||= (e) => nt("favorite", e)
-						}, [U("i", { class: X(ve.value ? "pi pi-star-fill" : "pi pi-star") }, null, 2)], 10, Ms)], 32),
-						k.value && !We.value ? (V(), Y("img", {
+							class: X(["mjr-workflow-action-btn", { "is-active": ye.value }]),
+							title: ye.value ? "Remove favorite" : "Add favorite",
+							"aria-label": ye.value ? "Remove favorite" : "Add favorite",
+							onClick: n[0] ||= (e) => rt("favorite", e)
+						}, [U("i", { class: X(ye.value ? "pi pi-star-fill" : "pi pi-star") }, null, 2)], 10, Ns)], 32),
+						k.value && !Ge.value ? (V(), Y("img", {
 							key: 0,
 							class: X(["mjr-thumb-media", { "mjr-workflow-graph-map-preview": w.value }]),
 							alt: A.value,
 							decoding: "async",
 							loading: "lazy",
 							src: k.value,
-							onError: tt
-						}, null, 42, Ns)) : W("", !0),
+							onError: nt
+						}, null, 42, Ps)) : W("", !0),
 						U("div", { class: X(["mjr-workflow-thumb", {
-							"has-thumbnail": k.value && !We.value,
-							"has-graph-map": w.value && !We.value
+							"has-thumbnail": k.value && !Ge.value,
+							"has-graph-map": w.value && !Ge.value
 						}]) }, [
 							n[15] ||= U("i", { class: "pi pi-sitemap" }, null, -1),
-							U("div", Ps, q(me.value || "Workflow"), 1),
-							U("div", Fs, [
-								he.value ? (V(), Y("span", Is, q(he.value), 1)) : W("", !0),
+							U("div", Fs, q(he.value || "Workflow"), 1),
+							U("div", Is, [
 								ge.value ? (V(), Y("span", Ls, q(ge.value), 1)) : W("", !0),
-								_e.value ? (V(), Y("span", Rs, q(_e.value) + " nodes", 1)) : W("", !0),
-								Se.value ? (V(), Y("span", zs, q(Ce.value), 1)) : W("", !0)
+								_e.value ? (V(), Y("span", Rs, q(_e.value), 1)) : W("", !0),
+								ve.value ? (V(), Y("span", zs, q(ve.value) + " nodes", 1)) : W("", !0),
+								Ce.value ? (V(), Y("span", Bs, q(we.value), 1)) : W("", !0)
 							])
 						], 2)
-					], 64)) : _.value ? (V(), Y(H, { key: 2 }, [We.value ? W("", !0) : (V(), Y("img", {
+					], 64)) : _.value ? (V(), Y(H, { key: 2 }, [Ge.value ? W("", !0) : (V(), Y("img", {
 						key: 0,
 						ref_key: "imgRef",
-						ref: He,
+						ref: Ue,
 						class: "mjr-thumb-media",
 						alt: A.value,
 						decoding: "async",
 						loading: "lazy",
-						src: Ke.value || E.value || void 0,
-						onError: tt
-					}, null, 40, Bs)), We.value ? (V(), Y("div", Vs, [...n[16] ||= [U("i", { class: "pi pi-image" }, null, -1)]])) : W("", !0)], 64)) : v.value ? (V(), Y(H, { key: 3 }, [U("video", {
+						src: qe.value || E.value || void 0,
+						onError: nt
+					}, null, 40, Vs)), Ge.value ? (V(), Y("div", Hs, [...n[16] ||= [U("i", { class: "pi pi-image" }, null, -1)]])) : W("", !0)], 64)) : v.value ? (V(), Y(H, { key: 3 }, [U("video", {
 						ref_key: "videoRef",
-						ref: Ve,
+						ref: He,
 						class: "mjr-thumb-media",
 						"data-src": D.value,
 						poster: k.value || void 0,
@@ -4369,75 +4379,75 @@ var ws = Cs(), Ts = ["title"], Es = {
 						draggable: !1,
 						tabindex: -1,
 						style: { "pointer-events": "none" }
-					}, null, 8, Hs), n[17] ||= U("div", { class: "mjr-thumb-play" }, [U("i", { class: "pi pi-play" })], -1)], 64)) : y.value ? (V(), Y(H, { key: 4 }, [k.value ? (V(), Y("img", {
+					}, null, 8, Us), n[17] ||= U("div", { class: "mjr-thumb-play" }, [U("i", { class: "pi pi-play" })], -1)], 64)) : y.value ? (V(), Y(H, { key: 4 }, [k.value ? (V(), Y("img", {
 						key: 0,
 						class: "mjr-thumb-media",
 						src: k.value,
 						draggable: !1,
 						alt: ""
-					}, null, 8, Us)) : W("", !0), U("div", { class: X(["mjr-audio-thumb", { "has-poster": k.value }]) }, [
-						U("div", Ws, [n[18] ||= U("span", { class: "mjr-audio-thumb-icon" }, [U("i", { class: "pi pi-volume-up" })], -1), U("span", Gs, q(M.value || "AUDIO"), 1)]),
-						U("div", Ks, [(V(!0), Y(H, null, ar(te.value, (e, t) => (V(), Y("span", {
+					}, null, 8, Ws)) : W("", !0), U("div", { class: X(["mjr-audio-thumb", { "has-poster": k.value }]) }, [
+						U("div", Gs, [n[18] ||= U("span", { class: "mjr-audio-thumb-icon" }, [U("i", { class: "pi pi-volume-up" })], -1), U("span", Ks, q(M.value || "AUDIO"), 1)]),
+						U("div", qs, [(V(!0), Y(H, null, ar(P.value, (e, t) => (V(), Y("span", {
 							key: t,
 							style: Cr({
 								height: `${e.height}%`,
 								opacity: e.opacity
 							})
 						}, null, 4))), 128))]),
-						U("div", qs, [U("span", Js, q(ne.value), 1), U("span", Ys, q(P.value), 1)])
-					], 2)], 64)) : b.value ? (V(), Y(H, { key: 5 }, [k.value && !Ge.value ? (V(), Y("img", {
+						U("div", Js, [U("span", Ys, q(te.value), 1), U("span", Xs, q(ne.value), 1)])
+					], 2)], 64)) : b.value ? (V(), Y(H, { key: 5 }, [k.value && !Ke.value ? (V(), Y("img", {
 						key: 0,
 						class: "mjr-thumb-media",
 						src: k.value,
 						draggable: !1,
 						alt: A.value,
-						onError: L
-					}, null, 40, Xs)) : (V(), Y("div", Zs, [...n[19] ||= [U("i", {
+						onError: I
+					}, null, 40, Zs)) : (V(), Y("div", Qs, [...n[19] ||= [U("i", {
 						class: "pi pi-box",
 						style: { "font-size": "2.5rem" }
 					}, null, -1)]]))], 64)) : W("", !0),
 					U("div", {
 						class: "mjr-file-badge mjr-badge-ext",
 						"data-mjr-ext": M.value,
-						"data-mjr-badge-bg": ke.value,
+						"data-mjr-badge-bg": Ae.value,
 						style: Cr({
 							position: "absolute",
 							top: "6px",
 							left: "6px",
 							zIndex: 10,
-							background: ke.value,
+							background: Ae.value,
 							color: "#fff",
 							padding: "2px 5px",
 							borderRadius: "4px",
 							fontSize: "10px",
 							fontWeight: "700",
-							pointerEvents: Oe.value ? "auto" : "none",
-							cursor: Oe.value ? "pointer" : "default"
+							pointerEvents: ke.value ? "auto" : "none",
+							cursor: ke.value ? "pointer" : "default"
 						}),
-						title: Oe.value ? `${M.value} - duplicate filename (${e.asset._mjrNameCollisionCount || 2} files)` : `${M.value} file`,
-						onClick: R
-					}, q(M.value) + q(Oe.value ? "+" : ""), 13, Qs),
-					J(Es, {
+						title: ke.value ? `${M.value} - duplicate filename (${e.asset._mjrNameCollisionCount || 2} files)` : `${M.value} file`,
+						onClick: L
+					}, q(M.value) + q(ke.value ? "+" : ""), 13, $s),
+					J(Ds, {
 						rating: re.value,
 						class: "mjr-badge-rating"
 					}, null, 8, ["rating"]),
-					J(Os, {
+					J(ks, {
 						tags: ie.value,
 						class: "mjr-badge-tags"
 					}, null, 8, ["tags"]),
-					J(As, { "gen-time-ms": ae.value }, null, 8, ["gen-time-ms"]),
-					le.value ? (V(), Y("div", {
+					J(js, { "gen-time-ms": ae.value }, null, 8, ["gen-time-ms"]),
+					ue.value ? (V(), Y("div", {
 						key: 6,
 						class: "mjr-live-pill",
-						title: de.value
+						title: fe.value
 					}, [n[20] ||= U("span", {
 						class: "mjr-live-pill-dot",
 						"aria-hidden": "true"
-					}, null, -1), U("span", null, q(ue.value), 1)], 8, $s)) : W("", !0),
-					ce.value || g.value && ee.value || oe.value ? (V(), Y("div", ec, [
-						ce.value ? (V(), Y("div", tc, q(ce.value), 1)) : W("", !0),
-						g.value && ee.value ? (V(), Y("div", nc, q(ee.value), 1)) : W("", !0),
-						oe.value ? (V(), Y("div", rc, "Time " + q(se.value.text), 1)) : W("", !0)
+					}, null, -1), U("span", null, q(de.value), 1)], 8, ec)) : W("", !0),
+					le.value || g.value && ee.value || oe.value ? (V(), Y("div", tc, [
+						le.value ? (V(), Y("div", nc, q(le.value), 1)) : W("", !0),
+						g.value && ee.value ? (V(), Y("div", rc, q(ee.value), 1)) : W("", !0),
+						oe.value ? (V(), Y("div", ic, "Time " + q(se.value.text), 1)) : W("", !0)
 					])) : W("", !0)
 				], 2),
 				U("div", {
@@ -4459,31 +4469,31 @@ var ws = Cs(), Ts = ["title"], Es = {
 							"margin-bottom": "4px",
 							"padding-right": "12px"
 						}
-					}, q(N.value), 9, ac),
-					U("div", oc, [g.value ? (V(), Y(H, { key: 0 }, [
-						me.value ? (V(), Y("span", {
+					}, q(N.value), 9, oc),
+					U("div", sc, [g.value ? (V(), Y(H, { key: 0 }, [
+						he.value ? (V(), Y("span", {
 							key: 0,
 							class: "mjr-meta-workflow-task",
-							title: `Task: ${me.value}`
-						}, q(me.value), 9, sc)) : W("", !0),
-						ye.value ? (V(), Y("span", {
+							title: `Task: ${he.value}`
+						}, q(he.value), 9, cc)) : W("", !0),
+						be.value ? (V(), Y("span", {
 							key: 1,
 							class: "mjr-meta-workflow-subgraphs",
-							title: `${ye.value} subgraph${ye.value > 1 ? "s" : ""}`
-						}, q(ye.value) + " sub", 9, cc)) : W("", !0),
-						Se.value ? (V(), Y("span", {
+							title: `${be.value} subgraph${be.value > 1 ? "s" : ""}`
+						}, q(be.value) + " sub", 9, lc)) : W("", !0),
+						Ce.value ? (V(), Y("span", {
 							key: 2,
 							class: "mjr-meta-workflow-missing",
-							title: Ce.value
-						}, q(Ce.value), 9, lc)) : W("", !0)
-					], 64)) : W("", !0), (V(!0), Y(H, null, ar(De.value, (e, t) => (V(), Y(H, { key: e.key }, [t > 0 ? (V(), Y("span", uc, "/")) : W("", !0), U("span", {
+							title: we.value
+						}, q(we.value), 9, uc)) : W("", !0)
+					], 64)) : W("", !0), (V(!0), Y(H, null, ar(Oe.value, (e, t) => (V(), Y(H, { key: e.key }, [t > 0 ? (V(), Y("span", dc, "/")) : W("", !0), U("span", {
 						class: X(e.className),
 						style: Cr(e.style || null),
 						title: e.title
-					}, q(e.text), 15, dc)], 64))), 128))]),
+					}, q(e.text), 15, fc)], 64))), 128))]),
 					U("div", {
 						ref_key: "dotWrapperRef",
-						ref: Ue,
+						ref: We,
 						class: "mjr-card-dot-wrapper",
 						style: {
 							position: "absolute",
@@ -4492,19 +4502,19 @@ var ws = Cs(), Ts = ["title"], Es = {
 							"z-index": "2"
 						}
 					}, null, 512)
-				], 8, ic),
-				je.value ? (V(), nr(r, {
+				], 8, ac),
+				Me.value ? (V(), nr(r, {
 					key: 0,
 					type: "button",
 					class: "mjr-stack-group-button",
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					disabled: Ie.value,
-					"aria-busy": Ie.value ? "true" : "false",
-					"aria-label": `Open generation group in grid (${Me.value} assets)`,
-					title: `Open generation group in grid (${Me.value} assets)`,
-					onClick: Re,
+					disabled: Le.value,
+					"aria-busy": Le.value ? "true" : "false",
+					"aria-label": `Open generation group in grid (${Ne.value} assets)`,
+					title: `Open generation group in grid (${Ne.value} assets)`,
+					onClick: ze,
 					onPointerdown: n[3] ||= pr(() => {}, ["stop"]),
 					onMousedown: n[4] ||= pr(() => {}, ["stop", "prevent"]),
 					onTouchstartPassive: n[5] ||= pr(() => {}, ["stop"]),
@@ -4512,7 +4522,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 					onKeydown: n[7] ||= pr(() => {}, ["stop"]),
 					onDragstart: n[8] ||= pr(() => {}, ["stop", "prevent"])
 				}, {
-					default: Q(() => [n[21] ||= U("span", { class: "pi pi-clone" }, null, -1), U("span", fc, q(Me.value), 1)]),
+					default: Q(() => [n[21] ||= U("span", { class: "pi pi-clone" }, null, -1), U("span", pc, q(Ne.value), 1)]),
 					_: 1
 				}, 8, [
 					"disabled",
@@ -4520,18 +4530,18 @@ var ws = Cs(), Ts = ["title"], Es = {
 					"aria-label",
 					"title"
 				])) : W("", !0),
-				Fe.value ? (V(), nr(r, {
+				Ie.value ? (V(), nr(r, {
 					key: 1,
 					type: "button",
 					class: "mjr-dup-stack-button",
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					disabled: Le.value,
-					"aria-busy": Le.value ? "true" : "false",
-					"aria-label": `${Pe.value} duplicate${Pe.value > 1 ? "s" : ""} - click to compare all copies`,
-					title: `${Pe.value} duplicate${Pe.value > 1 ? "s" : ""} - click to compare all copies`,
-					onClick: ze,
+					disabled: Re.value,
+					"aria-busy": Re.value ? "true" : "false",
+					"aria-label": `${Fe.value} duplicate${Fe.value > 1 ? "s" : ""} - click to compare all copies`,
+					title: `${Fe.value} duplicate${Fe.value > 1 ? "s" : ""} - click to compare all copies`,
+					onClick: Be,
 					onPointerdown: n[9] ||= pr(() => {}, ["stop"]),
 					onMousedown: n[10] ||= pr(() => {}, ["stop", "prevent"]),
 					onTouchstartPassive: n[11] ||= pr(() => {}, ["stop"]),
@@ -4539,7 +4549,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 					onKeydown: n[13] ||= pr(() => {}, ["stop"]),
 					onDragstart: n[14] ||= pr(() => {}, ["stop", "prevent"])
 				}, {
-					default: Q(() => [n[22] ||= U("span", { class: "pi pi-copy" }, null, -1), U("span", pc, q(Pe.value), 1)]),
+					default: Q(() => [n[22] ||= U("span", { class: "pi pi-copy" }, null, -1), U("span", mc, q(Fe.value), 1)]),
 					_: 1
 				}, 8, [
 					"disabled",
@@ -4550,19 +4560,23 @@ var ws = Cs(), Ts = ["title"], Es = {
 			], 64);
 		};
 	}
-}, hc = [
+}, gc = (e, t) => {
+	let n = e.__vccOpts || e;
+	for (let [e, r] of t) n[e] = r;
+	return n;
+}, _c = [
 	"data-mjr-asset-id",
 	"data-mjr-filename-key",
 	"data-mjr-stem",
 	"aria-label",
 	"aria-selected"
-], gc = {
+], vc = {
 	class: "mjr-card-info mjr-card-meta",
 	style: {
 		padding: "6px 8px",
 		"min-width": "0"
 	}
-}, _c = ["title"], vc = {
+}, yc = ["title"], bc = /*#__PURE__*/ gc({
 	__name: "FolderCard",
 	props: {
 		asset: {
@@ -4574,12 +4588,40 @@ var ws = Cs(), Ts = ["title"], Es = {
 			default: !1
 		}
 	},
-	setup(e) {
+	emits: ["drop-asset"],
+	setup(e, { emit: t }) {
+		let n = e, r = t, i = Z(!1);
+		function a(e) {
+			e.dataTransfer && (e.dataTransfer.dropEffect = "move"), i.value = !0;
+		}
+		function o() {
+			i.value = !1;
+		}
+		function s(e) {
+			if (i.value = !1, !e.dataTransfer || !Array.from(e.dataTransfer.types).includes("application/x-mjr-asset")) return;
+			let t = null;
+			try {
+				let n = e.dataTransfer.getData("application/x-mjr-asset");
+				n && (t = JSON.parse(n));
+			} catch {}
+			if (!t) return;
+			let a = String(n.asset.filepath || "").trim();
+			a && r("drop-asset", {
+				asset: t,
+				folderPath: a
+			});
+		}
 		return (t, n) => (V(), Y("div", {
-			class: X(["mjr-asset-card mjr-card mjr-folder-card", { "is-selected": e.selected }]),
+			class: X(["mjr-asset-card mjr-card mjr-folder-card", {
+				"is-selected": e.selected,
+				"drop-active": i.value
+			}]),
 			role: "button",
 			tabindex: 0,
 			draggable: "true",
+			onDragover: pr(a, ["prevent"]),
+			onDragleave: o,
+			onDrop: pr(s, ["stop", "prevent"]),
 			"data-mjr-asset-id": String(e.asset.id ?? ""),
 			"data-mjr-filename-key": String(e.asset.filename || "").toLowerCase(),
 			"data-mjr-ext": "FOLDER",
@@ -4605,7 +4647,7 @@ var ws = Cs(), Ts = ["title"], Es = {
 		}), U("path", {
 			fill: "#D9A730",
 			d: "M20 6H4c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z"
-		})])], -1), U("div", gc, [U("div", {
+		})])], -1), U("div", vc, [U("div", {
 			class: "mjr-card-filename",
 			title: e.asset.filename,
 			style: {
@@ -4614,15 +4656,15 @@ var ws = Cs(), Ts = ["title"], Es = {
 				"white-space": "nowrap",
 				"margin-bottom": "4px"
 			}
-		}, q(e.asset.filename), 9, _c), n[0] ||= U("div", { class: "mjr-card-meta-row" }, null, -1)])], 10, hc));
+		}, q(e.asset.filename), 9, yc), n[0] ||= U("div", { class: "mjr-card-meta-row" }, null, -1)])], 42, _c));
 	}
-};
+}, [["__scopeId", "data-v-18e248b5"]]);
 //#endregion
 //#region ui/vue/composables/useGridState.ts
-function yc(e) {
+function xc(e) {
 	return Array.from(e || []).map((e) => String(e || "").trim()).filter(Boolean);
 }
-function bc() {
+function Sc() {
 	let e = br({
 		query: "*",
 		offset: 0,
@@ -4652,7 +4694,7 @@ function bc() {
 	e.virtualGrid = { setItems(t) {
 		e.assets = Array.isArray(t) ? t.slice() : [];
 	} };
-	let t = G(() => new Set(yc(e.selectedIds)));
+	let t = G(() => new Set(xc(e.selectedIds)));
 	function n(t = "", { error: n = !1 } = {}) {
 		e.statusMessage = String(t || ""), e.statusError = !!n;
 	}
@@ -4672,14 +4714,14 @@ function bc() {
 		e.query = String(t || "*") || "*", e.offset = 0, e.cursor = null, e.total = n == null ? null : Number(n) || 0, e.done = !!r, e.assets = [], o();
 	}
 	function c(t, n = "", { preserveAnchor: r = !1 } = {}) {
-		let i = Array.from(new Set(yc(t))), a = String(n || i[0] || "").trim();
+		let i = Array.from(new Set(xc(t))), a = String(n || i[0] || "").trim();
 		return e.selectedIds = i, e.activeId = a, r || (a ? e.selectionAnchorId = a : i.length || (e.selectionAnchorId = "")), {
 			selectedIds: i,
 			activeId: a
 		};
 	}
 	function l(t, { activeId: n = "" } = {}) {
-		let r = new Set(yc(t)), i = yc(e.selectedIds).filter((e) => r.has(e)), a = String(n || e.activeId || i[0] || "").trim();
+		let r = new Set(xc(t)), i = xc(e.selectedIds).filter((e) => r.has(e)), a = String(n || e.activeId || i[0] || "").trim();
 		return c(i, r.has(a) ? a : i[0] || "", { preserveAnchor: !0 });
 	}
 	function u() {
@@ -4711,14 +4753,14 @@ function bc() {
 }
 //#endregion
 //#region ui/vue/composables/gridVisibility.ts
-function xc(e) {
+function Cc(e) {
 	try {
 		return typeof e?.getClientRects == "function" ? e.getClientRects().length > 0 : !0;
 	} catch (e) {
 		return console.debug?.(e), !1;
 	}
 }
-function Sc(e, { requireClientRect: t = !0 } = {}) {
+function wc(e, { requireClientRect: t = !0 } = {}) {
 	if (!e || typeof e != "object") return !1;
 	try {
 		if (typeof document < "u" && document.hidden) return !1;
@@ -4743,14 +4785,14 @@ function Sc(e, { requireClientRect: t = !0 } = {}) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return t ? xc(e) : !0;
+	return t ? Cc(e) : !0;
 }
-function Cc(e) {
-	return Sc(e, { requireClientRect: !0 });
+function Tc(e) {
+	return wc(e, { requireClientRect: !0 });
 }
-function wc(e, t = null) {
+function Ec(e, t = null) {
 	let n = t || e;
-	if (!Cc(n) || e && e !== n && !Sc(e, { requireClientRect: !1 })) return !1;
+	if (!Tc(n) || e && e !== n && !wc(e, { requireClientRect: !1 })) return !1;
 	try {
 		let e = Number(n?.clientWidth || 0) || 0, t = Number(n?.clientHeight || 0) || 0;
 		return e > 0 && t > 0;
@@ -4760,50 +4802,50 @@ function wc(e, t = null) {
 }
 //#endregion
 //#region ui/vue/grid/useGridQuery.ts
-function Tc(e, t = "") {
+function Dc(e, t = "") {
 	return String(e ?? t).trim() || String(t);
 }
-function Ec(e, t = 0) {
+function Oc(e, t = 0) {
 	let n = Number(e);
 	return Number.isFinite(n) ? n : t;
 }
-function Dc(e) {
+function kc(e) {
 	return e === !0 || e === 1 || String(e || "") === "1";
 }
-function Oc(e = {}) {
-	let t = Tc(e.q ?? e.query, "*") || "*", n = Object.prototype.hasOwnProperty.call(e, "resolutionCompare") ? String(e.resolutionCompare ?? "").trim().toLowerCase() : "gte", r = n === "lte" ? "lte" : n ? "gte" : "";
+function Ac(e = {}) {
+	let t = Dc(e.q ?? e.query, "*") || "*", n = Object.prototype.hasOwnProperty.call(e, "resolutionCompare") ? String(e.resolutionCompare ?? "").trim().toLowerCase() : "gte", r = n === "lte" ? "lte" : n ? "gte" : "";
 	return Object.freeze({
-		scope: Tc(e.scope, "output").toLowerCase(),
+		scope: Dc(e.scope, "output").toLowerCase(),
 		q: t,
 		query: t,
-		customRootId: Tc(e.customRootId),
-		subfolder: Tc(e.subfolder),
-		collectionId: Tc(e.collectionId),
-		viewScope: Tc(e.viewScope),
-		kind: Tc(e.kind).toLowerCase(),
-		workflowOnly: Dc(e.workflowOnly),
-		minRating: Ec(e.minRating, 0),
-		minSizeMB: Ec(e.minSizeMB, 0),
-		maxSizeMB: Ec(e.maxSizeMB, 0),
+		customRootId: Dc(e.customRootId),
+		subfolder: Dc(e.subfolder),
+		collectionId: Dc(e.collectionId),
+		viewScope: Dc(e.viewScope),
+		kind: Dc(e.kind).toLowerCase(),
+		workflowOnly: kc(e.workflowOnly),
+		minRating: Oc(e.minRating, 0),
+		minSizeMB: Oc(e.minSizeMB, 0),
+		maxSizeMB: Oc(e.maxSizeMB, 0),
 		resolutionCompare: r,
-		minWidth: Ec(e.minWidth, 0),
-		minHeight: Ec(e.minHeight, 0),
-		maxWidth: Ec(e.maxWidth, 0),
-		maxHeight: Ec(e.maxHeight, 0),
-		workflowType: Tc(e.workflowType).toUpperCase(),
-		workflowId: Tc(e.workflowId),
-		workflowModel: Tc(e.workflowModel),
-		workflowRunsOn: Tc(e.workflowRunsOn).toLowerCase(),
-		dateRange: Tc(e.dateRange).toLowerCase(),
-		dateExact: Tc(e.dateExact),
-		metadataSearchMode: Tc(e.metadataSearchMode),
-		sort: Tc(e.sort, "mtime_desc").toLowerCase(),
-		semanticMode: e.semanticMode === void 0 || e.semanticMode === null ? void 0 : Dc(e.semanticMode),
-		groupStacks: e.groupStacks === void 0 || e.groupStacks === null ? void 0 : Dc(e.groupStacks)
+		minWidth: Oc(e.minWidth, 0),
+		minHeight: Oc(e.minHeight, 0),
+		maxWidth: Oc(e.maxWidth, 0),
+		maxHeight: Oc(e.maxHeight, 0),
+		workflowType: Dc(e.workflowType).toUpperCase(),
+		workflowId: Dc(e.workflowId),
+		workflowModel: Dc(e.workflowModel),
+		workflowRunsOn: Dc(e.workflowRunsOn).toLowerCase(),
+		dateRange: Dc(e.dateRange).toLowerCase(),
+		dateExact: Dc(e.dateExact),
+		metadataSearchMode: Dc(e.metadataSearchMode),
+		sort: Dc(e.sort, "mtime_desc").toLowerCase(),
+		semanticMode: e.semanticMode === void 0 || e.semanticMode === null ? void 0 : kc(e.semanticMode),
+		groupStacks: e.groupStacks === void 0 || e.groupStacks === null ? void 0 : kc(e.groupStacks)
 	});
 }
-function kc(e = {}, t = {}) {
-	return Oc({
+function jc(e = {}, t = {}) {
+	return Ac({
 		scope: e.mjrScope,
 		q: e.mjrQuery,
 		customRootId: e.mjrCustomRootId,
@@ -4833,16 +4875,16 @@ function kc(e = {}, t = {}) {
 		...t
 	});
 }
-function Ac(e = null, t = "*") {
+function Mc(e = null, t = "*") {
 	let n = e?.dataset || {};
-	return kc(n, { q: n.mjrQuery ?? t }).q;
+	return jc(n, { q: n.mjrQuery ?? t }).q;
 }
-function jc(e = null, t = "mtime_desc") {
+function Nc(e = null, t = "mtime_desc") {
 	let n = e?.dataset || {};
-	return kc(n, { sort: n.mjrSort ?? t }).sort;
+	return jc(n, { sort: n.mjrSort ?? t }).sort;
 }
-function Mc(e = {}) {
-	let t = Oc(e);
+function Pc(e = {}) {
+	let t = Ac(e);
 	return [
 		t.scope,
 		t.q,
@@ -4868,31 +4910,31 @@ function Mc(e = {}) {
 		t.dateExact
 	].join("|");
 }
-function Nc(e = {}) {
-	let t = Oc(e), n = t.viewScope && t.viewScope !== t.scope ? t.viewScope : "";
+function Fc(e = {}) {
+	let t = Ac(e), n = t.viewScope && t.viewScope !== t.scope ? t.viewScope : "";
 	return !!(t.subfolder || t.customRootId || t.collectionId || n || t.kind || t.workflowOnly || t.minRating > 0 || t.minSizeMB > 0 || t.maxSizeMB > 0 || t.minWidth > 0 || t.minHeight > 0 || t.maxWidth > 0 || t.maxHeight > 0 || t.workflowType || t.workflowId || t.workflowModel || t.workflowRunsOn || t.dateRange || t.dateExact);
 }
-function Pc(e = {}) {
-	let t = Oc(e);
-	return t.scope === "output" && t.q === "*" && t.sort === "mtime_desc" && !Nc(t);
+function Ic(e = {}) {
+	let t = Ac(e);
+	return t.scope === "output" && t.q === "*" && t.sort === "mtime_desc" && !Fc(t);
 }
 //#endregion
 //#region ui/features/grid/PersistentAssetCache.ts
-var Fc = "mjr-asset-cache", Ic = 1, Lc = "snapshots", Rc = 24, zc = 500, Bc = 2700 * 1e3, Vc = null;
-function Hc() {
-	return Vc || (Vc = new Promise((e) => {
+var Lc = "mjr-asset-cache", Rc = 1, zc = "snapshots", Bc = 24, Vc = 500, Hc = 2700 * 1e3, Uc = null;
+function Wc() {
+	return Uc || (Uc = new Promise((e) => {
 		try {
-			let t = indexedDB.open(Fc, Ic);
+			let t = indexedDB.open(Lc, Rc);
 			t.onupgradeneeded = () => {
 				let e = t.result;
-				e.objectStoreNames.contains(Lc) || e.createObjectStore(Lc, { keyPath: "key" });
+				e.objectStoreNames.contains(zc) || e.createObjectStore(zc, { keyPath: "key" });
 			}, t.onsuccess = () => e(t.result), t.onerror = () => e(null);
 		} catch {
 			e(null);
 		}
-	}), Vc);
+	}), Uc);
 }
-function Uc(e) {
+function Gc(e) {
 	return !e || typeof e != "object" ? null : {
 		id: e.id,
 		filename: e.filename,
@@ -4917,39 +4959,39 @@ function Uc(e) {
 		positive_prompt: e.positive_prompt
 	};
 }
-function Wc(e) {
+function Kc(e) {
 	if (!e || typeof e != "object") return null;
 	let t = Number(e.at || 0);
-	if (!t || Date.now() - t > Bc) return null;
-	let n = Array.isArray(e.assets) ? e.assets.map(Uc).filter(Boolean) : [];
+	if (!t || Date.now() - t > Hc) return null;
+	let n = Array.isArray(e.assets) ? e.assets.map(Gc).filter(Boolean) : [];
 	return n.length ? {
 		...e,
 		assets: n
 	} : null;
 }
-async function Gc(e) {
-	let t = await Hc();
+async function qc(e) {
+	let t = await Wc();
 	if (!t) return null;
 	try {
-		return t.transaction(Lc, e).objectStore(Lc);
+		return t.transaction(zc, e).objectStore(zc);
 	} catch {
 		return null;
 	}
 }
-var Kc = {
+var Jc = {
 	async get(e) {
-		let t = await Gc("readonly");
+		let t = await qc("readonly");
 		return !t || !e ? null : await new Promise((n) => {
 			let r = t.get(e);
-			r.onsuccess = () => n(Wc(r.result)), r.onerror = () => n(null);
+			r.onsuccess = () => n(Kc(r.result)), r.onerror = () => n(null);
 		});
 	},
 	async put(e, t) {
-		let n = await Gc("readwrite"), r = Wc({
+		let n = await qc("readwrite"), r = Kc({
 			...t,
 			key: e,
 			at: t?.at || Date.now(),
-			assets: Array.isArray(t?.assets) ? t.assets.slice(0, zc) : []
+			assets: Array.isArray(t?.assets) ? t.assets.slice(0, Vc) : []
 		});
 		return !n || !e || !r ? !1 : (await new Promise((e) => {
 			let t = n.put(r);
@@ -4957,7 +4999,7 @@ var Kc = {
 		}), this.prune(), !0);
 	},
 	async prune() {
-		let e = await Gc("readwrite");
+		let e = await qc("readwrite");
 		if (!e) return;
 		let t = await new Promise((t) => {
 			let n = [], r = e.openCursor();
@@ -4966,186 +5008,186 @@ var Kc = {
 				if (!e) return t(n);
 				n.push(e.value), e.continue();
 			}, r.onerror = () => t(n);
-		}), n = t.filter((e) => !Wc(e)).map((e) => e.key), r = t.filter((e) => !n.includes(e.key)).sort((e, t) => Number(e.at || 0) - Number(t.at || 0)).slice(0, Math.max(0, t.length - Rc)).map((e) => e.key);
+		}), n = t.filter((e) => !Kc(e)).map((e) => e.key), r = t.filter((e) => !n.includes(e.key)).sort((e, t) => Number(e.at || 0) - Number(t.at || 0)).slice(0, Math.max(0, t.length - Bc)).map((e) => e.key);
 		for (let t of [...n, ...r]) e.delete(t);
 	}
-}, qc = /* @__PURE__ */ new Map(), Jc = !0, Yc = 8, Xc = 200, Zc = "mjr_grid_snapshot_cache_v2", Qc = 1800 * 1e3, $c = 1500, el = !1, tl = null, nl = !1;
-function rl() {
-	return Jc;
+}, Yc = /* @__PURE__ */ new Map(), Xc = !0, Zc = 8, Qc = 200, $c = "mjr_grid_snapshot_cache_v2", el = 1800 * 1e3, tl = 1500, nl = !1, rl = null, il = !1;
+function al() {
+	return Xc;
 }
-function il() {
+function ol() {
 	try {
-		qc.clear(), ul()?.removeItem?.(Zc), globalThis?.sessionStorage?.removeItem?.(Zc);
+		Yc.clear(), fl()?.removeItem?.($c), globalThis?.sessionStorage?.removeItem?.($c);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-var al = /* @__PURE__ */ "id.filename.name.display_name.filepath.path.fullpath.full_path.file_info.subfolder.source.type.root_id.custom_root_id.kind.ext.size.mtime.generation_time.file_creation_time.created_at.updated_at.indexed_at.width.height.duration.thumbnail_url.thumb_url.preview_url.poster.url.rating.tags.has_workflow.hasWorkflow.has_generation_data.hasGenerationData.workflow_type.workflowType.workflow_id.workflowId.generation_time_ms.positive_prompt.enhanced_caption.auto_tags.has_ai_info.has_ai_vector.has_ai_auto_tags.has_ai_enhanced_caption.job_id.stack_id.source_node_id.source_node_type.date.date_exact".split(".");
-function ol(e, t = "") {
+var sl = /* @__PURE__ */ "id.filename.name.display_name.filepath.path.fullpath.full_path.file_info.subfolder.source.type.root_id.custom_root_id.kind.ext.size.mtime.generation_time.file_creation_time.created_at.updated_at.indexed_at.width.height.duration.thumbnail_url.thumb_url.preview_url.poster.url.rating.tags.has_workflow.hasWorkflow.has_generation_data.hasGenerationData.workflow_type.workflowType.workflow_id.workflowId.generation_time_ms.positive_prompt.enhanced_caption.auto_tags.has_ai_info.has_ai_vector.has_ai_auto_tags.has_ai_enhanced_caption.job_id.stack_id.source_node_id.source_node_type.date.date_exact".split(".");
+function cl(e, t = "") {
 	try {
 		return String(e ?? t).trim();
 	} catch {
 		return String(t);
 	}
 }
-function sl(e = {}) {
+function ll(e = {}) {
 	return JSON.stringify({
-		scope: ol(e.scope || "output", "output"),
-		query: ol(e.query || e.q || "*", "*"),
-		customRootId: ol(e.customRootId || ""),
-		subfolder: ol(e.subfolder || ""),
-		collectionId: ol(e.collectionId || ""),
-		viewScope: ol(e.viewScope || ""),
-		kind: ol(e.kind || ""),
-		workflowOnly: ol(e.workflowOnly ? "1" : ""),
-		minRating: ol(e.minRating || ""),
-		minSizeMB: ol(e.minSizeMB || ""),
-		maxSizeMB: ol(e.maxSizeMB || ""),
-		resolutionCompare: ol(e.resolutionCompare || ""),
-		minWidth: ol(e.minWidth || ""),
-		minHeight: ol(e.minHeight || ""),
-		maxWidth: ol(e.maxWidth || ""),
-		maxHeight: ol(e.maxHeight || ""),
-		workflowType: ol(e.workflowType || "").toUpperCase(),
-		workflowId: ol(e.workflowId || ""),
-		workflowModel: ol(e.workflowModel || ""),
-		workflowRunsOn: ol(e.workflowRunsOn || "").toLowerCase(),
-		dateRange: ol(e.dateRange || ""),
-		dateExact: ol(e.dateExact || ""),
-		sort: ol(e.sort || "mtime_desc", "mtime_desc"),
-		semanticMode: ol(e.semanticMode ? "1" : "")
+		scope: cl(e.scope || "output", "output"),
+		query: cl(e.query || e.q || "*", "*"),
+		customRootId: cl(e.customRootId || ""),
+		subfolder: cl(e.subfolder || ""),
+		collectionId: cl(e.collectionId || ""),
+		viewScope: cl(e.viewScope || ""),
+		kind: cl(e.kind || ""),
+		workflowOnly: cl(e.workflowOnly ? "1" : ""),
+		minRating: cl(e.minRating || ""),
+		minSizeMB: cl(e.minSizeMB || ""),
+		maxSizeMB: cl(e.maxSizeMB || ""),
+		resolutionCompare: cl(e.resolutionCompare || ""),
+		minWidth: cl(e.minWidth || ""),
+		minHeight: cl(e.minHeight || ""),
+		maxWidth: cl(e.maxWidth || ""),
+		maxHeight: cl(e.maxHeight || ""),
+		workflowType: cl(e.workflowType || "").toUpperCase(),
+		workflowId: cl(e.workflowId || ""),
+		workflowModel: cl(e.workflowModel || ""),
+		workflowRunsOn: cl(e.workflowRunsOn || "").toLowerCase(),
+		dateRange: cl(e.dateRange || ""),
+		dateExact: cl(e.dateExact || ""),
+		sort: cl(e.sort || "mtime_desc", "mtime_desc"),
+		semanticMode: cl(e.semanticMode ? "1" : "")
 	});
 }
-function cl(e) {
+function ul(e) {
 	if (!e || typeof e != "object") return null;
 	let t = {};
-	for (let n of al) e[n] !== void 0 && (t[n] = e[n]);
+	for (let n of sl) e[n] !== void 0 && (t[n] = e[n]);
 	return !t.type && t.source && (t.type = t.source), !t.source && t.type && (t.source = t.type), t.kind ||= e.kind || "image", Array.isArray(t.tags) && (t.tags = t.tags.slice(0, 80)), Array.isArray(t.auto_tags) && (t.auto_tags = t.auto_tags.slice(0, 80)), t;
 }
-function ll(e) {
+function dl(e) {
 	if (!e || typeof e != "object") return null;
 	let t = Number(e.at || 0) || 0;
-	if (!t || Date.now() - t > Qc) return null;
-	let n = Array.isArray(e.assets) ? e.assets.map(cl).filter(Boolean) : [];
+	if (!t || Date.now() - t > el) return null;
+	let n = Array.isArray(e.assets) ? e.assets.map(ul).filter(Boolean) : [];
 	if (!n.length) return null;
 	let r = Number(e.total ?? n.length), i = Number(e.offset ?? n.length);
 	return {
 		assets: n,
-		title: ol(e.title || "Cached", "Cached"),
+		title: cl(e.title || "Cached", "Cached"),
 		at: t,
 		total: Number.isFinite(r) ? Math.max(0, r) : n.length,
 		offset: Number.isFinite(i) ? Math.max(n.length, i) : n.length,
 		done: !!e.done,
-		query: ol(e.query || "*", "*")
+		query: cl(e.query || "*", "*")
 	};
 }
-function ul() {
+function fl() {
 	try {
 		return globalThis?.localStorage || null;
 	} catch {
 		return null;
 	}
 }
-rl() || il();
-function dl(e) {
+al() || ol();
+function pl(e) {
 	try {
 		let t = globalThis?.sessionStorage;
 		if (!t || !e) return;
-		let n = t.getItem?.(Zc);
+		let n = t.getItem?.($c);
 		if (!n) return;
-		e.getItem?.(Zc) || e.setItem(Zc, n), t.removeItem(Zc);
+		e.getItem?.($c) || e.setItem($c, n), t.removeItem($c);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function fl() {
+function ml() {
 	let e = Date.now();
-	for (let [t, n] of qc.entries()) {
+	for (let [t, n] of Yc.entries()) {
 		let r = Number(n?.at || 0) || 0;
-		(!r || e - r > Qc) && qc.delete(t);
+		(!r || e - r > el) && Yc.delete(t);
 	}
-	for (; qc.size > Yc;) {
-		let e = qc.keys().next().value;
+	for (; Yc.size > Zc;) {
+		let e = Yc.keys().next().value;
 		if (!e) break;
-		qc.delete(e);
+		Yc.delete(e);
 	}
 }
-function pl() {
-	if (!rl()) {
-		el = !0, il();
+function hl() {
+	if (!al()) {
+		nl = !0, ol();
 		return;
 	}
-	if (!el) {
-		el = !0;
+	if (!nl) {
+		nl = !0;
 		try {
-			let e = ul();
-			dl(e);
-			let t = e?.getItem?.(Zc);
+			let e = fl();
+			pl(e);
+			let t = e?.getItem?.($c);
 			if (!t) return;
 			let n = JSON.parse(t), r = Array.isArray(n?.entries) ? n.entries : [];
 			for (let e of r) {
 				if (!Array.isArray(e) || e.length < 2) continue;
-				let t = String(e[0] || ""), n = ll(e[1]);
-				t && n && qc.set(t, n);
+				let t = String(e[0] || ""), n = dl(e[1]);
+				t && n && Yc.set(t, n);
 			}
-			fl();
+			ml();
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}
 }
-function ml() {
-	if (!rl()) {
-		il();
+function gl() {
+	if (!al()) {
+		ol();
 		return;
 	}
 	try {
-		fl();
-		let e = ul();
+		ml();
+		let e = fl();
 		if (!e) return;
-		let t = Array.from(qc.entries()).map(([e, t]) => [e, {
+		let t = Array.from(Yc.entries()).map(([e, t]) => [e, {
 			...t,
-			assets: Array.isArray(t?.assets) ? t.assets.slice(0, Xc) : []
+			assets: Array.isArray(t?.assets) ? t.assets.slice(0, Qc) : []
 		}]);
-		e.setItem(Zc, JSON.stringify({ entries: t }));
+		e.setItem($c, JSON.stringify({ entries: t }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function hl() {
-	if (!rl()) {
-		il(), nl = !1;
+function _l() {
+	if (!al()) {
+		ol(), il = !1;
 		return;
 	}
-	nl = !0, !tl && (tl = setTimeout(() => {
-		tl = null, nl && (nl = !1, ml());
-	}, $c));
+	il = !0, !rl && (rl = setTimeout(() => {
+		rl = null, il && (il = !1, gl());
+	}, tl));
 }
-function gl() {
-	tl &&= (clearTimeout(tl), null), nl && (nl = !1, ml());
+function vl() {
+	rl &&= (clearTimeout(rl), null), il && (il = !1, gl());
 }
-function _l(e) {
-	if (!rl()) return null;
-	pl();
-	let t = ll(qc.get(e));
-	return t ? (qc.delete(e), qc.set(e, t), hl(), t) : (qc.delete(e), hl(), null);
+function yl(e) {
+	if (!al()) return null;
+	hl();
+	let t = dl(Yc.get(e));
+	return t ? (Yc.delete(e), Yc.set(e, t), _l(), t) : (Yc.delete(e), _l(), null);
 }
-function vl(e) {
-	return rl() ? (pl(), !!ll(qc.get(e))) : !1;
+function bl(e) {
+	return al() ? (hl(), !!dl(Yc.get(e))) : !1;
 }
-function yl(e, t) {
-	if (!rl() || !e || !t || typeof t != "object") return !1;
-	let n = ll({
+function xl(e, t) {
+	if (!al() || !e || !t || typeof t != "object") return !1;
+	let n = dl({
 		...t,
 		at: t.at || Date.now()
 	});
-	return n ? (qc.delete(e), qc.set(e, n), hl(), Kc.put(String(e || ""), n).catch((e) => {
+	return n ? (Yc.delete(e), Yc.set(e, n), _l(), Jc.put(String(e || ""), n).catch((e) => {
 		console.debug?.(e);
 	}), !0) : !1;
 }
 //#endregion
 //#region ui/vue/grid/useAssetCollection.ts
-function bl(e) {
+function Sl(e) {
 	return !e || typeof e != "object" ? "" : [
 		e.source || e.type || "output",
 		e.root_id || e.custom_root_id || "",
@@ -5153,7 +5195,7 @@ function bl(e) {
 		e.filename || e.filepath || e.path || e.fullpath || e.full_path || ""
 	].join("|").trim().toLowerCase();
 }
-function xl(e = [], { assetKey: t = bl } = {}) {
+function Cl(e = [], { assetKey: t = Sl } = {}) {
 	let n = /* @__PURE__ */ new Map(), r = /* @__PURE__ */ new Map();
 	for (let i of Array.isArray(e) ? e : []) {
 		if (!i || typeof i != "object") continue;
@@ -5165,12 +5207,12 @@ function xl(e = [], { assetKey: t = bl } = {}) {
 		byKey: r
 	};
 }
-function Sl(e, { assetKey: t = bl } = {}) {
+function wl(e, { assetKey: t = Sl } = {}) {
 	if (!e || typeof e != "object") return e;
-	let n = xl(Array.isArray(e.assets) ? e.assets : [], { assetKey: t });
+	let n = Cl(Array.isArray(e.assets) ? e.assets : [], { assetKey: t });
 	return e.assetIdSet = new Set(n.byId.keys()), e.seenKeys = new Set(n.byKey.keys()), e;
 }
-function Cl(e, t = [], { assetKey: n = bl } = {}) {
+function Tl(e, t = [], { assetKey: n = Sl } = {}) {
 	if (!e || typeof e != "object") return 0;
 	let r = new Set((Array.isArray(t) ? t : [t]).map((e) => e == null ? "" : typeof e == "object" && e?.id != null ? String(e.id) : String(e)).map((e) => e.trim()).filter(Boolean));
 	if (!r.size) return 0;
@@ -5178,11 +5220,11 @@ function Cl(e, t = [], { assetKey: n = bl } = {}) {
 	return e.assets = (Array.isArray(e.assets) ? e.assets : []).filter((e) => {
 		let t = e?.id == null ? "" : String(e.id);
 		return !t || !r.has(t) ? !0 : (i += 1, !1);
-	}), i > 0 && Sl(e, { assetKey: n }), i;
+	}), i > 0 && wl(e, { assetKey: n }), i;
 }
 //#endregion
 //#region ui/vue/grid/usePagedAssets.ts
-function wl({ assets: e = [], count: t = null, limit: n = 0, offset: r = 0, total: i = null } = {}) {
+function El({ assets: e = [], count: t = null, limit: n = 0, offset: r = 0, total: i = null } = {}) {
 	let a = Array.isArray(e) ? e.length : 0, o = t == null ? a : Math.max(0, Number(t) || 0);
 	if (o <= 0) return 0;
 	let s = Math.max(0, Number(n) || 0), c = Math.max(0, Number(r) || 0), l = i == null ? null : Math.max(0, Number(i) || 0), u = l == null ? null : Math.max(0, l - c);
@@ -5191,7 +5233,7 @@ function wl({ assets: e = [], count: t = null, limit: n = 0, offset: r = 0, tota
 	let d = Math.min(s, u ?? 0);
 	return d <= 0 ? o : Math.max(o, d);
 }
-async function Tl({ fetchPage: e, applyPage: t, getLimit: n, canContinue: r = null, beforeApplyPage: i = null, onEmptyPage: a = null, maxEmptyPages: o = 6 } = {}) {
+async function Dl({ fetchPage: e, applyPage: t, getLimit: n, canContinue: r = null, beforeApplyPage: i = null, onEmptyPage: a = null, maxEmptyPages: o = 6 } = {}) {
 	if (typeof e != "function" || typeof t != "function") return {
 		ok: !1,
 		error: /* @__PURE__ */ Error("fetchPage and applyPage are required")
@@ -5247,7 +5289,7 @@ async function Tl({ fetchPage: e, applyPage: t, getLimit: n, canContinue: r = nu
 		lastResult: l
 	};
 }
-function El({ query: e, collection: t, fetchPage: n, pageSize: r = 80, getPageSize: i = null } = {}) {
+function Ol({ query: e, collection: t, fetchPage: n, pageSize: r = 80, getPageSize: i = null } = {}) {
 	let a = Sr({
 		offset: 0,
 		cursor: null,
@@ -5278,7 +5320,7 @@ function El({ query: e, collection: t, fetchPage: n, pageSize: r = 80, getPageSi
 		};
 	}
 	function f(e, { limit: n = l() } = {}) {
-		let r = Array.isArray(e?.assets) ? e.assets : [], i = e?.total == null ? null : Number(e.total) || 0, o = wl({
+		let r = Array.isArray(e?.assets) ? e.assets : [], i = e?.total == null ? null : Number(e.total) || 0, o = El({
 			assets: r,
 			count: e?.count,
 			limit: Number(e?.limit || n) || n,
@@ -5343,7 +5385,7 @@ function El({ query: e, collection: t, fetchPage: n, pageSize: r = 80, getPageSi
 		let u = a.requestId;
 		a.loading = !0, a.error = null;
 		try {
-			let n = await Tl({
+			let n = await Dl({
 				maxEmptyPages: o,
 				canContinue: t,
 				getLimit: e,
@@ -5404,12 +5446,12 @@ function El({ query: e, collection: t, fetchPage: n, pageSize: r = 80, getPageSi
 }
 //#endregion
 //#region ui/vue/composables/useVirtualGrid.ts
-function Dl(e, t) {
+function kl(e, t) {
 	if (!t || typeof t != "object") return !1;
-	let n = kc(e?.dataset || {}), r = n.scope, i = n.subfolder.toLowerCase(), a = n.kind, o = n.workflowOnly, s = n.minRating, c = n.workflowType.toLowerCase(), l = String(n.workflowId || "").trim(), u = n.dateExact, d = String(t?.subfolder || "").trim().toLowerCase(), f = String(t?.type || t?.source || "output").trim().toLowerCase(), p = String(t?.kind || "").trim().toLowerCase(), m = String(t?.workflow_type || t?.workflowType || "").trim().toLowerCase(), h = String(t?.workflow_id || t?.workflowId || t?.metadata?.workflow_id || t?.metadata?.workflow?.id || "").trim(), g = String(t?.date_exact || t?.date || "").trim(), _ = t?.has_workflow ?? t?.hasWorkflow ?? null;
+	let n = jc(e?.dataset || {}), r = n.scope, i = n.subfolder.toLowerCase(), a = n.kind, o = n.workflowOnly, s = n.minRating, c = n.workflowType.toLowerCase(), l = String(n.workflowId || "").trim(), u = n.dateExact, d = String(t?.subfolder || "").trim().toLowerCase(), f = String(t?.type || t?.source || "output").trim().toLowerCase(), p = String(t?.kind || "").trim().toLowerCase(), m = String(t?.workflow_type || t?.workflowType || "").trim().toLowerCase(), h = String(t?.workflow_id || t?.workflowId || t?.metadata?.workflow_id || t?.metadata?.workflow?.id || "").trim(), g = String(t?.date_exact || t?.date || "").trim(), _ = t?.has_workflow ?? t?.hasWorkflow ?? null;
 	return !(r && r !== "all" && f && f !== r || i && d !== i || a && p && p !== a || o && _ !== null && !_ || s > 0 && (Number(t?.rating || 0) || 0) < s || c && m !== c || l && h && h !== l || u && g && g !== u);
 }
-async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s = null } = {}) {
+async function Al(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s = null } = {}) {
 	let c = (e) => {
 		if (typeof e == "string") return e;
 		if (e && typeof e == "object") {
@@ -5417,12 +5459,12 @@ async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s
 			if (typeof e.target?.value == "string") return e.target.value;
 		}
 		return String(e || "");
-	}, l = kc(e?.dataset || {}), { scope: u, customRootId: d, subfolder: f, kind: p, workflowOnly: m, minRating: h, minSizeMB: g, maxSizeMB: _, resolutionCompare: v, minWidth: y, minHeight: b, maxWidth: x, maxHeight: S, workflowType: C, workflowId: w, workflowModel: T, workflowRunsOn: E, dateRange: D, dateExact: O, metadataSearchMode: k } = l, A = l.sort || "mtime_desc", j = c(t).trim() || "*", M = /^\[object\s+HTML.*Element\]$/i.test(j) ? "*" : j, N = i.sanitizeQuery(M) || M;
+	}, l = jc(e?.dataset || {}), { scope: u, customRootId: d, subfolder: f, kind: p, workflowOnly: m, minRating: h, minSizeMB: g, maxSizeMB: _, resolutionCompare: v, minWidth: y, minHeight: b, maxWidth: x, maxHeight: S, workflowType: C, workflowId: w, workflowModel: T, workflowRunsOn: E, dateRange: D, dateExact: O, metadataSearchMode: k } = l, A = l.sort || "mtime_desc", j = c(t).trim() || "*", M = /^\[object\s+HTML.*Element\]$/i.test(j) ? "*" : j, N = i.sanitizeQuery(M) || M;
 	try {
-		let t = String(u || "").toLowerCase() === "output", c = Nc({
+		let t = String(u || "").toLowerCase() === "output", c = Fc({
 			...l,
 			q: N
-		}), j = t && Number(r ?? 0) === 0 && N === "*" && !c && String(A || "mtime_desc").toLowerCase() === "mtime_desc", M = !(t && (Number(r ?? 0) > 0 || j)), ee = !!l.groupStacks, te = Number(r ?? 0) > 0 ? null : s || null, ne = i.buildListURL({
+		}), j = t && Number(r ?? 0) === 0 && N === "*" && !c && String(A || "mtime_desc").toLowerCase() === "mtime_desc", M = !(t && (Number(r ?? 0) > 0 || j)), ee = !!l.groupStacks, P = Number(r ?? 0) > 0 ? null : s || null, te = i.buildListURL({
 			q: N,
 			limit: n,
 			offset: r,
@@ -5446,11 +5488,11 @@ async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s
 			dateRange: D || null,
 			dateExact: O || null,
 			sort: A,
-			cursor: te,
+			cursor: P,
 			includeTotal: M,
 			groupStacks: ee,
 			metadataMode: k || null
-		}), P = await i.get(ne, {
+		}), ne = await i.get(te, {
 			timeoutMs: 12e4,
 			...o ? { signal: o } : {}
 		});
@@ -5464,23 +5506,23 @@ async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s
 		} catch (e) {
 			console.debug?.(e);
 		}
-		if (P.ok) {
-			let e = P.data?.assets || [], t = Array.isArray(e) ? e.length : 0, n = P.data?.total;
+		if (ne.ok) {
+			let e = ne.data?.assets || [], t = Array.isArray(e) ? e.length : 0, n = ne.data?.total;
 			return {
 				ok: !0,
 				assets: e,
 				total: n == null ? null : Number(n ?? 0) || 0,
 				count: t,
-				limit: Math.max(0, Number(P.data?.limit) || 0),
-				offset: Math.max(0, Number(P.data?.offset) || 0),
-				nextCursor: P.data?.next_cursor || P.data?.nextCursor || null,
-				hasMore: typeof P.data?.has_more == "boolean" ? P.data.has_more : null,
+				limit: Math.max(0, Number(ne.data?.limit) || 0),
+				offset: Math.max(0, Number(ne.data?.offset) || 0),
+				nextCursor: ne.data?.next_cursor || ne.data?.nextCursor || null,
+				hasMore: typeof ne.data?.has_more == "boolean" ? ne.data.has_more : null,
 				sortKey: A,
 				safeQuery: N
 			};
 		}
 		try {
-			if (String(P?.code || "") === "ABORTED") return {
+			if (String(ne?.code || "") === "ABORTED") return {
 				ok: !1,
 				aborted: !0,
 				error: "Aborted"
@@ -5490,7 +5532,7 @@ async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s
 		}
 		return {
 			ok: !1,
-			error: P.error
+			error: ne.error
 		};
 	} catch (e) {
 		try {
@@ -5508,7 +5550,7 @@ async function Ol(e, t, n, r, i, { requestId: a = 0, signal: o = null, cursor: s
 		};
 	}
 }
-function kl(e, t) {
+function jl(e, t) {
 	switch (t) {
 		case "mtime_desc": return -(Number(e?.mtime) || 0);
 		case "mtime_asc": return Number(e?.mtime) || 0;
@@ -5517,23 +5559,23 @@ function kl(e, t) {
 		default: return -(Number(e?.mtime) || 0);
 	}
 }
-function Al(e, t, n) {
+function Ml(e, t, n) {
 	if (n === "name_desc") {
 		let n = String(e?.filename || "").toLowerCase(), r = String(t?.filename || "").toLowerCase();
 		return n > r ? -1 : +(n < r);
 	}
-	let r = kl(e, n), i = kl(t, n);
+	let r = jl(e, n), i = jl(t, n);
 	return r < i ? -1 : +(r > i);
 }
-function jl(e, t, n) {
+function Nl(e, t, n) {
 	return n === "name_asc" ? String(e) < String(t) : n === "name_desc" ? String(e) > String(t) : Number(e) < Number(t);
 }
-function Ml(e, t, n) {
-	let r = kl(t, n);
-	for (let t = 0; t < e.length; t++) if (jl(r, kl(e[t], n), n)) return t;
+function Pl(e, t, n) {
+	let r = jl(t, n);
+	for (let t = 0; t < e.length; t++) if (Nl(r, jl(e[t], n), n)) return t;
 	return e.length;
 }
-function Nl(e, t) {
+function Fl(e, t) {
 	let n = t.get(e);
 	return n || (n = {
 		pending: /* @__PURE__ */ new Map(),
@@ -5541,13 +5583,13 @@ function Nl(e, t) {
 		flushing: !1
 	}, t.set(e, n)), n;
 }
-function Pl(e) {
+function Il(e) {
 	return String(e ?? "").trim().toLowerCase();
 }
-function Fl(e) {
+function Ll(e) {
 	return e?._mjrLivePlaceholder === !0 || e?.is_live_placeholder === !0 || String(e?.id || "").trim().toLowerCase().startsWith("live:");
 }
-function Il(e) {
+function Rl(e) {
 	if (!e || typeof e != "object") return e;
 	try {
 		delete e._mjrLivePlaceholder, delete e._mjrLiveStatus, delete e._mjrLiveLabel, delete e.is_live_placeholder;
@@ -5556,24 +5598,24 @@ function Il(e) {
 	}
 	return e;
 }
-function Ll(e) {
+function zl(e) {
 	if (!e || typeof e != "object") return "";
-	let t = Pl(e?.type || e?.source || "output"), n = Pl(e?.root_id || e?.custom_root_id || ""), r = Pl(e?.subfolder || ""), i = Pl(e?.filename || "");
+	let t = Il(e?.type || e?.source || "output"), n = Il(e?.root_id || e?.custom_root_id || ""), r = Il(e?.subfolder || ""), i = Il(e?.filename || "");
 	if (i) return `${t}|${n}|${r}|${i}`;
-	let a = Pl(e?.filepath || e?.path || e?.fullpath || e?.full_path || "");
+	let a = Il(e?.filepath || e?.path || e?.fullpath || e?.full_path || "");
 	return a ? `${t}|${n}|path|${a}` : "";
 }
-function Rl(e, t, n) {
+function Bl(e, t, n) {
 	let r = Array.isArray(e?.assets) ? e.assets : [];
 	if (t) {
 		let e = r.findIndex((e) => String(e?.id || "") === t);
 		if (e > -1) return e;
 	}
-	let i = Ll(n);
-	return i ? r.findIndex((e) => Ll(e) === i) : -1;
+	let i = zl(n);
+	return i ? r.findIndex((e) => zl(e) === i) : -1;
 }
-function zl(e, t) {
-	return !t || typeof t != "object" || !e || typeof e != "object" ? !1 : Fl(t) ? !0 : ![
+function Vl(e, t) {
+	return !t || typeof t != "object" || !e || typeof e != "object" ? !1 : Ll(t) ? !0 : ![
 		"filename",
 		"filepath",
 		"path",
@@ -5592,7 +5634,7 @@ function zl(e, t) {
 		"date"
 	].some((t) => Object.prototype.hasOwnProperty.call(e, t));
 }
-function Bl(e, t) {
+function Hl(e, t) {
 	let n = /* @__PURE__ */ new Set(), r = /* @__PURE__ */ new Set(), i = /* @__PURE__ */ new Map(), a = [];
 	for (let o of Array.isArray(e?.assets) ? e.assets : []) {
 		let e = o?.id == null ? "" : String(o.id), s = t.assetKey(o), c = Mt(o?.filename);
@@ -5608,9 +5650,9 @@ function Bl(e, t) {
 			e && n.add(e), s && r.add(s), c && i.set(c, o), o._mjrNameCollision = !1, delete o._mjrNameCollisionCount, delete o._mjrNameCollisionPaths, a.push(o);
 		}
 	}
-	e.assets = a, Sl(e, { assetKey: t.assetKey });
+	e.assets = a, wl(e, { assetKey: t.assetKey });
 }
-function Vl(e, t) {
+function Ul(e, t) {
 	let n = t.upsertState.get(e);
 	if (!n || n.pending.size === 0 || n.flushing) return;
 	n.flushing = !0, n.timer &&= (clearTimeout(n.timer), null);
@@ -5620,7 +5662,7 @@ function Vl(e, t) {
 	try {
 		let n = !1;
 		for (let [a, o] of r.entries()) {
-			let r = Fl(o);
+			let r = Ll(o);
 			i.assetKeyFn = t.assetKey;
 			let s = wt(o, i, t.loadMajoorSettings);
 			if (Array.isArray(s?.removed) && s.removed.length) {
@@ -5647,14 +5689,14 @@ function Vl(e, t) {
 			let c = i.assets.findIndex((e) => String(e.id) === a), l = c > -1 ? i.assets[c] : null, u = l ? {
 				...l,
 				...o
-			} : o, d = c > -1 ? c : Rl(i, a, u), f = d > -1 ? i.assets[d] : null, p = f ? {
+			} : o, d = c > -1 ? c : Bl(i, a, u), f = d > -1 ? i.assets[d] : null, p = f ? {
 				...f,
 				...o
 			} : u, m = t.assetKey(u);
-			if (!Dl(e, p)) {
+			if (!kl(e, p)) {
 				if (d > -1) {
-					if (zl(o, f)) {
-						Object.assign(f, o), r || Il(f), i.assets[d] = { ...f }, n = !0;
+					if (Vl(o, f)) {
+						Object.assign(f, o), r || Rl(f), i.assets[d] = { ...f }, n = !0;
 						continue;
 					}
 					let [e] = i.assets.splice(d, 1);
@@ -5664,16 +5706,16 @@ function Vl(e, t) {
 			}
 			if (d > -1) {
 				let e = t.assetKey(f);
-				Object.assign(f, o), r || Il(f);
+				Object.assign(f, o), r || Rl(f);
 				let a = { ...f }, s = t.assetKey(a);
 				i.assets[d] = a, e && e !== s && (i.seenKeys?.delete?.(e), s && i.seenKeys?.add?.(s)), n = !0;
 			} else if (!(i.seenKeys.has(m) || o.id != null && i.assetIdSet?.has?.(a))) {
-				let t = kc(e?.dataset || {}).sort || "mtime_desc", s = r ? u : Il({ ...u }), c = Ml(i.assets, s, t);
+				let t = jc(e?.dataset || {}).sort || "mtime_desc", s = r ? u : Rl({ ...u }), c = Pl(i.assets, s, t);
 				i.seenKeys.add(m), o.id != null && i.assetIdSet?.add?.(a), i.assets.splice(c, 0, s), n = !0;
 			}
 		}
 		if (n && a) {
-			Bl(i, t);
+			Hl(i, t);
 			try {
 				e.dataset.mjrHiddenPngSiblings = String(Number(i.hiddenPngSiblings || 0) || 0);
 			} catch (e) {
@@ -5685,23 +5727,23 @@ function Vl(e, t) {
 		if (n.flushing = !1, n.pending.size > 0 && !n.timer) {
 			let r = Math.min(16, t.debounceMs);
 			n.timer = setTimeout(() => {
-				n.timer = null, Vl(e, t);
+				n.timer = null, Ul(e, t);
 			}, r);
 		}
 	}
 }
-function Hl(e, t, n) {
+function Wl(e, t, n) {
 	if (!t || !t.id) return !1;
 	let r = n.getOrCreateState(e), i = String(t.id);
 	if (!n.ensureVirtualGrid(e, r)) return !1;
-	let a = Nl(e, n.upsertState);
-	return a.pending.set(i, t), a.pending.size >= n.maxBatchSize ? Vl(e, n) : !a.timer && !a.flushing && (a.timer = setTimeout(() => {
-		a.timer = null, Vl(e, n);
+	let a = Fl(e, n.upsertState);
+	return a.pending.set(i, t), a.pending.size >= n.maxBatchSize ? Ul(e, n) : !a.timer && !a.flushing && (a.timer = setTimeout(() => {
+		a.timer = null, Ul(e, n);
 	}, n.debounceMs)), !0;
 }
 //#endregion
 //#region ui/vue/components/grid/gridDomBridge.ts
-function Ul(e) {
+function Gl(e) {
 	let t = String(e ?? "");
 	try {
 		if (typeof CSS < "u" && typeof CSS.escape == "function") return CSS.escape(t);
@@ -5710,7 +5752,7 @@ function Ul(e) {
 	}
 	return t.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 }
-function Wl(e) {
+function Kl(e) {
 	if (!e) return [];
 	try {
 		return Array.from(e.querySelectorAll?.(".mjr-asset-card") || []);
@@ -5718,7 +5760,7 @@ function Wl(e) {
 		return console.debug?.(e), [];
 	}
 }
-function Gl(e) {
+function ql(e) {
 	if (!e) return null;
 	try {
 		return e.querySelector?.(".mjr-asset-card.is-selected") || null;
@@ -5726,47 +5768,47 @@ function Gl(e) {
 		return console.debug?.(e), null;
 	}
 }
-function Kl(e, t) {
+function Jl(e, t) {
 	if (!e) return null;
 	let n = String(t || "").trim();
 	if (!n) return null;
 	try {
-		return e.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${Ul(n)}"]`) || null;
+		return e.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${Gl(n)}"]`) || null;
 	} catch (e) {
 		return console.debug?.(e), null;
 	}
 }
-function ql(e, t = 0) {
+function Yl(e, t = 0) {
 	let n = e?.dataset?.mjrShown, r = Number(n);
 	return Number.isFinite(r) ? Math.max(0, r) : Math.max(0, Number(t) || 0);
 }
 //#endregion
 //#region ui/vue/composables/useGridLoader.ts
-var Jl = 200, Yl = 50, Xl = /* @__PURE__ */ new WeakMap(), Zl = new Set([
+var Xl = 200, Zl = 50, Ql = /* @__PURE__ */ new WeakMap(), $l = new Set([
 	"collection",
 	"filter",
 	"initial",
 	"scope",
 	"search",
 	"sort"
-]), Ql = 0;
-function $l(e) {
+]), eu = 0;
+function tu(e) {
 	return new Promise((t) => setTimeout(t, Math.max(0, Number(e) || 0)));
 }
-function eu(e) {
+function nu(e) {
 	if (!e || typeof e != "object") return "";
 	if (e.id != null && String(e.id).trim()) return `id:${String(e.id).trim()}`;
-	let t = String(e?.type || e?.source || "output").trim().toLowerCase(), n = String(Ne(e) || "").trim().toLowerCase(), r = String(e?.subfolder || "").trim().toLowerCase(), i = String(e?.filename || "").trim().toLowerCase();
+	let t = String(e?.type || e?.source || "output").trim().toLowerCase(), n = String(Pe(e) || "").trim().toLowerCase(), r = String(e?.subfolder || "").trim().toLowerCase(), i = String(e?.filename || "").trim().toLowerCase();
 	if (i) return `${t}|${n}|${r}|${i}`;
 	let a = String(e?.filepath || e?.path || e?.fullpath || e?.full_path || "").trim().toLowerCase();
 	return a ? `${t}|${n}|path|${a}` : "";
 }
-function tu(e) {
+function ru(e) {
 	if (e == null) return e;
 	let t = String(e);
 	return t.trim() === "" ? t : t.trim() === "*" ? "*" : t.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/[<>]/g, " ").replace(/\s+/g, " ").trim() || t;
 }
-function nu(e) {
+function iu(e) {
 	if (typeof e == "string") return e;
 	if (e && typeof e == "object") {
 		if (typeof e.value == "string") return e.value;
@@ -5782,13 +5824,13 @@ function nu(e) {
 	}
 	return String(e || "");
 }
-function ru(e) {
+function au(e) {
 	return e ? typeof e == "object" && "value" in e ? e.value || null : e : null;
 }
-async function iu() {
+async function ou() {
 	await or();
 }
-function au(e, t) {
+function su(e, t) {
 	let n = String(e || "Failed to load");
 	try {
 		let e = String(t?.message || t || "").trim(), r = e.toLowerCase();
@@ -5797,13 +5839,13 @@ function au(e, t) {
 		return n;
 	}
 }
-function ou(e, t) {
-	let n = Math.max(1, Math.min(z.MAX_PAGE_SIZE, Number(e) || 1)), r = Math.max(0, Number(t) || 0);
+function cu(e, t) {
+	let n = Math.max(1, Math.min(R.MAX_PAGE_SIZE, Number(e) || 1)), r = Math.max(0, Number(t) || 0);
 	if (r <= 0) return n;
 	let i = 2 ** Math.min(r, 5);
-	return Math.max(1, Math.min(z.MAX_PAGE_SIZE, n * i));
+	return Math.max(1, Math.min(R.MAX_PAGE_SIZE, n * i));
 }
-function su() {
+function lu() {
 	try {
 		let e = typeof navigator < "u" ? navigator : null, t = Number(e?.deviceMemory || 0) || 0;
 		if (t > 0 && t <= 4 || e?.connection?.saveData === !0) return !0;
@@ -5812,10 +5854,10 @@ function su() {
 	}
 	return !1;
 }
-function cu() {
-	return z.PREFETCH_NEXT_PAGE ? !su() : !1;
+function uu() {
+	return R.PREFETCH_NEXT_PAGE ? !lu() : !1;
 }
-function lu(e, t = {}) {
+function du(e, t = {}) {
 	let n = Array.isArray(e.assets) ? e.assets : [];
 	if (t.rebuildFromVisible && n.length) {
 		vt(e, n, {
@@ -5829,7 +5871,7 @@ function lu(e, t = {}) {
 		preserveHiddenCount: !1
 	});
 }
-function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingMessage: r, setStatusMessage: i, clearStatusMessage: a, resetAssets: o, setSelection: s, reconcileSelection: c, readScrollElement: l = () => null, readRenderedCards: u = () => [], scrollToAssetId: d = () => {}, canLoadMore: f = null } = {}) {
+function fu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingMessage: r, setStatusMessage: i, clearStatusMessage: a, resetAssets: o, setSelection: s, reconcileSelection: c, readScrollElement: l = () => null, readRenderedCards: u = () => [], scrollToAssetId: d = () => {}, canLoadMore: f = null } = {}) {
 	let p = !1, m = null, h = null, g = {
 		pagesRequested: 0,
 		assetsReceived: 0,
@@ -5856,7 +5898,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		g.lastOperation = String(e || ""), t.reloadReason && (g.lastReloadReason = String(t.reloadReason || "")), t.appendReason && (g.lastAppendReason = String(t.appendReason || ""));
 	}
 	function y() {
-		return ru(e);
+		return au(e);
 	}
 	function b() {
 		return C();
@@ -5892,7 +5934,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			...e,
 			counts: {
 				loaded: e.assets.length,
-				visible: ql(y(), e.assets.length),
+				visible: Yl(y(), e.assets.length),
 				total: e.pagination.total
 			},
 			metrics: { ...g }
@@ -5900,8 +5942,8 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 	}
 	function C() {
 		let e = y();
-		return kc(e?.dataset || {}, {
-			q: Ac(e, t.query || "*"),
+		return jc(e?.dataset || {}, {
+			q: Mc(e, t.query || "*"),
 			resolutionCompare: e?.dataset?.mjrFilterResolutionCompare || ""
 		});
 	}
@@ -5939,7 +5981,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		};
 	}
 	function D(e) {
-		return Zl.has(String(e || "").toLowerCase());
+		return $l.has(String(e || "").toLowerCase());
 	}
 	function O(e = null) {
 		try {
@@ -5957,10 +5999,10 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		} catch (e) {
 			console.debug?.(e);
 		}
-		return wc(y(), l());
+		return Ec(y(), l());
 	}
 	function j() {
-		if (!z.DEFER_GRID_FETCH_DURING_EXECUTION) return !1;
+		if (!R.DEFER_GRID_FETCH_DURING_EXECUTION) return !1;
 		try {
 			if (!Array.isArray(t.assets) || t.assets.length === 0) return !1;
 		} catch (e) {
@@ -5979,7 +6021,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			console.debug?.(e);
 		}
 		try {
-			m?.listener && window.removeEventListener(B.RUNTIME_STATUS, m.listener);
+			m?.listener && window.removeEventListener(z.RUNTIME_STATUS, m.listener);
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -5993,21 +6035,21 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		}
 		h = null;
 	}
-	function ee(e, n = z.PREFETCH_NEXT_PAGE_DELAY_MS) {
-		if (!cu()) return;
+	function ee(e, n = R.PREFETCH_NEXT_PAGE_DELAY_MS) {
+		if (!uu()) return;
 		N();
 		let r = Math.max(0, Number(n) || 0);
 		h = setTimeout(() => {
-			h = null, !(t.requestId !== e || t.done || t.loading) && he().catch((e) => {
+			h = null, !(t.requestId !== e || t.done || t.loading) && ge().catch((e) => {
 				console.debug?.("[AssetsManager][GridLoader] Delayed prefetch failed", e);
 			});
 		}, r);
 	}
-	function te(e, t = {}) {
+	function P(e, t = {}) {
 		M();
 		let n = (() => {
 			try {
-				return sl(C());
+				return ll(C());
 			} catch (e) {
 				return console.debug?.(e), null;
 			}
@@ -6028,17 +6070,17 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			if (n) {
 				let e = null;
 				try {
-					e = sl(C());
+					e = ll(C());
 				} catch (e) {
 					console.debug?.(e);
 				}
 				if (e && e !== n) {
-					we("[Grid] Deferred execution reload skipped  -  scope/filter changed during execution");
+					Te("[Grid] Deferred execution reload skipped  -  scope/filter changed during execution");
 					return;
 				}
 			}
-			let a = Ac(i, e);
-			Promise.resolve().then(() => ve(a, {
+			let a = Mc(i, e);
+			Promise.resolve().then(() => ye(a, {
 				...t || {},
 				reset: !0,
 				preserveVisibleUntilReady: !0
@@ -6051,21 +6093,21 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			timer: setTimeout(r, 1250)
 		};
 		try {
-			window.addEventListener(B.RUNTIME_STATUS, i);
+			window.addEventListener(z.RUNTIME_STATUS, i);
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}
-	function ne(e, t = null) {
+	function te(e, t = null) {
 		if (!e || typeof e != "object") return "";
-		let n = e.id == null ? `${e.type || ""}|${Ne(e)}|${e.filepath || ""}|${e.subfolder || ""}|${e.filename || ""}` : `id:${e.id}`;
+		let n = e.id == null ? `${e.type || ""}|${Pe(e)}|${e.filepath || ""}|${e.subfolder || ""}|${e.filename || ""}` : `id:${e.id}`;
 		try {
-			return no(t || y() || globalThis?.__MJR_LAST_ASSETKEY_GRID__, e, n);
+			return ro(t || y() || globalThis?.__MJR_LAST_ASSETKEY_GRID__, e, n);
 		} catch (e) {
 			return console.debug?.(e), n;
 		}
 	}
-	function P() {
+	function ne() {
 		try {
 			let e = mn?.() || {}, t = e.grid || {};
 			return t.snapshotCacheEnabled === !0 || t.enableSnapshotCache === !0 || e.snapshotCacheEnabled === !0 || e.enableSnapshotCache === !0;
@@ -6075,17 +6117,17 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 	}
 	function F(e = "") {
 		try {
-			if (!P()) return;
+			if (!ne()) return;
 			let n = y(), r = Array.isArray(t.assets) ? t.assets : [];
 			if (!n || !r.length) return;
-			let i = r.map(cl).filter(Boolean);
+			let i = r.map(ul).filter(Boolean);
 			if (!i.length) return;
-			let a = i.length < r.length, o = Number(t.offset || i.length) || i.length, s = Number(t.total ?? i.length), c = kc(n.dataset || {}, {
-				q: Ac(n, t.query || "*"),
+			let a = i.length < r.length, o = Number(t.offset || i.length) || i.length, s = Number(t.total ?? i.length), c = jc(n.dataset || {}, {
+				q: Mc(n, t.query || "*"),
 				resolutionCompare: n.dataset?.mjrFilterResolutionCompare || ""
-			}), l = sl(c);
+			}), l = ll(c);
 			if (!l) return;
-			yl(l, {
+			xl(l, {
 				assets: i,
 				title: String(e || "").trim(),
 				query: String(t.query || c.query || "*").trim() || "*",
@@ -6100,7 +6142,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 	function re() {
 		let e = y();
 		if (e) try {
-			let t = Xl.get(e);
+			let t = Ql.get(e);
 			if (!t) return;
 			t.timer &&= (clearTimeout(t.timer), null), t.pending.clear(), t.flushing = !1;
 		} catch (e) {
@@ -6115,31 +6157,31 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			},
 			ensureVirtualGrid: () => t.virtualGrid,
 			setFileBadgeCollision: Tt,
-			assetKey: (t) => ne(t, e),
-			ensureDupStackCard: (e, t, n) => io(e, t, n)
+			assetKey: (t) => te(t, e),
+			ensureDupStackCard: (e, t, n) => ao(e, t, n)
 		});
 		return g.renderTimeMs += Math.max(0, _() - r), g.assetsReceived += i, g.visibleAssetsAdded += Number(o || 0) || 0, g.hiddenOrDedupedAssets += Math.max(0, i - (Number(o || 0) || 0)), o;
 	}
 	function ae(e, t) {
 		let n = String(t || "*").trim() || "*";
-		return Mc(kc(e?.dataset || {}, { q: n }));
+		return Pc(jc(e?.dataset || {}, { q: n }));
 	}
-	function oe(e) {
-		let t = C(), n = tu(nu(e).trim() || "*") || "*";
-		return Pc({
+	function se(e) {
+		let t = C(), n = ru(iu(e).trim() || "*") || "*";
+		return Ic({
 			...t,
 			q: n
 		});
 	}
-	function se(e, { query: t = "*", limit: n = 0, offset: r = 0 } = {}) {
-		if (!e?.ok || e.total == null || !oe(t)) return e;
+	function ce(e, { query: t = "*", limit: n = 0, offset: r = 0 } = {}) {
+		if (!e?.ok || e.total == null || !se(t)) return e;
 		let i = Number(e.total), a = Number(e.count ?? e.assets?.length ?? 0) || 0, o = Math.max(1, Number(n) || 1), s = Math.max(0, Number(r) || 0) + a;
 		return Number.isFinite(i) && i > 0 && i <= s && a > 0 && a < o ? {
 			...e,
 			total: null
 		} : e;
 	}
-	async function ce(e, n, r, { requestId: i = 0, signal: a = null } = {}) {
+	async function le(e, n, r, { requestId: i = 0, signal: a = null } = {}) {
 		let o = y();
 		if (!o) return {
 			ok: !1,
@@ -6163,9 +6205,9 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 					};
 					let c = s?.data?.assets;
 					if (s?.ok && Array.isArray(c)) {
-						we("[Grid] Using early-fetched data:", c.length, "assets");
+						Te("[Grid] Using early-fetched data:", c.length, "assets");
 						let t = s.data?.total ?? s.meta?.total ?? null;
-						return se({
+						return ce({
 							ok: !0,
 							assets: c,
 							total: t == null ? null : Number(t) || 0,
@@ -6180,14 +6222,14 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 						});
 					}
 				} catch (e) {
-					we("[Grid] Early fetch failed, falling back to normal fetch", e);
+					Te("[Grid] Early fetch failed, falling back to normal fetch", e);
 				}
 			}
 		}
-		return se(await Ol(o, e, n, r, {
-			sanitizeQuery: tu,
-			buildListURL: L,
-			get: I,
+		return ce(await Al(o, e, n, r, {
+			sanitizeQuery: ru,
+			buildListURL: I,
+			get: oe,
 			getGridState: () => t
 		}, {
 			requestId: i,
@@ -6199,7 +6241,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			offset: r
 		});
 	}
-	let le = El({
+	let ue = Ol({
 		query: {
 			get value() {
 				return t.query || "*";
@@ -6218,16 +6260,16 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		fetchPage: async ({ query: e, limit: n, offset: r, requestId: i }) => {
 			let a = _();
 			g.pagesRequested += 1;
-			let o = await ce(e, n, r, {
+			let o = await le(e, n, r, {
 				requestId: i,
 				signal: t.abortController?.signal || null
 			});
 			return g.apiTimeMs += Math.max(0, _() - a), o;
 		},
-		pageSize: z.DEFAULT_PAGE_SIZE
+		pageSize: R.DEFAULT_PAGE_SIZE
 	});
-	function ue() {
-		le.setPageState({
+	function de() {
+		ue.setPageState({
 			offset: t.offset,
 			cursor: t.cursor,
 			total: t.total,
@@ -6237,22 +6279,22 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			error: null
 		});
 	}
-	function de(e = {}, { syncPaged: n = !0 } = {}) {
-		!e || typeof e != "object" || (Object.prototype.hasOwnProperty.call(e, "offset") && (t.offset = Math.max(0, Number(e.offset || 0) || 0)), Object.prototype.hasOwnProperty.call(e, "cursor") && (t.cursor = e.cursor || null), Object.prototype.hasOwnProperty.call(e, "total") && (t.total = e.total == null ? null : Math.max(0, Number(e.total) || 0)), Object.prototype.hasOwnProperty.call(e, "done") && (t.done = !!e.done), n && ue());
-	}
-	function fe() {
-		de(le.getPageState(), { syncPaged: !1 });
+	function fe(e = {}, { syncPaged: n = !0 } = {}) {
+		!e || typeof e != "object" || (Object.prototype.hasOwnProperty.call(e, "offset") && (t.offset = Math.max(0, Number(e.offset || 0) || 0)), Object.prototype.hasOwnProperty.call(e, "cursor") && (t.cursor = e.cursor || null), Object.prototype.hasOwnProperty.call(e, "total") && (t.total = e.total == null ? null : Math.max(0, Number(e.total) || 0)), Object.prototype.hasOwnProperty.call(e, "done") && (t.done = !!e.done), n && de());
 	}
 	function pe() {
-		let e = Array.isArray(t.assets) ? t.assets.length : 0;
-		e <= 0 || t.done || Number(t.offset || 0) >= e || de({ offset: e }, { syncPaged: !0 });
+		fe(ue.getPageState(), { syncPaged: !1 });
 	}
-	function me({ title: e = "", showEmptyMessage: n = !0 } = {}) {
+	function me() {
+		let e = Array.isArray(t.assets) ? t.assets.length : 0;
+		e <= 0 || t.done || Number(t.offset || 0) >= e || fe({ offset: e }, { syncPaged: !0 });
+	}
+	function he({ title: e = "", showEmptyMessage: n = !0 } = {}) {
 		r(), Array.isArray(t.assets) && t.assets.length ? (a(), F(e || t.query)) : n && (!t.statusMessage || !t.statusError) && i("No assets found");
 		let o = (Array.isArray(t.assets) ? t.assets : []).map((e) => String(e?.id || "")).filter(Boolean);
 		(t.done || Number.isFinite(Number(t.total)) && Number(t.total || 0) <= o.length) && c(o, { activeId: t.activeId });
 	}
-	async function he() {
+	async function ge() {
 		let e = y();
 		if (!e || t.loading || t.done) return {
 			ok: !0,
@@ -6270,7 +6312,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			console.debug?.(e);
 		}
 		let f = Array.isArray(t.selectedIds) ? t.selectedIds.join("|") : "", m = String(t.activeId || "");
-		if (v("appendNextPage", { appendReason: "pagination" }), !A()) return !t.assets.length && !t.loading && cu() && ee(t.requestId, 400), {
+		if (v("appendNextPage", { appendReason: "pagination" }), !A()) return !t.assets.length && !t.loading && uu() && ee(t.requestId, 400), {
 			ok: !0,
 			skipped: !0,
 			hidden: !0
@@ -6280,7 +6322,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			skipped: !0,
 			busy: !0
 		};
-		let h = Math.max(1, Math.min(z.MAX_PAGE_SIZE, z.DEFAULT_PAGE_SIZE)), _ = Date.now();
+		let h = Math.max(1, Math.min(R.MAX_PAGE_SIZE, R.DEFAULT_PAGE_SIZE)), _ = Date.now();
 		t.loading = !0, a();
 		try {
 			if (!t.done) {
@@ -6289,11 +6331,11 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 					skipped: !0,
 					hidden: !0
 				};
-				p || pe(), ue();
-				let n = t.requestId, r = await le.loadUntilVisible({
+				p || me(), de();
+				let n = t.requestId, r = await ue.loadUntilVisible({
 					maxEmptyPages: 6,
 					canContinue: () => A(),
-					getLimit: (e) => ou(h, e),
+					getLimit: (e) => cu(h, e),
 					beforeApplyPage: (e) => {
 						if (t.requestId !== n) return {
 							ok: !1,
@@ -6306,12 +6348,12 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 							query: t.query || "*",
 							total: null,
 							done: !1
-						}), de({
+						}), fe({
 							offset: 0,
 							cursor: null,
 							total: null,
 							done: !1
-						}), lu(t), g.resetCount += 1, p = !1, null) : Array.isArray(t.assets) && t.assets.length ? (we("[Grid LoadPage] empty response with cached visible assets  -  preserving cached view", {
+						}), du(t), g.resetCount += 1, p = !1, null) : Array.isArray(t.assets) && t.assets.length ? (Te("[Grid LoadPage] empty response with cached visible assets  -  preserving cached view", {
 							offset: t.offset,
 							query: t.query
 						}), {
@@ -6322,18 +6364,18 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 						}) : null;
 					},
 					onEmptyPage: (e) => {
-						e.emptyPageIndex <= 0 || we(`[Grid LoadPage] fetched adaptive page with no visible additions: offset=${t.offset}, fetched=${e.count}, consumed=${e.advanced}, added=${e.added}, limit=${e.limit}, done=${t.done}, visibleCount=${t.assets.length}, total=${t.total}`);
+						e.emptyPageIndex <= 0 || Te(`[Grid LoadPage] fetched adaptive page with no visible additions: offset=${t.offset}, fetched=${e.count}, consumed=${e.advanced}, added=${e.added}, limit=${e.limit}, done=${t.done}, visibleCount=${t.assets.length}, total=${t.total}`);
 					}
 				});
-				if (fe(), pe(), !r.ok) return r.aborted || r.stale ? r : (de({ done: !0 }), i(au("Failed to load assets", r?.error || "Unknown error"), { error: !0 }), r);
+				if (pe(), me(), !r.ok) return r.aborted || r.stale ? r : (fe({ done: !0 }), i(su("Failed to load assets", r?.error || "Unknown error"), { error: !0 }), r);
 				if (r.preservedCached) return r;
-				if (t.done || r.added > 0) return F(t.query || Ac(e, "*")), {
+				if (t.done || r.added > 0) return F(t.query || Mc(e, "*")), {
 					ok: !0,
 					count: r.count,
 					total: t.total
 				};
 				let a = r.lastResult || r.firstResult || r;
-				return we(`[Grid LoadPage] fetched one page with no visible additions: offset=${t.offset}, fetched=${r.count}, consumed=${a.advanced}, added=${a.added}, limit=${a.limit || h}, done=${t.done}, visibleCount=${t.assets.length}, total=${t.total}`), !t.done && cu() && ee(Number(t.requestId ?? 0) || 0, Math.min(z.PREFETCH_NEXT_PAGE_DELAY_MS ?? 700, 250)), {
+				return Te(`[Grid LoadPage] fetched one page with no visible additions: offset=${t.offset}, fetched=${r.count}, consumed=${a.advanced}, added=${a.added}, limit=${a.limit || h}, done=${t.done}, visibleCount=${t.assets.length}, total=${t.total}`), !t.done && uu() && ee(Number(t.requestId ?? 0) || 0, Math.min(R.PREFETCH_NEXT_PAGE_DELAY_MS ?? 700, 250)), {
 					ok: !0,
 					count: r.count,
 					total: t.total,
@@ -6355,7 +6397,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			} catch (e) {
 				console.debug?.(e);
 			}
-			return i(au("Failed to load assets", e), { error: !0 }), {
+			return i(su("Failed to load assets", e), { error: !0 }), {
 				ok: !1,
 				error: e?.message || String(e)
 			};
@@ -6377,44 +6419,44 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			}
 			try {
 				let e = Date.now() - _;
-				e < Ql && await $l(Ql - e);
+				e < eu && await tu(eu - e);
 			} catch (e) {
 				console.debug?.(e);
 			}
 			t.loading = !1, r();
 		}
 	}
-	let ge = null;
-	function _e(e = 250) {
+	let _e = null;
+	function ve(e = 250) {
 		v("refreshHead", { appendReason: "snapshotHeadRefresh" });
 		try {
-			ge && clearTimeout(ge);
+			_e && clearTimeout(_e);
 		} catch (e) {
 			console.debug?.(e);
 		}
 		let n = t.requestId, r = null;
 		try {
-			r = sl(C());
+			r = ll(C());
 		} catch (e) {
 			console.debug?.(e);
 		}
-		ge = setTimeout(async () => {
-			if (ge = null, Number(t.requestId) !== Number(n) || j() || !y()) return;
+		_e = setTimeout(async () => {
+			if (_e = null, Number(t.requestId) !== Number(n) || j() || !y()) return;
 			if (r) {
 				let e = null;
 				try {
-					e = sl(C());
+					e = ll(C());
 				} catch (e) {
 					console.debug?.(e);
 				}
 				if (e && e !== r) {
-					we("[Grid] Snapshot head refresh skipped  -  context changed");
+					Te("[Grid] Snapshot head refresh skipped  -  context changed");
 					return;
 				}
 			}
-			let e = Math.max(1, Math.min(z.MAX_PAGE_SIZE, z.DEFAULT_PAGE_SIZE));
+			let e = Math.max(1, Math.min(R.MAX_PAGE_SIZE, R.DEFAULT_PAGE_SIZE));
 			try {
-				let i = await ce(t.query || "*", e, 0, {
+				let i = await le(t.query || "*", e, 0, {
 					requestId: n,
 					signal: t.abortController?.signal || null
 				});
@@ -6422,27 +6464,27 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 				if (r) {
 					let e = null;
 					try {
-						e = sl(C());
+						e = ll(C());
 					} catch (e) {
 						console.debug?.(e);
 					}
 					if (e && e !== r) {
-						we("[Grid] Snapshot head refresh discarded  -  context changed mid-fetch");
+						Te("[Grid] Snapshot head refresh discarded  -  context changed mid-fetch");
 						return;
 					}
 				}
 				if (!i?.ok) return;
 				let a = Array.isArray(i.assets) ? i.assets : [];
-				if (i.total != null && de({ total: i.total }), !a.length) return;
+				if (i.total != null && fe({ total: i.total }), !a.length) return;
 				let o = 0;
-				for (let e of a) e && e.id != null && Oe(e) && (o += 1);
-				o > 0 && (F(t.query || "*"), we("[Grid] Snapshot head refresh: inserted", o, "new asset(s)"));
+				for (let e of a) e && e.id != null && ke(e) && (o += 1);
+				o > 0 && (F(t.query || "*"), Te("[Grid] Snapshot head refresh: inserted", o, "new asset(s)"));
 			} catch (e) {
 				console.debug?.("[Grid] Snapshot head refresh failed", e);
 			}
 		}, Math.max(0, Number(e) || 0));
 	}
-	async function ve(e = "*", i = {}) {
+	async function ye(e = "*", i = {}) {
 		let s = t.requestId, { reset: c = !0, preserveVisibleUntilReady: l = !0 } = i || {}, u = y();
 		if (!u) return {
 			ok: !1,
@@ -6457,7 +6499,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let d = nu(e).trim() || "*", f = /^\[object\s+HTML.*Element\]$/i.test(d) ? "*" : d, m = tu(f) || f;
+		let d = iu(e).trim() || "*", f = /^\[object\s+HTML.*Element\]$/i.test(d) ? "*" : d, m = ru(f) || f;
 		t.query = m;
 		let h = c ? E(m, i) : {
 			reason: "append",
@@ -6468,15 +6510,15 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			try {
 				let n = C();
 				n.query = m;
-				let r = sl(n);
-				if (P() && vl(r) && (e = await Ee(n, { allowReplaceExisting: !0 }), t.requestId > s + +!!e)) return console.debug?.("[Grid] loadAssets aborted during deferral due to scope switch"), {
+				let r = ll(n);
+				if (ne() && bl(r) && (e = await De(n, { allowReplaceExisting: !0 }), t.requestId > s + +!!e)) return console.debug?.("[Grid] loadAssets aborted during deferral due to scope switch"), {
 					ok: !1,
 					aborted: !0
 				};
 			} catch (e) {
 				console.debug?.(e);
 			}
-			return e ? (r(), t.loading = !1) : n("Grid refresh deferred while ComfyUI is generating..."), te(m, i || {}), {
+			return e ? (r(), t.loading = !1) : n("Grid refresh deferred while ComfyUI is generating..."), P(m, i || {}), {
 				ok: !0,
 				deferred: !0,
 				cached: e,
@@ -6503,28 +6545,28 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			} catch {
 				t.abortController = null;
 			}
-			t.requestId = (Number(t.requestId) || 0) + 1, N(), re(), a(), p ? (t.query = m, de({
+			t.requestId = (Number(t.requestId) || 0) + 1, N(), re(), a(), p ? (t.query = m, fe({
 				offset: 0,
 				cursor: null,
 				total: null,
 				done: !1
-			}), lu(t, {
+			}), du(t, {
 				rebuildFromVisible: !0,
 				preserveHiddenCount: !0,
-				assetKey: (e) => ne(e, u)
+				assetKey: (e) => te(e, u)
 			})) : (o({
 				query: m,
 				total: null,
 				done: !1
-			}), de({
+			}), fe({
 				offset: 0,
 				cursor: null,
 				total: null,
 				done: !1
-			}), lu(t), g.resetCount += 1), n(m === "*" ? "Loading assets..." : `Searching for "${m}"...`);
+			}), du(t), g.resetCount += 1), n(m === "*" ? "Loading assets..." : `Searching for "${m}"...`);
 		}
-		let _ = await he();
-		return pe(), cu() && _?.ok && !_?.skipped && !t.done && !_?.aborted && ee(t.requestId), c && (me({
+		let _ = await ge();
+		return me(), uu() && _?.ok && !_?.skipped && !t.done && !_?.aborted && ee(t.requestId), c && (he({
 			title: m,
 			showEmptyMessage: !(_?.skipped || _?.hidden || _?.aborted || _?.stale || _?.preservedCached || _?.busy)
 		}), O(h.nextContext)), {
@@ -6535,7 +6577,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			aborted: !!_?.aborted
 		};
 	}
-	async function ye(e, s = {}) {
+	async function be(e, s = {}) {
 		let { title: c = "Collection", reset: l = !0, showLoading: u = !0, preserveVisibleUntilReady: d = !0 } = s || {};
 		v("reload", { reloadReason: s?.resetReason || s?.reason || "collection" });
 		let f = y();
@@ -6559,7 +6601,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			} catch {
 				t.abortController = null;
 			}
-			t.requestId = (Number(t.requestId) || 0) + 1, re(), a(), h ? (t.query = String(c || "Collection"), de({
+			t.requestId = (Number(t.requestId) || 0) + 1, re(), a(), h ? (t.query = String(c || "Collection"), fe({
 				offset: 0,
 				cursor: null,
 				total: p.length,
@@ -6568,48 +6610,48 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 				query: String(c || "Collection"),
 				total: p.length,
 				done: !0
-			}), de({
+			}), fe({
 				offset: 0,
 				cursor: null,
 				total: p.length,
 				done: !0
-			}), lu(t), g.resetCount += 1), u ? (n(p.length ? `Loading ${c}...` : `${c} is empty`), t.loading = !0) : (r(), t.loading = !1);
+			}), du(t), g.resetCount += 1), u ? (n(p.length ? `Loading ${c}...` : `${c} is empty`), t.loading = !0) : (r(), t.loading = !1);
 		}
 		try {
-			let e = jc(f, "mtime_desc"), n = p.sort((t, n) => Al(t, n, e));
+			let e = Nc(f, "mtime_desc"), n = p.sort((t, n) => Ml(t, n, e));
 			return l && h && (o({
 				query: String(c || "Collection"),
 				total: p.length,
 				done: !0
-			}), lu(t), g.resetCount += 1), ie(f, n), de({
+			}), du(t), g.resetCount += 1), ie(f, n), fe({
 				offset: n.length,
 				cursor: null,
 				total: n.length,
 				done: !0
-			}), me({ title: c }), O(w(String(c || "Collection"))), {
+			}), he({ title: c }), O(w(String(c || "Collection"))), {
 				ok: !0,
 				count: n.length,
 				total: n.length
 			};
 		} catch (e) {
-			return i(au("Failed to load collection", e), { error: !0 }), {
+			return i(su("Failed to load collection", e), { error: !0 }), {
 				ok: !1,
 				error: e?.message || String(e)
 			};
 		} finally {
 			if (u) try {
 				let e = Date.now() - m;
-				e < Ql && await $l(Ql - e);
+				e < eu && await tu(eu - e);
 			} catch (e) {
 				console.debug?.(e);
 			}
 			t.loading = !1, u && r();
 		}
 	}
-	function be() {
+	function xe() {
 		v("reload", { reloadReason: "scopeSwitch" });
 		try {
-			ro(y());
+			io(y());
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -6618,19 +6660,19 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		} catch (e) {
 			console.debug?.(e);
 		}
-		t.abortController = null, t.requestId = (Number(t.requestId) || 0) + 1, t.loading = !0, de({
+		t.abortController = null, t.requestId = (Number(t.requestId) || 0) + 1, t.loading = !0, fe({
 			offset: 0,
 			cursor: null,
 			total: null,
 			done: !1
 		}), N(), re(), r(), a(), p = !0, s([], "");
 	}
-	function xe() {
+	function Se() {
 		t.virtualGrid?.setItems?.(t.assets || []);
 	}
-	function Se(e, { updateSelection: n = !0 } = {}) {
-		let r = Cl(t, e, { assetKey: (e) => ne(e, y()) });
-		return r ? (Number.isFinite(Number(t.total)) && de({ total: Math.max(0, Number(t.total || 0) - r) }), n && c(t.assets.map((e) => String(e?.id || "")).filter(Boolean), { activeId: t.activeId }), !t.assets.length && !t.loading && i("No assets found"), {
+	function Ce(e, { updateSelection: n = !0 } = {}) {
+		let r = Tl(t, e, { assetKey: (e) => te(e, y()) });
+		return r ? (Number.isFinite(Number(t.total)) && fe({ total: Math.max(0, Number(t.total || 0) - r) }), n && c(t.assets.map((e) => String(e?.id || "")).filter(Boolean), { activeId: t.activeId }), !t.assets.length && !t.loading && i("No assets found"), {
 			ok: !0,
 			removed: r,
 			selectedIds: t.selectedIds.slice()
@@ -6640,7 +6682,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			selectedIds: t.selectedIds.slice()
 		};
 	}
-	function Ce() {
+	function we() {
 		let e = y(), t = l();
 		if (!e || !t) return null;
 		let n = (e) => {
@@ -6651,7 +6693,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			} catch {
 				return !1;
 			}
-		}, r = Gl(e), i = u(), a = i.find((e) => n(e)) || i[0] || null, o = n(r) ? r : a;
+		}, r = ql(e), i = u(), a = i.find((e) => n(e)) || i[0] || null, o = n(r) ? r : a;
 		if (!o) return null;
 		try {
 			let e = o.getBoundingClientRect(), n = t.getBoundingClientRect();
@@ -6664,17 +6706,17 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			return console.debug?.(e), null;
 		}
 	}
-	async function Te(e) {
+	async function Ee(e) {
 		let t = y(), n = l();
 		if (!t || !n || !e) return;
-		await iu();
+		await ou();
 		let r = String(e.id || "").trim();
 		if (!r) {
 			n.scrollTop = Number(e.scrollTop || 0) || 0, g.scrollRestoreCount += 1;
 			return;
 		}
-		d(r, { align: "start" }), await iu();
-		let i = Kl(t, r);
+		d(r, { align: "start" }), await ou();
+		let i = Jl(t, r);
 		if (!i) {
 			n.scrollTop = Number(e.scrollTop || 0) || 0, g.scrollRestoreCount += 1;
 			return;
@@ -6686,10 +6728,10 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			console.debug?.(t), n.scrollTop = Number(e.scrollTop || 0) || 0, g.scrollRestoreCount += 1;
 		}
 	}
-	async function Ee(e = {}, n = {}) {
+	async function De(e = {}, n = {}) {
 		let i = y();
-		if (!i || !P()) return !1;
-		let s = sl(e), c = _l(s);
+		if (!i || !ne()) return !1;
+		let s = ll(e), c = yl(s);
 		if (!c || !Array.isArray(c.assets) || !c.assets.length || !n.allowReplaceExisting && Array.isArray(t.assets) && t.assets.length) return !1;
 		g.lastResetReason = "snapshot";
 		try {
@@ -6706,7 +6748,7 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 			query: c.query || n.title || "Cached",
 			total: Number(c.total ?? c.assets.length) || c.assets.length,
 			done: !!c.done
-		}), lu(t), g.resetCount += 1, a(), r(), t.loading = !1, ie(i, c.assets), de({
+		}), du(t), g.resetCount += 1, a(), r(), t.loading = !1, ie(i, c.assets), fe({
 			offset: Math.max(Number(c.assets.length || 0) || 0, Number(c.offset || c.assets.length) || c.assets.length),
 			cursor: c.cursor || null,
 			total: Number(c.total ?? c.assets.length) || c.assets.length,
@@ -6714,40 +6756,40 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		}), t._mjrLastHydrateKey = s, t._mjrLastHydrateAt = Date.now(), O({
 			...e,
 			query: c.query || e.query || "*"
-		}), p = !1, me({ title: c.title || n.title || "Cached" }), !0;
+		}), p = !1, he({ title: c.title || n.title || "Cached" }), !0;
 	}
-	function De(e) {
+	function Oe(e) {
 		return {
 			getOrCreateState: () => t,
 			ensureVirtualGrid: () => t.virtualGrid,
-			upsertState: Xl,
-			maxBatchSize: Yl,
-			debounceMs: Jl,
-			assetKey: (t) => eu(t) || ne(t, e),
+			upsertState: Ql,
+			maxBatchSize: Zl,
+			debounceMs: Xl,
+			assetKey: (t) => nu(t) || te(t, e),
 			loadMajoorSettings: mn
 		};
 	}
-	function Oe(e) {
+	function ke(e) {
 		v("upsertRealtime", { appendReason: "realtime" });
 		let t = y();
-		return !t || !e || !e.id ? !1 : Hl(t, e, De(t));
+		return !t || !e || !e.id ? !1 : Wl(t, e, Oe(t));
 	}
-	let ke = !1;
-	function Ae(e) {
+	let Ae = !1;
+	function je(e) {
 		v("upsertRealtime", { appendReason: "realtimeImmediate" });
 		let t = y();
 		if (!t || !e || !e.id) return !1;
-		let n = Hl(t, e, De(t));
-		return n && !ke && (ke = !0, queueMicrotask(() => {
-			ke = !1;
+		let n = Wl(t, e, Oe(t));
+		return n && !Ae && (Ae = !0, queueMicrotask(() => {
+			Ae = !1;
 			let e = y();
-			e && Vl(e, De(e));
+			e && Ul(e, Oe(e));
 		})), n;
 	}
-	function je() {
+	function Me() {
 		F(t.query || "Cached");
 		try {
-			gl();
+			vl();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -6759,85 +6801,106 @@ function uu({ gridContainerRef: e, state: t, setLoadingMessage: n, clearLoadingM
 		}
 		let e = y();
 		if (e) try {
-			let t = Nl(e, Xl);
+			let t = Fl(e, Ql);
 			t?.timer && (clearTimeout(t.timer), t.timer = null), t?.pending?.clear?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}
 	try {
-		window.addEventListener("pagehide", je, { once: !0 });
+		window.addEventListener("pagehide", Me, { once: !0 });
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return {
-		reload: ve,
-		appendNextPage: he,
-		refreshHead: _e,
-		upsertRealtime: Ae,
-		loadAssets: ve,
-		loadAssetsFromList: ye,
-		loadNextPage: he,
-		prepareGridForScopeSwitch: be,
-		refreshGrid: xe,
-		removeAssets: Se,
-		captureAnchor: Ce,
-		restoreAnchor: Te,
-		hydrateFromSnapshot: Ee,
-		upsertAsset: Oe,
-		upsertAssetNow: Ae,
+		reload: ye,
+		appendNextPage: ge,
+		refreshHead: ve,
+		upsertRealtime: je,
+		loadAssets: ye,
+		loadAssetsFromList: be,
+		loadNextPage: ge,
+		prepareGridForScopeSwitch: xe,
+		refreshGrid: Se,
+		removeAssets: Ce,
+		captureAnchor: we,
+		restoreAnchor: Ee,
+		hydrateFromSnapshot: De,
+		upsertAsset: ke,
+		upsertAssetNow: je,
 		getCanonicalState: x,
 		getDebugSnapshot: S,
-		dispose: je
+		dispose: Me
 	};
 }
 //#endregion
+//#region node_modules/@tanstack/virtual-core/dist/esm/lazy-measurements.js
+function pu(e, t, n) {
+	let r = Array(e);
+	return new Proxy(r, { get(r, i, a) {
+		if (typeof i == "string") {
+			let a = i.charCodeAt(0);
+			if (a >= 48 && a <= 57) {
+				let a = +i;
+				if (Number.isInteger(a) && a >= 0 && a < e) {
+					let e = r[a];
+					if (!e) {
+						let i = t[a * 2];
+						e = r[a] = {
+							index: a,
+							key: n(a),
+							start: i,
+							size: t[a * 2 + 1],
+							end: i + t[a * 2 + 1],
+							lane: 0
+						};
+					}
+					return e;
+				}
+			}
+			if (i === "length") return e;
+		}
+		return Reflect.get(r, i, a);
+	} });
+}
+//#endregion
 //#region node_modules/@tanstack/virtual-core/dist/esm/utils.js
-function du(e, t, n) {
+function mu(e, t, n) {
 	let r = n.initialDeps ?? [], i, a = !0;
 	function o() {
-		let o;
-		n.key && n.debug?.call(n) && (o = Date.now());
-		let s = e();
-		if (!(s.length !== r.length || s.some((e, t) => r[t] !== e))) return i;
-		r = s;
-		let c;
-		if (n.key && n.debug?.call(n) && (c = Date.now()), i = t(...s), n.key && n.debug?.call(n)) {
-			let e = Math.round((Date.now() - o) * 100) / 100, t = Math.round((Date.now() - c) * 100) / 100, r = t / 16, i = (e, t) => {
-				for (e = String(e); e.length < t;) e = " " + e;
-				return e;
-			};
-			console.info(`%c⏱ ${i(t, 5)} /${i(e, 5)} ms`, `
-            font-size: .6rem;
-            font-weight: bold;
-            color: hsl(${Math.max(0, Math.min(120 - 120 * r, 120))}deg 100% 31%);`, n?.key);
-		}
-		return n?.onChange && !(a && n.skipInitialOnChange) && n.onChange(i), a = !1, i;
+		let o = e();
+		return o.length !== r.length || o.some((e, t) => r[t] !== e) ? (r = o, i = t(...o), n?.onChange && !(a && n.skipInitialOnChange) && n.onChange(i), a = !1, i) : i;
 	}
 	return o.updateDeps = (e) => {
 		r = e;
 	}, o;
 }
-function fu(e, t) {
+function hu(e, t) {
 	if (e === void 0) throw Error(`Unexpected undefined${t ? `: ${t}` : ""}`);
 	return e;
 }
-var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
+var gu = (e, t) => Math.abs(e - t) < 1.01, _u = (e, t, n) => {
 	let r;
 	return function(...i) {
 		e.clearTimeout(r), r = e.setTimeout(() => t.apply(this, i), n);
 	};
-}, hu = (e) => {
+}, vu, yu = () => {
+	if (vu !== void 0) return vu;
+	if (typeof navigator > "u") return vu = !1;
+	if (/iP(hone|od|ad)/.test(navigator.userAgent)) return vu = !0;
+	let e = navigator.maxTouchPoints;
+	return vu = navigator.platform === "MacIntel" && e !== void 0 && e > 0;
+}, bu = (e) => {
 	let { offsetWidth: t, offsetHeight: n } = e;
 	return {
 		width: t,
 		height: n
 	};
-}, gu = (e) => e, _u = (e) => {
-	let t = Math.max(e.startIndex - e.overscan, 0), n = Math.min(e.endIndex + e.overscan, e.count - 1), r = [];
-	for (let e = t; e <= n; e++) r.push(e);
+}, xu = (e) => e, Su = (e) => {
+	let t = Math.max(e.startIndex - e.overscan, 0), n = Math.min(e.endIndex + e.overscan, e.count - 1) - t + 1, r = Array(n);
+	for (let e = 0; e < n; e++) r[e] = t + e;
 	return r;
-}, vu = (e, t) => {
+}, Cu = (e, t) => {
 	let n = e.scrollElement;
 	if (!n) return;
 	let r = e.targetWindow;
@@ -6849,7 +6912,7 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			height: Math.round(r)
 		});
 	};
-	if (i(hu(n)), !r.ResizeObserver) return () => {};
+	if (i(bu(n)), !r.ResizeObserver) return () => {};
 	let a = new r.ResizeObserver((t) => {
 		let r = () => {
 			let e = t[0];
@@ -6863,45 +6926,50 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 					return;
 				}
 			}
-			i(hu(n));
+			i(bu(n));
 		};
 		e.options.useAnimationFrameWithResizeObserver ? requestAnimationFrame(r) : r();
 	});
 	return a.observe(n, { box: "border-box" }), () => {
 		a.unobserve(n);
 	};
-}, yu = { passive: !0 }, bu = typeof window > "u" ? !0 : "onscrollend" in window, xu = (e, t) => {
-	let n = e.scrollElement;
-	if (!n) return;
-	let r = e.targetWindow;
+}, wu = { passive: !0 }, Tu = typeof window > "u" ? !0 : "onscrollend" in window, Eu = (e, t, n) => {
+	let r = e.scrollElement;
 	if (!r) return;
-	let i = 0, a = e.options.useScrollendEvent && bu ? () => void 0 : mu(r, () => {
-		t(i, !1);
-	}, e.options.isScrollingResetDelay), o = (r) => () => {
-		let { horizontal: o, isRtl: s } = e.options;
-		i = o ? n.scrollLeft * (s && -1 || 1) : n.scrollTop, a(), t(i, r);
-	}, s = o(!0), c = o(!1);
-	n.addEventListener("scroll", s, yu);
-	let l = e.options.useScrollendEvent && bu;
-	return l && n.addEventListener("scrollend", c, yu), () => {
-		n.removeEventListener("scroll", s), l && n.removeEventListener("scrollend", c);
+	let i = e.targetWindow;
+	if (!i) return;
+	let a = e.options.useScrollendEvent && Tu, o = 0, s = a ? null : _u(i, () => t(o, !1), e.options.isScrollingResetDelay), c = (e) => () => {
+		o = n(r), s?.(), t(o, e);
+	}, l = c(!0), u = c(!1);
+	return r.addEventListener("scroll", l, wu), a && r.addEventListener("scrollend", u, wu), () => {
+		r.removeEventListener("scroll", l), a && r.removeEventListener("scrollend", u);
 	};
-}, Su = (e, t, n) => {
+}, Du = (e, t) => Eu(e, t, (t) => {
+	let { horizontal: n, isRtl: r } = e.options;
+	return n ? t.scrollLeft * (r && -1 || 1) : t.scrollTop;
+}), Ou = (e, t, n) => {
+	if (n.options.useCachedMeasurements) {
+		let t = n.indexFromElement(e), r = n.options.getItemKey(t);
+		return n.itemSizeCache.get(r) ?? n.options.estimateSize(t);
+	}
 	if (t?.borderBoxSize) {
 		let e = t.borderBoxSize[0];
 		if (e) return Math.round(e[n.options.horizontal ? "inlineSize" : "blockSize"]);
 	}
+	if (!t) {
+		let t = n.indexFromElement(e), r = n.options.getItemKey(t), i = n.itemSizeCache.get(r);
+		if (i !== void 0) return i;
+	}
 	return e[n.options.horizontal ? "offsetWidth" : "offsetHeight"];
-}, Cu = (e, { adjustments: t = 0, behavior: n }, r) => {
+}, ku = (e, { adjustments: t = 0, behavior: n }, r) => {
 	var i, a;
-	let o = e + t;
 	(a = (i = r.scrollElement)?.scrollTo) == null || a.call(i, {
-		[r.options.horizontal ? "left" : "top"]: o,
+		[r.options.horizontal ? "left" : "top"]: e + t,
 		behavior: n
 	});
-}, wu = class {
+}, Au = class {
 	constructor(e) {
-		this.unsubs = [], this.scrollElement = null, this.targetWindow = null, this.isScrolling = !1, this.scrollState = null, this.measurementsCache = [], this.itemSizeCache = /* @__PURE__ */ new Map(), this.laneAssignments = /* @__PURE__ */ new Map(), this.pendingMeasuredCacheIndexes = [], this.prevLanes = void 0, this.lanesChangedFlag = !1, this.lanesSettling = !1, this.scrollRect = null, this.scrollOffset = null, this.scrollDirection = null, this.scrollAdjustments = 0, this.elementsCache = /* @__PURE__ */ new Map(), this.now = () => {
+		this.unsubs = [], this.scrollElement = null, this.targetWindow = null, this.isScrolling = !1, this.scrollState = null, this.measurementsCache = [], this._flatMeasurements = null, this.itemSizeCache = /* @__PURE__ */ new Map(), this.itemSizeCacheVersion = 0, this.laneAssignments = /* @__PURE__ */ new Map(), this.pendingMin = null, this.prevLanes = void 0, this.lanesChangedFlag = !1, this.lanesSettling = !1, this.pendingScrollAnchor = null, this.scrollRect = null, this.scrollOffset = null, this.scrollDirection = null, this.scrollAdjustments = 0, this._iosDeferredAdjustment = 0, this._iosTouching = !1, this._iosJustTouchEnded = !1, this._iosTouchEndTimerId = null, this._intendedScrollOffset = null, this.elementsCache = /* @__PURE__ */ new Map(), this.now = () => {
 			var e;
 			return ((e = this.targetWindow?.performance)?.now)?.call(e) ?? Date.now();
 		}, this.observer = /* @__PURE__ */ (() => {
@@ -6911,6 +6979,10 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 						let t = e.target, n = this.indexFromElement(t);
 						if (!t.isConnected) {
 							this.observer.unobserve(t);
+							for (let [e, n] of this.elementsCache) if (n === t) {
+								this.elementsCache.delete(e);
+								break;
+							}
 							return;
 						}
 						this.shouldMeasureDuringScroll(n) && this.resizeItem(n, this.options.measureElement(t, e, this));
@@ -6927,9 +6999,7 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				unobserve: (e) => t()?.unobserve(e)
 			};
 		})(), this.range = null, this.setOptions = (e) => {
-			Object.entries(e).forEach(([t, n]) => {
-				n === void 0 && delete e[t];
-			}), this.options = {
+			let t = {
 				debug: !1,
 				initialOffset: 0,
 				overscan: 1,
@@ -6938,10 +7008,10 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				scrollPaddingStart: 0,
 				scrollPaddingEnd: 0,
 				horizontal: !1,
-				getItemKey: gu,
-				rangeExtractor: _u,
+				getItemKey: xu,
+				rangeExtractor: Su,
 				onChange: () => {},
-				measureElement: Su,
+				measureElement: Ou,
 				initialRect: {
 					width: 0,
 					height: 0
@@ -6951,18 +7021,55 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				indexAttribute: "data-index",
 				initialMeasurementsCache: [],
 				lanes: 1,
+				anchorTo: "start",
+				followOnAppend: !1,
+				scrollEndThreshold: 1,
 				isScrollingResetDelay: 150,
 				enabled: !0,
 				isRtl: !1,
 				useScrollendEvent: !1,
 				useAnimationFrameWithResizeObserver: !1,
 				laneAssignmentMode: "estimate",
-				...e
+				useCachedMeasurements: !1
 			};
+			for (let n in e) {
+				let r = e[n];
+				r !== void 0 && (t[n] = r);
+			}
+			let n = this.options, r = null, i = null, a = !1;
+			if (n !== void 0 && n.enabled && t.enabled && t.anchorTo === "end" && this.scrollElement !== null) {
+				let e = n.count, o = t.count, s = this.getMeasurements(), c = e > 0 ? s[0]?.key ?? n.getItemKey(0) : null, l = e > 0 ? s[e - 1]?.key ?? n.getItemKey(e - 1) : null;
+				if (o !== e || e > 0 && o > 0 && (t.getItemKey(0) !== c || t.getItemKey(o - 1) !== l)) {
+					a = !0;
+					let c = e > 0 ? this.getVirtualItemForOffset(this.getScrollOffset()) ?? s[0] : null;
+					c && (r = [c.key, this.getScrollOffset() - c.start]);
+					let u = t.followOnAppend === !0 ? "auto" : t.followOnAppend || null;
+					u && o > e && this.isAtEnd(n.scrollEndThreshold) && (e === 0 || t.getItemKey(o - 1) !== l) && (i = u);
+				}
+			}
+			this.options = t, a && (this.pendingMin = 0, this.itemSizeCacheVersion++);
+			let o = !1, s = 0;
+			if (r && this.scrollOffset !== null) {
+				let [e, t] = r, n = this.getMeasurements(), { count: i, getItemKey: a } = this.options, c = 0;
+				for (; c < i && a(c) !== e;) c++;
+				if (c < i) {
+					let e = n[c];
+					if (e) {
+						let n = e.start + t;
+						n !== this.scrollOffset && (s = n - this.scrollOffset, this.scrollOffset = n, o = !0);
+					}
+				}
+			}
+			(o || i) && (this.pendingScrollAnchor = [
+				o ? r[0] : null,
+				o ? r[1] : 0,
+				i,
+				s
+			]);
 		}, this.notify = (e) => {
 			var t, n;
 			(n = (t = this.options).onChange) == null || n.call(t, this, e);
-		}, this.maybeNotify = du(() => (this.calculateRange(), [
+		}, this.maybeNotify = mu(() => (this.calculateRange(), [
 			this.isScrolling,
 			this.range ? this.range.startIndex : null,
 			this.range ? this.range.endIndex : null
@@ -6987,17 +7094,49 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 					this.maybeNotify();
 					return;
 				}
-				this.scrollElement = e, this.scrollElement && "ownerDocument" in this.scrollElement ? this.targetWindow = this.scrollElement.ownerDocument.defaultView : this.targetWindow = this.scrollElement?.window ?? null, this.elementsCache.forEach((e) => {
+				if (this.scrollElement = e, this.scrollElement && "ownerDocument" in this.scrollElement ? this.targetWindow = this.scrollElement.ownerDocument.defaultView : this.targetWindow = this.scrollElement?.window ?? null, this.elementsCache.forEach((e) => {
 					this.observer.observe(e);
 				}), this.unsubs.push(this.options.observeElementRect(this, (e) => {
 					this.scrollRect = e, this.maybeNotify();
 				})), this.unsubs.push(this.options.observeElementOffset(this, (e, t) => {
-					this.scrollAdjustments = 0, this.scrollDirection = t ? this.getScrollOffset() < e ? "forward" : "backward" : null, this.scrollOffset = e, this.isScrolling = t, this.scrollState && this.scheduleScrollReconcile(), this.maybeNotify();
-				})), this._scrollToOffset(this.getScrollOffset(), {
+					if (t && this._intendedScrollOffset === null && e === this.scrollOffset) return;
+					this._intendedScrollOffset !== null && Math.abs(e - this._intendedScrollOffset) < 1.5 && (e = this._intendedScrollOffset), this._intendedScrollOffset = null, this.scrollAdjustments = 0;
+					let n = this.getScrollOffset();
+					this.scrollDirection = t ? n === e ? this.scrollDirection : n < e ? "forward" : "backward" : null, this.scrollOffset = e, this.isScrolling = t, this._flushIosDeferredIfReady(), this.scrollState && this.scheduleScrollReconcile(), this.maybeNotify();
+				})), "addEventListener" in this.scrollElement) {
+					let e = this.scrollElement, t = () => {
+						this._iosTouching = !0, this._iosJustTouchEnded = !1, this._iosTouchEndTimerId !== null && this.targetWindow != null && (this.targetWindow.clearTimeout(this._iosTouchEndTimerId), this._iosTouchEndTimerId = null);
+					}, n = () => {
+						this._iosTouching = !1, !(!yu() || this.targetWindow == null) && (this._iosJustTouchEnded = !0, this._iosTouchEndTimerId = this.targetWindow.setTimeout(() => {
+							this._iosJustTouchEnded = !1, this._iosTouchEndTimerId = null, this._flushIosDeferredIfReady();
+						}, 150));
+					};
+					e.addEventListener("touchstart", t, wu), e.addEventListener("touchend", n, wu), this.unsubs.push(() => {
+						e.removeEventListener("touchstart", t), e.removeEventListener("touchend", n), this._iosTouchEndTimerId !== null && this.targetWindow != null && (this.targetWindow.clearTimeout(this._iosTouchEndTimerId), this._iosTouchEndTimerId = null);
+					});
+				}
+				this._scrollToOffset(this.getScrollOffset(), {
 					adjustments: void 0,
 					behavior: void 0
 				});
 			}
+			let t = this.pendingScrollAnchor;
+			if (this.pendingScrollAnchor = null, t && this.scrollElement && this.options.enabled) {
+				let [e, n, r, i] = t;
+				e !== null && !r && (yu() && (this.isScrolling || this._iosTouching || this._iosJustTouchEnded) ? i !== 0 && (this._iosDeferredAdjustment += i) : this._scrollToOffset(this.getScrollOffset(), {
+					adjustments: void 0,
+					behavior: void 0
+				})), r && this.scrollToEnd({ behavior: r });
+			}
+		}, this._flushIosDeferredIfReady = () => {
+			if (this._iosDeferredAdjustment === 0 || this.isScrolling || this._iosTouching || this._iosJustTouchEnded) return;
+			let e = this.getScrollOffset(), t = this.getMaxScrollOffset();
+			if (e < 0 || e > t) return;
+			let n = this._iosDeferredAdjustment;
+			this._iosDeferredAdjustment = 0, this._scrollToOffset(e, {
+				adjustments: this.scrollAdjustments += n,
+				behavior: void 0
+			});
 		}, this.rafId = null, this.getSize = () => this.options.enabled ? (this.scrollRect = this.scrollRect ?? this.options.initialRect, this.scrollRect[this.options.horizontal ? "width" : "height"]) : (this.scrollRect = null, 0), this.getScrollOffset = () => this.options.enabled ? (this.scrollOffset = this.scrollOffset ?? (typeof this.options.initialOffset == "function" ? this.options.initialOffset() : this.options.initialOffset), this.scrollOffset) : (this.scrollOffset = null, 0), this.getFurthestMeasurement = (e, t) => {
 			let n = /* @__PURE__ */ new Map(), r = /* @__PURE__ */ new Map();
 			for (let i = t - 1; i >= 0; i--) {
@@ -7007,7 +7146,7 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				if (a == null || t.end > a.end ? r.set(t.lane, t) : t.end < a.end && n.set(t.lane, !0), n.size === this.options.lanes) break;
 			}
 			return r.size === this.options.lanes ? Array.from(r.values()).sort((e, t) => e.end === t.end ? e.index - t.index : e.end - t.end)[0] : void 0;
-		}, this.getMeasurementOptions = du(() => [
+		}, this.getMeasurementOptions = mu(() => [
 			this.options.count,
 			this.options.paddingStart,
 			this.options.scrollMargin,
@@ -7015,7 +7154,7 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			this.options.enabled,
 			this.options.lanes,
 			this.options.laneAssignmentMode
-		], (e, t, n, r, i, a, o) => (this.prevLanes !== void 0 && this.prevLanes !== a && (this.lanesChangedFlag = !0), this.prevLanes = a, this.pendingMeasuredCacheIndexes = [], {
+		], (e, t, n, r, i, a, o) => (this.prevLanes !== void 0 && this.prevLanes !== a && (this.lanesChangedFlag = !0), this.prevLanes = a, this.pendingMin = null, {
 			count: e,
 			paddingStart: t,
 			scrollMargin: n,
@@ -7023,57 +7162,71 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			enabled: i,
 			lanes: a,
 			laneAssignmentMode: o
-		}), { key: !1 }), this.getMeasurements = du(() => [this.getMeasurementOptions(), this.itemSizeCache], ({ count: e, paddingStart: t, scrollMargin: n, getItemKey: r, enabled: i, lanes: a, laneAssignmentMode: o }, s) => {
+		}), { key: !1 }), this.getMeasurements = mu(() => [this.getMeasurementOptions(), this.itemSizeCacheVersion], ({ count: e, paddingStart: t, scrollMargin: n, getItemKey: r, enabled: i, lanes: a, laneAssignmentMode: o }, s) => {
+			let c = this.itemSizeCache;
 			if (!i) return this.measurementsCache = [], this.itemSizeCache.clear(), this.laneAssignments.clear(), [];
 			if (this.laneAssignments.size > e) for (let t of this.laneAssignments.keys()) t >= e && this.laneAssignments.delete(t);
-			this.lanesChangedFlag && (this.lanesChangedFlag = !1, this.lanesSettling = !0, this.measurementsCache = [], this.itemSizeCache.clear(), this.laneAssignments.clear(), this.pendingMeasuredCacheIndexes = []), this.measurementsCache.length === 0 && !this.lanesSettling && (this.measurementsCache = this.options.initialMeasurementsCache, this.measurementsCache.forEach((e) => {
+			this.lanesChangedFlag && (this.lanesChangedFlag = !1, this.lanesSettling = !0, this.measurementsCache = [], this.itemSizeCache.clear(), this.laneAssignments.clear(), this.pendingMin = null), this.measurementsCache.length === 0 && !this.lanesSettling && (this.measurementsCache = this.options.initialMeasurementsCache, this.measurementsCache.forEach((e) => {
 				this.itemSizeCache.set(e.key, e.size);
 			}));
-			let c = this.lanesSettling ? 0 : this.pendingMeasuredCacheIndexes.length > 0 ? Math.min(...this.pendingMeasuredCacheIndexes) : 0;
-			this.pendingMeasuredCacheIndexes = [], this.lanesSettling && this.measurementsCache.length === e && (this.lanesSettling = !1);
-			let l = this.measurementsCache.slice(0, c), u = Array(a).fill(void 0);
-			for (let e = 0; e < c; e++) {
-				let t = l[e];
-				t && (u[t.lane] = e);
-			}
-			for (let i = c; i < e; i++) {
-				let e = r(i), a = this.laneAssignments.get(i), c, d, f = o === "estimate" || s.has(e);
-				if (a !== void 0 && this.options.lanes > 1) {
-					c = a;
-					let e = u[c], r = e === void 0 ? void 0 : l[e];
-					d = r ? r.end + this.options.gap : t + n;
-				} else {
-					let e = this.options.lanes === 1 ? l[i - 1] : this.getFurthestMeasurement(l, i);
-					d = e ? e.end + this.options.gap : t + n, c = e ? e.lane : i % this.options.lanes, this.options.lanes > 1 && f && this.laneAssignments.set(i, c);
+			let l = this.lanesSettling ? 0 : this.pendingMin ?? 0;
+			if (this.pendingMin = null, this.lanesSettling && this.measurementsCache.length === e && (this.lanesSettling = !1), a === 1) {
+				let i = this.options.gap, a = e * 2, o = this._flatMeasurements;
+				if (!o || o.length < a) {
+					let e = new Float64Array(a);
+					o && l > 0 && e.set(o.subarray(0, l * 2)), o = e, this._flatMeasurements = o;
 				}
-				let p = s.get(e), m = typeof p == "number" ? p : this.options.estimateSize(i), h = d + m;
-				l[i] = {
+				let s;
+				if (l === 0) s = t + n;
+				else {
+					let e = l - 1;
+					s = o[e * 2] + o[e * 2 + 1] + i;
+				}
+				for (let t = l; t < e; t++) {
+					let e = r(t), n = c.get(e), a = typeof n == "number" ? n : this.options.estimateSize(t);
+					o[t * 2] = s, o[t * 2 + 1] = a, s += a + i;
+				}
+				let u = pu(e, o, r);
+				return this.measurementsCache = u, u;
+			}
+			let u = this.measurementsCache.slice(0, l), d = Array(a).fill(void 0);
+			for (let e = 0; e < l; e++) {
+				let t = u[e];
+				t && (d[t.lane] = e);
+			}
+			for (let i = l; i < e; i++) {
+				let e = r(i), a = this.laneAssignments.get(i), s, l, f = o === "estimate" || c.has(e);
+				if (a !== void 0 && this.options.lanes > 1) {
+					s = a;
+					let e = d[s], r = e === void 0 ? void 0 : u[e];
+					l = r ? r.end + this.options.gap : t + n;
+				} else {
+					let e = this.options.lanes === 1 ? u[i - 1] : this.getFurthestMeasurement(u, i);
+					l = e ? e.end + this.options.gap : t + n, s = e ? e.lane : i % this.options.lanes, this.options.lanes > 1 && f && this.laneAssignments.set(i, s);
+				}
+				let p = c.get(e), m = typeof p == "number" ? p : this.options.estimateSize(i), h = l + m;
+				u[i] = {
 					index: i,
-					start: d,
+					start: l,
 					size: m,
 					end: h,
 					key: e,
-					lane: c
-				}, u[c] = i;
+					lane: s
+				}, d[s] = i;
 			}
-			return this.measurementsCache = l, l;
+			return this.measurementsCache = u, u;
 		}, {
 			key: !1,
 			debug: () => this.options.debug
-		}), this.calculateRange = du(() => [
+		}), this.calculateRange = mu(() => [
 			this.getMeasurements(),
 			this.getSize(),
 			this.getScrollOffset(),
 			this.options.lanes
-		], (e, t, n, r) => this.range = e.length > 0 && t > 0 ? Eu({
-			measurements: e,
-			outerSize: t,
-			scrollOffset: n,
-			lanes: r
-		}) : null, {
+		], (e, t, n, r) => e.length === 0 || t === 0 ? (this.range = null, null) : (this.range = Nu(e, t, n, r, r === 1 && this._flatMeasurements != null ? this._flatMeasurements : null), this.range), {
 			key: !1,
 			debug: () => this.options.debug
-		}), this.getVirtualIndexes = du(() => {
+		}), this.getVirtualIndexes = mu(() => {
 			let e = null, t = null, n = this.calculateRange();
 			return n && (e = n.startIndex, t = n.endIndex), this.maybeNotify.updateDeps([
 				this.isScrolling,
@@ -7115,14 +7268,27 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			let t = this.indexFromElement(e), n = this.options.getItemKey(t), r = this.elementsCache.get(n);
 			r !== e && (r && this.observer.unobserve(r), this.observer.observe(e), this.elementsCache.set(n, e)), (!this.isScrolling || this.scrollState) && this.shouldMeasureDuringScroll(t) && this.resizeItem(t, this.options.measureElement(e, void 0, this));
 		}, this.resizeItem = (e, t) => {
-			let n = this.measurementsCache[e];
-			if (!n) return;
-			let r = t - (this.itemSizeCache.get(n.key) ?? n.size);
-			r !== 0 && (this.scrollState?.behavior !== "smooth" && (this.shouldAdjustScrollPositionOnItemSizeChange === void 0 ? n.start < this.getScrollOffset() + this.scrollAdjustments : this.shouldAdjustScrollPositionOnItemSizeChange(n, r, this)) && this._scrollToOffset(this.getScrollOffset(), {
-				adjustments: this.scrollAdjustments += r,
-				behavior: void 0
-			}), this.pendingMeasuredCacheIndexes.push(n.index), this.itemSizeCache = new Map(this.itemSizeCache.set(n.key, t)), this.notify(!1));
-		}, this.getVirtualItems = du(() => [this.getVirtualIndexes(), this.getMeasurements()], (e, t) => {
+			if (e < 0 || e >= this.options.count) return;
+			let n, r, i, a = this._flatMeasurements;
+			if (this.options.lanes === 1 && a !== null) i = this.options.getItemKey(e), r = a[e * 2], n = a[e * 2 + 1];
+			else {
+				let t = this.measurementsCache[e];
+				if (!t) return;
+				i = t.key, r = t.start, n = t.size;
+			}
+			let o = t - (this.itemSizeCache.get(i) ?? n);
+			if (o !== 0) {
+				let a = this.options.anchorTo === "end" && this.scrollState?.behavior !== "smooth" && this.getVirtualDistanceFromEnd() <= this.options.scrollEndThreshold, s = a ? this.getTotalSize() : 0, c = this.scrollState?.behavior !== "smooth" && (this.shouldAdjustScrollPositionOnItemSizeChange === void 0 ? r < this.getScrollOffset() + this.scrollAdjustments && (!this.itemSizeCache.has(i) || this.scrollDirection !== "backward") : this.shouldAdjustScrollPositionOnItemSizeChange(this.measurementsCache[e] ?? {
+					index: e,
+					key: i,
+					start: r,
+					size: n,
+					end: r + n,
+					lane: 0
+				}, o, this));
+				(this.pendingMin === null || e < this.pendingMin) && (this.pendingMin = e), this.itemSizeCache.set(i, t), this.itemSizeCacheVersion++, a ? this.applyScrollAdjustment(this.getTotalSize() - s) : c && this.applyScrollAdjustment(o), this.notify(!1);
+			}
+		}, this.getVirtualItems = mu(() => [this.getVirtualIndexes(), this.getMeasurements()], (e, t) => {
 			let n = [];
 			for (let r = 0, i = e.length; r < i; r++) {
 				let i = t[e[r]];
@@ -7134,7 +7300,9 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			debug: () => this.options.debug
 		}), this.getVirtualItemForOffset = (e) => {
 			let t = this.getMeasurements();
-			if (t.length !== 0) return fu(t[Tu(0, t.length - 1, (e) => fu(t[e]).start, e)]);
+			if (t.length === 0) return;
+			let n = this._flatMeasurements, r = this.options.lanes === 1 && n != null;
+			return hu(t[ju(0, t.length - 1, r ? (e) => n[e * 2] : (e) => hu(t[e]).start, e)]);
 		}, this.getMaxScrollOffset = () => {
 			if (!this.scrollElement) return 0;
 			if ("scrollHeight" in this.scrollElement) return this.options.horizontal ? this.scrollElement.scrollWidth - this.scrollElement.clientWidth : this.scrollElement.scrollHeight - this.scrollElement.clientHeight;
@@ -7142,7 +7310,7 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				let e = this.scrollElement.document.documentElement;
 				return this.options.horizontal ? e.scrollWidth - this.scrollElement.innerWidth : e.scrollHeight - this.scrollElement.innerHeight;
 			}
-		}, this.getOffsetForAlignment = (e, t, n = 0) => {
+		}, this.getVirtualDistanceFromEnd = () => Math.max(this.getTotalSize() - this.getSize() - this.getScrollOffset(), 0), this.getDistanceFromEnd = () => Math.max(this.getMaxScrollOffset() - this.getScrollOffset(), 0), this.isAtEnd = (e = this.options.scrollEndThreshold) => this.getDistanceFromEnd() <= e, this.getOffsetForAlignment = (e, t, n = 0) => {
 			if (!this.scrollElement) return 0;
 			let r = this.getSize(), i = this.getScrollOffset();
 			t === "auto" && (t = e >= i + r ? "end" : "start"), t === "center" ? e += (n - r) / 2 : t === "end" && (e -= r);
@@ -7200,11 +7368,22 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				adjustments: void 0,
 				behavior: t
 			}), this.scheduleScrollReconcile();
+		}, this.scrollToEnd = ({ behavior: e = "auto" } = {}) => {
+			if (this.options.count > 0) {
+				this.scrollToIndex(this.options.count - 1, {
+					align: "end",
+					behavior: e
+				});
+				return;
+			}
+			this.scrollToOffset(Math.max(this.getTotalSize() - this.getSize(), 0), { behavior: e });
 		}, this.getTotalSize = () => {
 			let e = this.getMeasurements(), t;
 			if (e.length === 0) t = this.options.paddingStart;
-			else if (this.options.lanes === 1) t = e[e.length - 1]?.end ?? 0;
-			else {
+			else if (this.options.lanes === 1) {
+				let n = e.length - 1, r = this._flatMeasurements;
+				t = r == null ? e[n]?.end ?? 0 : r[n * 2] + r[n * 2 + 1];
+			} else {
 				let n = Array(this.options.lanes).fill(null), r = e.length - 1;
 				for (; r >= 0 && n.some((e) => e === null);) {
 					let t = e[r];
@@ -7213,14 +7392,33 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 				t = Math.max(...n.filter((e) => e !== null));
 			}
 			return Math.max(t - this.options.scrollMargin + this.options.paddingEnd, 0);
+		}, this.takeSnapshot = () => {
+			let e = [];
+			if (this.itemSizeCache.size === 0) return e;
+			let t = this.getMeasurements();
+			for (let n of t) n && this.itemSizeCache.has(n.key) && e.push({
+				index: n.index,
+				key: n.key,
+				start: n.start,
+				size: n.size,
+				end: n.end,
+				lane: n.lane
+			});
+			return e;
 		}, this._scrollToOffset = (e, { adjustments: t, behavior: n }) => {
-			this.options.scrollToFn(e, {
+			this._intendedScrollOffset = e + (t ?? 0), this.options.scrollToFn(e, {
 				behavior: n,
 				adjustments: t
 			}, this);
 		}, this.measure = () => {
-			this.itemSizeCache = /* @__PURE__ */ new Map(), this.laneAssignments = /* @__PURE__ */ new Map(), this.notify(!1);
+			this.pendingMin = null, this.itemSizeCache.clear(), this.laneAssignments.clear(), this.itemSizeCacheVersion++, this.notify(!1);
 		}, this.setOptions(e);
+	}
+	applyScrollAdjustment(e, t) {
+		e !== 0 && (yu() && (this.isScrolling || this._iosTouching || this._iosJustTouchEnded) ? this._iosDeferredAdjustment += e : (this._scrollToOffset(this.getScrollOffset(), {
+			adjustments: this.scrollAdjustments += e,
+			behavior: t
+		}), this.scrollOffset !== null && (this.scrollOffset += this.scrollAdjustments, this.scrollAdjustments = 0)));
 	}
 	scheduleScrollReconcile() {
 		if (!this.targetWindow) {
@@ -7238,18 +7436,24 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 			return;
 		}
 		let e = this.scrollState.index == null ? void 0 : this.getOffsetForIndex(this.scrollState.index, this.scrollState.align), t = e ? e[0] : this.scrollState.lastTargetOffset, n = t !== this.scrollState.lastTargetOffset;
-		if (!n && pu(t, this.getScrollOffset())) {
+		if (!n && gu(t, this.getScrollOffset())) {
 			if (this.scrollState.stableFrames++, this.scrollState.stableFrames >= 1) {
-				this.scrollState = null;
+				this.getScrollOffset() !== t && this._scrollToOffset(t, {
+					adjustments: void 0,
+					behavior: "auto"
+				}), this.scrollState = null;
 				return;
 			}
-		} else this.scrollState.stableFrames = 0, n && (this.scrollState.lastTargetOffset = t, this.scrollState.behavior = "auto", this._scrollToOffset(t, {
-			adjustments: void 0,
-			behavior: "auto"
-		}));
+		} else if (this.scrollState.stableFrames = 0, n) {
+			let e = this.getSize() || 600, n = Math.abs(t - this.getScrollOffset()), r = this.scrollState.behavior === "smooth" && n > e;
+			this.scrollState.lastTargetOffset = t, r || (this.scrollState.behavior = "auto"), this._scrollToOffset(t, {
+				adjustments: void 0,
+				behavior: r ? "smooth" : "auto"
+			});
+		}
 		this.scheduleScrollReconcile();
 	}
-}, Tu = (e, t, n, r) => {
+}, ju = (e, t, n, r) => {
 	for (; e <= t;) {
 		let i = (e + t) / 2 | 0, a = n(i);
 		if (a < r) e = i + 1;
@@ -7258,26 +7462,44 @@ var pu = (e, t) => Math.abs(e - t) < 1.01, mu = (e, t, n) => {
 	}
 	return e > 0 ? e - 1 : 0;
 };
-function Eu({ measurements: e, outerSize: t, scrollOffset: n, lanes: r }) {
-	let i = e.length - 1, a = (t) => e[t].start;
+function Mu(e, t, n) {
+	let r = 0;
+	for (; r <= t;) {
+		let i = (r + t) / 2 | 0, a = e[i * 2];
+		if (a < n) r = i + 1;
+		else if (a > n) t = i - 1;
+		else return i;
+	}
+	return r > 0 ? r - 1 : 0;
+}
+function Nu(e, t, n, r, i) {
+	let a = e.length - 1;
 	if (e.length <= r) return {
 		startIndex: 0,
-		endIndex: i
+		endIndex: a
 	};
-	let o = Tu(0, i, a, n), s = o;
-	if (r === 1) for (; s < i && e[s].end < n + t;) s++;
+	if (r === 1 && i !== null) {
+		let e = Mu(i, a, n), r = e, o = n + t;
+		for (; r < a && i[r * 2] + i[r * 2 + 1] < o;) r++;
+		return {
+			startIndex: e,
+			endIndex: r
+		};
+	}
+	let o = ju(0, a, (t) => e[t].start, n), s = o;
+	if (r === 1) for (; s < a && e[s].end < n + t;) s++;
 	else if (r > 1) {
-		let a = Array(r).fill(0);
-		for (; s < i && a.some((e) => e < n + t);) {
+		let i = Array(r).fill(0);
+		for (; s < a && i.some((e) => e < n + t);) {
 			let t = e[s];
-			a[t.lane] = t.end, s++;
+			i[t.lane] = t.end, s++;
 		}
 		let c = Array(r).fill(n + t);
 		for (; o >= 0 && c.some((e) => e >= n);) {
 			let t = e[o];
 			c[t.lane] = t.start, o--;
 		}
-		o = Math.max(0, o - o % r), s = Math.min(i, s + (r - 1 - s % r));
+		o = Math.max(0, o - o % r), s = Math.min(a, s + (r - 1 - s % r));
 	}
 	return {
 		startIndex: o,
@@ -7286,8 +7508,8 @@ function Eu({ measurements: e, outerSize: t, scrollOffset: n, lanes: r }) {
 }
 //#endregion
 //#region node_modules/@tanstack/vue-virtual/dist/esm/index.js
-function Du(e) {
-	let t = new wu(K(e)), n = yr(t), r = t._didMount();
+function Pu(e) {
+	let t = new Au(K(e)), n = yr(t), r = t._didMount();
 	return ir(() => K(e).getScrollElement(), (e) => {
 		e && t._willUpdate();
 	}, { immediate: !0 }), ir(() => K(e), (e) => {
@@ -7300,21 +7522,21 @@ function Du(e) {
 		}), t._willUpdate(), xr(n);
 	}, { immediate: !0 }), vr(r), n;
 }
-function Ou(e) {
-	return Du(G(() => ({
-		observeElementRect: vu,
-		observeElementOffset: xu,
-		scrollToFn: Cu,
+function Fu(e) {
+	return Pu(G(() => ({
+		observeElementRect: Cu,
+		observeElementOffset: Du,
+		scrollToFn: ku,
 		...K(e)
 	})));
 }
 //#endregion
 //#region ui/vue/grid/useGridVirtualRows.ts
-function ku(e, t = 0) {
+function Iu(e, t = 0) {
 	let n = Number(K(e));
 	return Number.isFinite(n) ? n : t;
 }
-function Au(e = [], t = 1) {
+function Lu(e = [], t = 1) {
 	let n = Array.isArray(e) ? e : [], r = Math.max(1, Number(t) || 1), i = [];
 	for (let e = 0; e < n.length; e += r) i.push({
 		index: Math.floor(e / r),
@@ -7322,22 +7544,22 @@ function Au(e = [], t = 1) {
 	});
 	return i;
 }
-function ju(e = [], t = 0, n = 1) {
+function Ru(e = [], t = 0, n = 1) {
 	let r = Array.isArray(e) ? e : [], i = Math.max(1, Number(n) || 1), a = Math.max(0, Number(t) || 0) * i;
 	return r.slice(a, a + i);
 }
-function Mu({ scrollRef: e, items: t, rows: n, columnCount: r, estimateRowHeight: i, overscan: a = 8, enabled: o = !0, measure: s = Su } = {}) {
+function zu({ scrollRef: e, items: t, rows: n, columnCount: r, estimateRowHeight: i, overscan: a = 8, enabled: o = !0, measure: s = Ou } = {}) {
 	let c = G(() => {
 		if (!K(o)) return 0;
 		let e = K(n);
 		if (Array.isArray(e)) return e.length;
-		let i = K(t) || [], a = Math.max(1, ku(r, 1));
+		let i = K(t) || [], a = Math.max(1, Iu(r, 1));
 		return Math.ceil((Array.isArray(i) ? i.length : 0) / a);
-	}), l = Ou(G(() => ({
+	}), l = Fu(G(() => ({
 		count: c.value,
 		getScrollElement: () => K(e) || null,
-		estimateSize: () => Math.max(1, ku(i, 120)),
-		overscan: Math.max(0, ku(a, 8)),
+		estimateSize: () => Math.max(1, Iu(i, 120)),
+		overscan: Math.max(0, Iu(a, 8)),
 		measureElement: s
 	})));
 	return {
@@ -7357,28 +7579,28 @@ function Mu({ scrollRef: e, items: t, rows: n, columnCount: r, estimateRowHeight
 					groupKey: String(n?.groupKey || "")
 				};
 			});
-			let i = K(t) || [], a = Math.max(1, ku(r, 1));
+			let i = K(t) || [], a = Math.max(1, Iu(r, 1));
 			return l.value.getVirtualItems().map((e) => ({
 				key: e.key,
 				index: e.index,
 				virtual: e,
-				items: ju(i, e.index, a),
+				items: Ru(i, e.index, a),
 				kind: "assets",
 				title: "",
 				groupKey: ""
 			}));
 		}),
 		totalSize: G(() => l.value.getTotalSize()),
-		getRowItems: (e) => ju(K(t) || [], e, ku(r, 1))
+		getRowItems: (e) => Ru(K(t) || [], e, Iu(r, 1))
 	};
 }
 //#endregion
 //#region ui/vue/grid/useInfiniteTrigger.ts
-function Nu(e, t = !0) {
+function Bu(e, t = !0) {
 	let n = K(e);
 	return n == null ? t : !!n;
 }
-function Pu({ rootRef: e, enabled: t = !0, canLoad: n = !0, loadMore: r, rootMargin: i = "900px", threshold: a = .01 } = {}) {
+function Vu({ rootRef: e, enabled: t = !0, canLoad: n = !0, loadMore: r, rootMargin: i = "900px", threshold: a = .01 } = {}) {
 	let o = Z(null), s = null, c = !1;
 	function l() {
 		try {
@@ -7389,7 +7611,7 @@ function Pu({ rootRef: e, enabled: t = !0, canLoad: n = !0, loadMore: r, rootMar
 		s = null;
 	}
 	async function u() {
-		if (!c && !(!Nu(t, !0) || !Nu(n, !0)) && typeof r == "function") {
+		if (!c && !(!Bu(t, !0) || !Bu(n, !0)) && typeof r == "function") {
 			c = !0;
 			try {
 				await r();
@@ -7418,18 +7640,18 @@ function Pu({ rootRef: e, enabled: t = !0, canLoad: n = !0, loadMore: r, rootMar
 }
 //#endregion
 //#region ui/vue/grid/useGridDisplayAssets.ts
-function Fu(e) {
+function Hu(e) {
 	let t = Mt(e?.filename);
 	return t ? `${String(e?.source || e?.type || "").trim().toLowerCase()}|${String(e?.root_id || e?.custom_root_id || "").trim().toLowerCase()}|${String(e?.subfolder || "").trim().toLowerCase()}|${t}` : "";
 }
-function Iu(e) {
+function Uu(e) {
 	return !!e;
 }
-function Lu(e) {
+function Wu(e) {
 	let t = Array.isArray(e) ? e : [], n = /* @__PURE__ */ new Map(), r = [];
 	for (let e of t) {
 		if (!e) continue;
-		let t = Fu(e);
+		let t = Hu(e);
 		if (!t) {
 			e._mjrNameCollision = !1, delete e._mjrNameCollisionCount, delete e._mjrNameCollisionPaths, e._mjrDupStack = !1, e._mjrDupMembers = null, e._mjrDupCount = 0, r.push(e);
 			continue;
@@ -7448,7 +7670,7 @@ function Lu(e) {
 }
 //#endregion
 //#region ui/vue/components/grid/VirtualAssetGridHost.vue
-var Ru = {
+var Gu = {
 	key: 0,
 	class: "mjr-grid-loading-overlay",
 	style: {
@@ -7463,19 +7685,19 @@ var Ru = {
 		background: "rgba(20,22,28,0.55)",
 		"backdrop-filter": "blur(2px)"
 	}
-}, zu = { style: { width: "100%" } }, Bu = { style: {
+}, Ku = { style: { width: "100%" } }, qu = { style: {
 	"margin-top": "10px",
 	"font-size": "12px",
 	opacity: "0.68",
 	"text-align": "center"
-} }, Vu = ["data-index"], Hu = [
+} }, Ju = ["data-index"], Yu = [
 	"aria-expanded",
 	"title",
 	"onClick"
-], Uu = {
+], Xu = {
 	class: "mjr-grid-group-separator-chevron",
 	"aria-hidden": "true"
-}, Wu = { class: "mjr-grid-group-separator-title" }, Gu = [
+}, Zu = { class: "mjr-grid-group-separator-title" }, Qu = [
 	"data-mjr-asset-id",
 	"data-mjr-filename-key",
 	"data-mjr-ext",
@@ -7491,21 +7713,21 @@ var Ru = {
 	"onMousedown",
 	"onClick",
 	"onDblclick"
-], Ku = {
+], $u = {
 	key: 3,
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		width: "100%"
 	}
-}, qu = [
+}, ed = [
 	"aria-expanded",
 	"title",
 	"onClick"
-], Ju = {
+], td = {
 	class: "mjr-grid-group-separator-chevron",
 	"aria-hidden": "true"
-}, Yu = { class: "mjr-grid-group-separator-title" }, Xu = [
+}, nd = { class: "mjr-grid-group-separator-title" }, rd = [
 	"data-mjr-asset-id",
 	"data-mjr-filename-key",
 	"data-mjr-ext",
@@ -7521,7 +7743,7 @@ var Ru = {
 	"onMousedown",
 	"onClick",
 	"onDblclick"
-], Zu = 501, Qu = {
+], id = 501, ad = {
 	__name: "VirtualAssetGridHost",
 	props: {
 		scrollElement: {
@@ -7550,14 +7772,14 @@ var Ru = {
 		}
 	},
 	setup(e, { expose: t }) {
-		let n = e, r = Z(null), i = Z(1024);
+		let n = e, r = Z(null), a = Z(1024);
 		Z(!0);
 		let o = Z(0), s = Z(0), c = /* @__PURE__ */ new WeakMap(), l = 0, u = 0, d = 0, f = 0, p = 0, m = /* @__PURE__ */ new Map(), h = null, g = null;
 		function _() {
-			return h ||= import("./chunks/viewerOpenRequest-DeJyXX9z.js").then((e) => e.n), h;
+			return h ||= import("./chunks/viewerOpenRequest-BcaSPESm.js").then((e) => e.n), h;
 		}
 		function v() {
-			return g ||= import("./chunks/floatingViewerManager-CGdpmtv-.js").then((e) => e.n), g;
+			return g ||= import("./chunks/floatingViewerManager-C0fDYFQu.js").then((e) => e.n), g;
 		}
 		function y(e) {
 			return (Array.isArray(e) ? e : []).slice().sort((e, t) => {
@@ -7576,7 +7798,7 @@ var Ru = {
 				let a = t._mjrStackMembersCache.get(i);
 				if (!Array.isArray(a)) {
 					let e = m.get(i);
-					e || (e = I(Ye(n, { limit: Zu }), { timeoutMs: 3e4 }).finally(() => {
+					e || (e = oe(Xe(n, { limit: id }), { timeoutMs: 3e4 }).finally(() => {
 						m.delete(i);
 					}), m.set(i, e));
 					let r = await e;
@@ -7584,7 +7806,7 @@ var Ru = {
 					else return;
 				}
 				let o = y(a);
-				t.dispatchEvent(new CustomEvent(B.OPEN_STACK_GROUP, {
+				t.dispatchEvent(new CustomEvent(z.OPEN_STACK_GROUP, {
 					bubbles: !0,
 					detail: {
 						asset: e,
@@ -7598,7 +7820,7 @@ var Ru = {
 				let t = r.value;
 				if (!t || !e) return;
 				let n = Array.isArray(e._mjrDupMembers) ? e._mjrDupMembers : [e];
-				t.dispatchEvent(new CustomEvent(B.OPEN_STACK_GROUP, {
+				t.dispatchEvent(new CustomEvent(z.OPEN_STACK_GROUP, {
 					bubbles: !0,
 					detail: {
 						asset: e,
@@ -7609,23 +7831,23 @@ var Ru = {
 				}));
 			}
 		});
-		let { state: b, selectedIdSet: x, setLoadingMessage: S, clearLoadingMessage: C, setStatusMessage: T, clearStatusMessage: E, resetAssets: D, setSelection: O, reconcileSelection: k, getSelectedAssets: j, getActiveAsset: M } = bc();
+		let { state: b, selectedIdSet: x, setLoadingMessage: S, clearLoadingMessage: w, setStatusMessage: T, clearStatusMessage: E, resetAssets: D, setSelection: O, reconcileSelection: A, getSelectedAssets: j, getActiveAsset: M } = Sc();
 		function N(e) {
 			return e ? typeof e == "object" && "value" in e ? e.value || null : e : null;
 		}
 		let ee = G(() => N(n.scrollElement));
-		function te() {
-			return Wl(r.value);
+		function P() {
+			return Kl(r.value);
 		}
-		function ne(e, { align: t = "auto" } = {}) {
+		function te(e, { align: t = "auto" } = {}) {
 			let r = String(e || "").trim();
 			if (!r) return;
-			let i = (Array.isArray(xe.value) ? xe.value : []).findIndex((e) => String(e?.id || "") === r);
+			let i = (Array.isArray(Se.value) ? Se.value : []).findIndex((e) => String(e?.id || "") === r);
 			if (!(i < 0)) {
 				if (n.virtualize) {
-					let e = Math.floor(i / Math.max(1, ze.value));
+					let e = Math.floor(i / Math.max(1, Ve.value));
 					try {
-						Xe.value.scrollToIndex(e, { align: t });
+						Qe.value.scrollToIndex(e, { align: t });
 					} catch (e) {
 						console.debug?.(e);
 					}
@@ -7641,27 +7863,27 @@ var Ru = {
 				}
 			}
 		}
-		function P() {
-			return wc(r.value, ee.value);
+		function ne() {
+			return Ec(r.value, ee.value);
 		}
-		let F = uu({
+		let F = fu({
 			gridContainerRef: r,
 			state: b,
 			setLoadingMessage: S,
-			clearLoadingMessage: C,
+			clearLoadingMessage: w,
 			setStatusMessage: T,
 			clearStatusMessage: E,
 			resetAssets: D,
 			setSelection: O,
-			reconcileSelection: k,
+			reconcileSelection: A,
 			readScrollElement: () => ee.value,
-			readRenderedCards: te,
-			scrollToAssetId: ne,
-			canLoadMore: P
-		}), { sentinelRef: re } = Pu({
+			readRenderedCards: P,
+			scrollToAssetId: te,
+			canLoadMore: ne
+		}), { sentinelRef: re } = Vu({
 			rootRef: ee,
 			enabled: !0,
-			canLoad: G(() => !b.loading && !b.done && P()),
+			canLoad: G(() => !b.loading && !b.done && ne()),
 			loadMore: () => F.loadNextPage(),
 			rootMargin: "900px"
 		});
@@ -7673,19 +7895,19 @@ var Ru = {
 			let t = String(e?.filename || ""), n = t.lastIndexOf(".");
 			return n >= 0 ? t.slice(0, n).toLowerCase() : t.toLowerCase();
 		}
-		function oe(e) {
+		function se(e) {
 			return x.value.has(String(e?.id || ""));
 		}
-		function se(e) {
+		function ce(e) {
 			return String(e?.kind || "").toLowerCase() === "folder";
 		}
-		function ce(e) {
+		function ue(e) {
 			return String(e?.kind || "").toLowerCase() === "workflow";
 		}
-		function ue() {
-			return String(Ce.value || "").trim().toLowerCase() === "workflow";
+		function de() {
+			return String(we.value || "").trim().toLowerCase() === "workflow";
 		}
-		function de(e) {
+		function fe(e) {
 			let t = String(e || "none").trim().toLowerCase();
 			return [
 				"task",
@@ -7693,29 +7915,29 @@ var Ru = {
 				"category"
 			].includes(t) ? t : "none";
 		}
-		function fe(e) {
+		function pe(e) {
 			let t = String(e || ""), n = 0;
 			for (let e = 0; e < t.length; e += 1) n = (n << 5) - n + t.charCodeAt(e), n |= 0;
 			return `hsl(${Math.abs(n) % 360}deg 68% 60%)`;
 		}
-		function pe(e, t) {
+		function me(e, t) {
 			return !e || typeof e != "object" ? "Ungrouped" : t === "task" ? String(e?.task || e?.workflow_task || "").trim() || "Task: Unknown" : t === "model" ? String(e?.model_family || e?.workflow_model_family || e?.workflow_model || e?.model || "").trim() || "Model: Unknown" : t === "category" ? String(e?.category || e?.subfolder || e?.workflow_category || "").trim() || "Category: Uncategorized" : "Ungrouped";
 		}
-		function me(e, t) {
+		function he(e, t) {
 			return (Array.isArray(e) ? e : []).slice().sort((e, n) => {
-				let r = pe(e, t).toLowerCase(), i = pe(n, t).toLowerCase();
+				let r = me(e, t).toLowerCase(), i = me(n, t).toLowerCase();
 				if (r < i) return -1;
 				if (r > i) return 1;
 				let a = Number(e?.mtime || e?.created_at || 0) || 0;
 				return (Number(n?.mtime || n?.created_at || 0) || 0) - a;
 			});
 		}
-		function he(e, t, n) {
-			let r = me(e, n), i = [];
+		function ge(e, t, n) {
+			let r = he(e, n), i = [];
 			if (!r.length) return i;
 			let a = /* @__PURE__ */ new Map();
 			for (let e of r) {
-				let t = ce(e) ? pe(e, n) : "Other";
+				let t = ue(e) ? me(e, n) : "Other";
 				a.has(t) || a.set(t, []), a.get(t).push(e);
 			}
 			let o = Array.from(a.keys());
@@ -7726,7 +7948,7 @@ var Ru = {
 					title: e,
 					groupKey: e,
 					groupCount: n.length,
-					accent: fe(e),
+					accent: pe(e),
 					items: []
 				});
 				for (let r = 0; r < n.length; r += t) i.push({
@@ -7734,20 +7956,20 @@ var Ru = {
 					title: "",
 					groupKey: e,
 					groupCount: n.length,
-					accent: fe(e),
+					accent: pe(e),
 					items: n.slice(r, r + t)
 				});
 			}
 			return i;
 		}
-		function ge(e) {
+		function _e(e) {
 			let t = r.value;
 			return !t || String(t.dataset?.mjrGroupStacks || "") !== "1" ? !1 : !!String(e?.stack_id || "").trim() && Number(e?.stack_asset_count || 0) > 1;
 		}
-		function _e(e) {
+		function ve(e) {
 			return e?._mjrLivePlaceholder === !0 || e?.is_live_placeholder === !0 || String(e?.id || "").trim().toLowerCase().startsWith("live:");
 		}
-		function ve() {
+		function ye() {
 			let e = r.value;
 			if (!e) return;
 			let t = new Set((Array.isArray(b.selectedIds) ? b.selectedIds : []).map((e) => String(e || "").trim()).filter(Boolean));
@@ -7758,12 +7980,12 @@ var Ru = {
 				console.debug?.(e);
 			}
 		}
-		function ye() {
+		function be() {
 			let e = r.value;
 			if (!e) return;
 			let t = Array.isArray(b.selectedIds) ? b.selectedIds.slice() : [], i = String(b.activeId || ""), a = `${t.join("|")}::${i}`;
-			if (a === ye._lastSelectionKey) return;
-			ye._lastSelectionKey = a;
+			if (a === be._lastSelectionKey) return;
+			be._lastSelectionKey = a;
 			let o = {
 				selectedIds: t,
 				activeId: i,
@@ -7780,64 +8002,64 @@ var Ru = {
 				console.debug?.(e);
 			}
 		}
-		ye._lastSelectionKey = "";
-		let be = G(() => Lu(b.assets)), xe = G(() => (Array.isArray(be.value) ? be.value : []).filter((e) => Iu(e))), Se = Z(/* @__PURE__ */ new Set()), Ce = Z(""), we = G(() => {
+		be._lastSelectionKey = "";
+		let xe = G(() => Wu(b.assets)), Se = G(() => (Array.isArray(xe.value) ? xe.value : []).filter((e) => Uu(e))), Ce = Z(/* @__PURE__ */ new Set()), we = Z(""), Te = G(() => {
 			o.value;
-			let e = de(z.WORKFLOW_GRID_GROUP_BY);
-			return e === "none" || Ce.value !== "workflow" ? "none" : e;
-		}), Te = G(() => {
-			let e = Array.isArray(xe.value) ? xe.value : [];
+			let e = fe(R.WORKFLOW_GRID_GROUP_BY);
+			return e === "none" || we.value !== "workflow" ? "none" : e;
+		}), Ee = G(() => {
+			let e = Array.isArray(Se.value) ? Se.value : [];
 			if (!e.length) return [];
-			let t = we.value;
-			return t === "none" ? [] : he(e, ze.value, t);
+			let t = Te.value;
+			return t === "none" ? [] : ge(e, Ve.value, t);
 		});
-		ir(() => `${we.value}::${Te.value.map((e) => `${e.kind}:${e.groupKey}`).join("|")}`, () => {
-			if (we.value === "none") {
-				Se.value = /* @__PURE__ */ new Set();
+		ir(() => `${Te.value}::${Ee.value.map((e) => `${e.kind}:${e.groupKey}`).join("|")}`, () => {
+			if (Te.value === "none") {
+				Ce.value = /* @__PURE__ */ new Set();
 				return;
 			}
-			let e = /* @__PURE__ */ new Set(), t = Se.value;
-			for (let n of Te.value) {
+			let e = /* @__PURE__ */ new Set(), t = Ce.value;
+			for (let n of Ee.value) {
 				if (n?.kind !== "header") continue;
 				let r = String(n.groupKey || "");
 				r && t.has(r) && e.add(r);
 			}
-			Se.value = e;
+			Ce.value = e;
 		}, { immediate: !0 });
-		function Ee(e) {
-			let t = String(e || "");
-			return t ? Se.value.has(t) : !1;
-		}
 		function De(e) {
 			let t = String(e || "");
-			if (!t) return;
-			let n = new Set(Se.value);
-			n.has(t) ? n.delete(t) : n.add(t), Se.value = n;
+			return t ? Ce.value.has(t) : !1;
 		}
 		function Oe(e) {
+			let t = String(e || "");
+			if (!t) return;
+			let n = new Set(Ce.value);
+			n.has(t) ? n.delete(t) : n.add(t), Ce.value = n;
+		}
+		function ke(e) {
 			let t = String(e?.groupKey || e?.title || ""), n = 0;
 			for (let e = 0; e < t.length; e += 1) n = (n << 5) - n + t.charCodeAt(e) | 0;
 			return `mjr-grid-group-separator--accent-${Math.abs(n) % 8}`;
 		}
-		let ke = G(() => {
-			let e = Array.isArray(xe.value) ? xe.value : [];
+		let je = G(() => {
+			let e = Array.isArray(Se.value) ? Se.value : [];
 			if (!e.length) return [];
-			if (we.value === "none") return Au(e, ze.value);
-			let t = Array.isArray(Te.value) ? Te.value : [], n = [];
+			if (Te.value === "none") return Lu(e, Ve.value);
+			let t = Array.isArray(Ee.value) ? Ee.value : [], n = [];
 			for (let e of t) {
 				if (e?.kind === "header") {
 					n.push(e);
 					continue;
 				}
-				Ee(String(e?.groupKey || "")) || n.push(e);
+				De(String(e?.groupKey || "")) || n.push(e);
 			}
 			return n;
 		});
-		function Ae() {
+		function Me() {
 			let e = r.value;
 			if (!e) return;
 			let t = {
-				count: Array.isArray(xe.value) ? xe.value.length : 0,
+				count: Array.isArray(Se.value) ? Se.value.length : 0,
 				total: Number(b.total || 0) || 0
 			};
 			try {
@@ -7851,7 +8073,7 @@ var Ru = {
 				console.debug?.(e);
 			}
 		}
-		function je(e) {
+		function Ne(e) {
 			if (!e?.id) return;
 			let t = (Array.isArray(b.assets) ? b.assets : []).find((t) => String(t?.id || "") === String(e.id));
 			if (t) try {
@@ -7860,14 +8082,14 @@ var Ru = {
 				console.debug?.(e);
 			}
 		}
-		function Me() {
+		function Pe() {
 			try {
 				window.dispatchEvent(new CustomEvent("mjr:open-sidebar", { detail: { tab: "details" } }));
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		function Ne(e, t = 6) {
+		function Ie(e, t = 6) {
 			let n = b.cardElements.get(e);
 			if (n) {
 				try {
@@ -7877,13 +8099,13 @@ var Ru = {
 				}
 				return;
 			}
-			t <= 0 || requestAnimationFrame(() => Ne(e, t - 1));
+			t <= 0 || requestAnimationFrame(() => Ie(e, t - 1));
 		}
-		function Fe(e) {
+		function Le(e) {
 			let t = e?.detail || {}, n = String(t.assetId ?? t.id ?? "").trim();
-			n && (Array.isArray(xe.value) ? xe.value : []).some((e) => String(e?.id || "") === n) && (O([n], n), ve(), ye(), ne(n, { align: "center" }), setTimeout(() => Ne(n), 0));
+			n && (Array.isArray(Se.value) ? Se.value : []).some((e) => String(e?.id || "") === n) && (O([n], n), ye(), be(), te(n, { align: "center" }), setTimeout(() => Ie(n), 0));
 		}
-		function Ie(e) {
+		function Re(e) {
 			if (!e) return;
 			e._mjrSelectionManagedByVue = !0;
 			try {
@@ -7892,27 +8114,27 @@ var Ru = {
 				console.debug?.(e);
 			}
 			try {
-				pt?.();
+				mt?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
 			Si(e, { applySettingsClasses: n.applyDefaultSettingsClasses });
 			try {
-				pt = ss(e);
+				mt = cs(e);
 			} catch (e) {
-				console.debug?.(e), pt = null;
+				console.debug?.(e), mt = null;
 			}
-			e._mjrPrimaryPointerSelectionUnbind = () => {}, e._mjrGetAssets = () => Array.isArray(xe.value) ? xe.value : [], e._mjrSetSelection = (e, t = "") => {
+			e._mjrPrimaryPointerSelectionUnbind = () => {}, e._mjrGetAssets = () => Array.isArray(Se.value) ? Se.value : [], e._mjrSetSelection = (e, t = "") => {
 				let n = O(e, t);
-				return ve(), ye(), n.selectedIds;
+				return ye(), be(), n.selectedIds;
 			};
 			let t = (e, t = {}) => {
 				let n = F.removeAssets(e, t);
-				return Ae(), n;
+				return Me(), n;
 			};
-			e._mjrRemoveAssets = t, e._mjrGetRenderedCards = () => te(), e._mjrScrollToAssetId = (e, t = {}) => {
-				ne(e, t);
-			}, e._mjrHasAssetId = (e) => (Array.isArray(b.assets) ? b.assets : []).some((t) => String(t?.id || "") === String(e || "")), e._mjrGetGridState = () => b, e._mjrGetSelectedAssets = () => j(), e._mjrGetActiveAsset = () => M(), e._mjrOnKeyboardAssetChanged = (e) => je(e), e._mjrOpenKeyboardDetails = () => Me();
+			e._mjrRemoveAssets = t, e._mjrGetRenderedCards = () => P(), e._mjrScrollToAssetId = (e, t = {}) => {
+				te(e, t);
+			}, e._mjrHasAssetId = (e) => (Array.isArray(b.assets) ? b.assets : []).some((t) => String(t?.id || "") === String(e || "")), e._mjrGetGridState = () => b, e._mjrGetSelectedAssets = () => j(), e._mjrGetActiveAsset = () => M(), e._mjrOnKeyboardAssetChanged = (e) => Ne(e), e._mjrOpenKeyboardDetails = () => Pe();
 			let r = () => (n.applyDefaultSettingsClasses && (xi(e), o.value += 1), F.refreshGrid()), i = () => {
 				F.prepareGridForScopeSwitch(), F.dispose(), b.cardElements.clear(), e._mjrGridApi = null;
 			};
@@ -7935,37 +8157,37 @@ var Ru = {
 			}, e._mjrLoadAssets = (...e) => F.loadAssets(...e), e._mjrLoadAssetsFromList = (...e) => F.loadAssetsFromList(...e), e._mjrPrepareForScopeSwitch = () => F.prepareGridForScopeSwitch(), e._mjrRefreshGrid = r, e._mjrCaptureAnchor = () => F.captureAnchor(), e._mjrRestoreAnchor = (e) => F.restoreAnchor(e), e._mjrHydrateFromSnapshot = (...e) => F.hydrateFromSnapshot(...e), e._mjrUpsertAsset = (e) => F.upsertAsset(e), e._mjrUpsertAssetNow = (e) => F.upsertAssetNow(e), e._mjrGetCanonicalState = () => F.getCanonicalState(), e._mjrGetDebugSnapshot = () => F.getDebugSnapshot(), e._mjrDispose = i;
 		}
 		ir(r, (e) => {
-			e && (Ie(e), ve(), Ae());
+			e && (Re(e), ye(), Me());
 		}, { immediate: !0 }), ir(() => `${(b.selectedIds || []).join("|")}::${String(b.activeId || "")}`, () => {
-			r.value && (ve(), ye());
-		}, { flush: "post" }), ir(() => `${Array.isArray(xe.value) ? xe.value.length : 0}::${Number(b.total || 0)}::${Number(b.hiddenPngSiblings || 0)}`, () => {
-			r.value && Ae();
+			r.value && (ye(), be());
+		}, { flush: "post" }), ir(() => `${Array.isArray(Se.value) ? Se.value.length : 0}::${Number(b.total || 0)}::${Number(b.hiddenPngSiblings || 0)}`, () => {
+			r.value && Me();
 		}, {
 			flush: "post",
 			immediate: !0
 		});
-		function Le() {
-			let e = r.value, t = String(e?.dataset?.mjrBottomFeed || "").toLowerCase() === "true", n = Number(z.GRID_MIN_SIZE || 120) || 120;
-			return t ? Math.max(80, Number(z.FEED_GRID_MIN_SIZE || n) || n) : ue() ? Math.max(180, n) : Math.max(80, n);
+		function Be() {
+			let e = r.value, t = String(e?.dataset?.mjrBottomFeed || "").toLowerCase() === "true", n = Number(R.GRID_MIN_SIZE || 120) || 120;
+			return t ? Math.max(80, Number(R.FEED_GRID_MIN_SIZE || n) || n) : de() ? Math.max(180, n) : Math.max(80, n);
 		}
-		let ze = G(() => {
+		let Ve = G(() => {
 			o.value;
-			let e = Math.max(0, Number(z.GRID_GAP || 10) || 10), t = Le(), n = Number(i.value || 0) || Number(ee.value?.clientWidth || 0) || 0;
+			let e = Math.max(0, Number(R.GRID_GAP || 10) || 10), t = Be(), n = Number(a.value || 0) || Number(ee.value?.clientWidth || 0) || 0;
 			return n <= 0 ? 1 : Math.max(1, Math.floor((n + e) / (t + e)));
-		}), Be = G(() => (Number(i.value || 0) || Number(ee.value?.clientWidth || 0) || 0) > 0), Ve = G(() => (o.value, Math.max(0, Number(z.GRID_GAP || 10) || 10))), He = G(() => {
-			let e = Math.max(1, ze.value), t = Number(i.value || 0) || Number(ee.value?.clientWidth || 0) || 0;
-			return t <= 0 ? Le() : Math.max(80, Math.floor((t - Ve.value * Math.max(0, e - 1)) / e));
-		}), Ue = G(() => {
+		}), He = G(() => (Number(a.value || 0) || Number(ee.value?.clientWidth || 0) || 0) > 0), Ue = G(() => (o.value, Math.max(0, Number(R.GRID_GAP || 10) || 10))), We = G(() => {
+			let e = Math.max(1, Ve.value), t = Number(a.value || 0) || Number(ee.value?.clientWidth || 0) || 0;
+			return t <= 0 ? Be() : Math.max(80, Math.floor((t - Ue.value * Math.max(0, e - 1)) / e));
+		}), Ge = G(() => {
 			o.value;
-			let e = !!z.GRID_SHOW_DETAILS, t = He.value, n = e ? 82 : 0;
-			return we.value === "none" ? t + n + Ve.value : Math.max(48, t + n + Ve.value);
-		}), We = G(() => n.virtualize ? [] : Array.isArray(ke.value) ? ke.value : []);
-		function Ge(e) {
+			let e = !!R.GRID_SHOW_DETAILS, t = We.value, n = e ? 82 : 0;
+			return Te.value === "none" ? t + n + Ue.value : Math.max(48, t + n + Ue.value);
+		}), Ke = G(() => n.virtualize ? [] : Array.isArray(je.value) ? je.value : []);
+		function qe(e) {
 			if (!u) try {
 				u = requestAnimationFrame(() => {
 					u = 0;
 					try {
-						let t = typeof performance < "u" && typeof performance.now == "function" ? performance.now() : Date.now(), n = Number(e?.scrollTop || 0) || 0, r = Math.max(16, t - Number(p || t)), i = Math.abs(n - Number(f || n)) / Math.max(1, Ue.value) * (16 / r);
+						let t = typeof performance < "u" && typeof performance.now == "function" ? performance.now() : Date.now(), n = Number(e?.scrollTop || 0) || 0, r = Math.max(16, t - Number(p || t)), i = Math.abs(n - Number(f || n)) / Math.max(1, Ge.value) * (16 / r);
 						s.value = Math.max(0, Math.min(20, i)), f = n, p = t, d && clearTimeout(d), d = setTimeout(() => {
 							d = 0, s.value = 0;
 						}, 140);
@@ -7977,7 +8199,7 @@ var Ru = {
 				console.debug?.(e), u = 0;
 			}
 		}
-		function Ke() {
+		function Je() {
 			if (u) {
 				try {
 					cancelAnimationFrame(u);
@@ -7996,52 +8218,52 @@ var Ru = {
 			}
 			s.value = 0;
 		}
-		let qe = Mu({
+		let Ye = zu({
 			scrollRef: ee,
-			items: xe,
-			rows: ke,
-			columnCount: ze,
-			estimateRowHeight: Ue,
+			items: Se,
+			rows: je,
+			columnCount: Ve,
+			estimateRowHeight: Ge,
 			overscan: G(() => {
-				let e = Math.max(1, Ue.value), t = ee.value?.clientHeight || 0;
+				let e = Math.max(1, Ge.value), t = ee.value?.clientHeight || 0;
 				if (t <= 0) return 6;
 				let n = Math.ceil(t / e), r = Math.ceil(s.value * 3);
 				return Math.max(3, Math.min(30, n + r));
 			}),
 			enabled: G(() => n.virtualize)
-		}), Je = qe.rowCount, Xe = qe.virtualizer, Ze = qe.virtualRows, Qe = qe.totalSize, $e = G(() => {
+		}), Ze = Ye.rowCount, Qe = Ye.virtualizer, $e = Ye.virtualRows, et = Ye.totalSize, tt = G(() => {
 			let e = /* @__PURE__ */ new Map();
-			for (let t of Ze.value) e.set(t.index, t.virtual || t);
+			for (let t of $e.value) e.set(t.index, t.virtual || t);
 			return e;
-		}), et = G(() => (o.value, !!z.GRID_SHOW_DETAILS)), L = G(() => {
-			let e = Math.max(1, Number(ze.value || 1));
+		}), I = G(() => (o.value, !!R.GRID_SHOW_DETAILS)), rt = G(() => {
+			let e = Math.max(1, Number(Ve.value || 1));
 			return Math.max(12, Math.min(36, e * 4));
-		}), nt = G(() => Array.from({ length: Number(L.value || 12) }, (e, t) => t)), rt = G(() => {
-			let e = Math.max(80, Number(Ue.value || 0) - Number(Ve.value || 0)), t = Math.max(80, Number(He.value || 0));
+		}), it = G(() => Array.from({ length: Number(rt.value || 12) }, (e, t) => t)), at = G(() => {
+			let e = Math.max(80, Number(Ge.value || 0) - Number(Ue.value || 0)), t = Math.max(80, Number(We.value || 0));
 			return Math.max(0, e - t);
-		}), it = G(() => ({
+		}), ot = G(() => ({
 			display: "grid",
-			gridTemplateColumns: `repeat(${Math.max(1, Number(ze.value || 1))}, minmax(0, ${Math.max(80, Number(He.value || 0))}px))`,
-			gap: `${Ve.value}px`,
+			gridTemplateColumns: `repeat(${Math.max(1, Number(Ve.value || 1))}, minmax(0, ${Math.max(80, Number(We.value || 0))}px))`,
+			gap: `${Ue.value}px`,
 			justifyContent: "start",
 			boxSizing: "border-box"
-		})), at = G(() => ({
+		})), st = G(() => ({
 			width: "100%",
 			minWidth: "0",
-			height: `${Math.max(80, Number(Ue.value || 0) - Number(Ve.value || 0))}px`,
+			height: `${Math.max(80, Number(Ge.value || 0) - Number(Ue.value || 0))}px`,
 			borderRadius: "12px",
 			border: "1px solid rgba(255,255,255,0.22)",
 			background: "rgba(192,198,206,0.20)",
 			overflow: "hidden",
 			boxShadow: "0 6px 18px rgba(0,0,0,0.24)",
 			boxSizing: "border-box"
-		})), ot = G(() => ({
+		})), ct = G(() => ({
 			width: "100%",
-			height: `${Math.max(80, Number(He.value || 0))}px`,
+			height: `${Math.max(80, Number(We.value || 0))}px`,
 			background: "linear-gradient(90deg, rgba(168,174,182,0.40) 0%, rgba(220,225,232,0.54) 50%, rgba(168,174,182,0.40) 100%)",
 			backgroundSize: "220% 100%",
 			animation: "mjr-skeleton-shimmer 2.2s ease-in-out infinite"
-		})), st = G(() => ({
+		})), lt = G(() => ({
 			height: "10px",
 			margin: "10px 10px 6px",
 			borderRadius: "8px",
@@ -8049,7 +8271,7 @@ var Ru = {
 			background: "linear-gradient(90deg, rgba(162,168,176,0.38) 0%, rgba(214,219,226,0.52) 50%, rgba(162,168,176,0.38) 100%)",
 			backgroundSize: "220% 100%",
 			animation: "mjr-skeleton-shimmer 2.2s ease-in-out infinite"
-		})), ct = G(() => ({
+		})), B = G(() => ({
 			height: "10px",
 			margin: "0 10px 10px",
 			borderRadius: "8px",
@@ -8057,23 +8279,23 @@ var Ru = {
 			background: "linear-gradient(90deg, rgba(160,166,173,0.34) 0%, rgba(208,214,221,0.48) 50%, rgba(160,166,173,0.34) 100%)",
 			backgroundSize: "220% 100%",
 			animation: "mjr-skeleton-shimmer 2.2s ease-in-out infinite"
-		})), lt = G(() => ({
-			display: et.value ? "block" : "none",
-			minHeight: `${Math.max(0, Number(rt.value || 0))}px`
+		})), ut = G(() => ({
+			display: I.value ? "block" : "none",
+			minHeight: `${Math.max(0, Number(at.value || 0))}px`
 		}));
-		function ut() {
+		function dt() {
 			let e = Number(ee.value?.clientWidth || 0) || Number(r.value?.clientWidth || 0) || 0;
-			e > 0 && (i.value = e);
+			e > 0 && (a.value = e);
 		}
-		let dt = null, ft = null, pt = null, mt = !1;
-		function ht() {
-			let e = String(r.value?.dataset?.mjrScope || "").trim().toLowerCase();
-			Ce.value !== e && (Ce.value = e);
-		}
+		let ft = null, pt = null, mt = null, ht = !1;
 		function gt() {
-			Rt();
+			let e = String(r.value?.dataset?.mjrScope || "").trim().toLowerCase();
+			we.value !== e && (we.value = e);
+		}
+		function _t() {
+			Bt();
 			let e = () => {
-				Rt(), Ut();
+				Bt(), Kt();
 			};
 			try {
 				requestAnimationFrame(() => {
@@ -8089,52 +8311,52 @@ var Ru = {
 			]) setTimeout(e, t);
 		}
 		fr(() => {
-			gt(), window.addEventListener(B.VIEWER_ACTIVE_ASSET_CHANGED, Fe);
+			_t(), window.addEventListener(z.VIEWER_ACTIVE_ASSET_CHANGED, Le);
 		}), ir(r, (e) => {
+			try {
+				pt?.disconnect?.();
+			} catch (e) {
+				console.debug?.(e);
+			}
+			if (pt = null, e) {
+				gt();
+				try {
+					pt = new MutationObserver(() => {
+						gt();
+					}), pt.observe(e, {
+						attributes: !0,
+						attributeFilter: ["data-mjr-scope"]
+					});
+				} catch (e) {
+					console.debug?.(e), pt = null;
+				}
+			}
+		}, { immediate: !0 }), ir(ee, (e, t) => {
 			try {
 				ft?.disconnect?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
-			if (ft = null, e) {
-				ht();
+			if (e) {
+				dt();
 				try {
-					ft = new MutationObserver(() => {
-						ht();
-					}), ft.observe(e, {
-						attributes: !0,
-						attributeFilter: ["data-mjr-scope"]
-					});
+					ft = new ResizeObserver(() => {
+						dt();
+					}), ft.observe(e);
 				} catch (e) {
 					console.debug?.(e), ft = null;
 				}
 			}
-		}, { immediate: !0 }), ir(ee, (e, t) => {
-			try {
-				dt?.disconnect?.();
-			} catch (e) {
-				console.debug?.(e);
-			}
-			if (e) {
-				ut();
-				try {
-					dt = new ResizeObserver(() => {
-						ut();
-					}), dt.observe(e);
-				} catch (e) {
-					console.debug?.(e), dt = null;
-				}
-			}
-		}, { immediate: !0 }), ir(() => Je.value, async () => {
-			Be.value && (await or(), bt(), zt());
+		}, { immediate: !0 }), ir(() => Ze.value, async () => {
+			He.value && (await or(), xt(), Vt());
 		}), ir(() => b.assets, async (e) => {
 			if (!Array.isArray(e) || e.length === 0) {
 				let e = r.value;
 				e?._mjrStackMembersCache && e._mjrStackMembersCache.clear();
 			}
-			await or(), bt();
+			await or(), xt();
 		});
-		function _t(e, t) {
+		function vt(e, t) {
 			let n = String(t?.filename || "").trim().toLowerCase(), r = c.get(e);
 			if (r && r !== n) {
 				let t = b.renderedFilenameMap.get(r);
@@ -8147,14 +8369,14 @@ var Ru = {
 			let i = b.renderedFilenameMap.get(n);
 			i || (i = /* @__PURE__ */ new Set(), b.renderedFilenameMap.set(n, i)), i.add(e), c.set(e, n);
 		}
-		function vt(e) {
+		function yt(e) {
 			if (!e) return;
 			let t = c.get(e);
 			if (!t) return;
 			let n = b.renderedFilenameMap.get(t);
 			n && (n.delete(e), n.size || b.renderedFilenameMap.delete(t)), c.delete(e);
 		}
-		function yt(e) {
+		function bt(e) {
 			let t = String(e || "").trim().toLowerCase();
 			if (!t) return;
 			let n = b.renderedFilenameMap.get(t), r = Array.from(n || []);
@@ -8175,20 +8397,20 @@ var Ru = {
 			}
 			c._mjrDupStack = !0, c._mjrDupMembers = i.length ? i : [c], c._mjrDupCount = c._mjrDupMembers.length, c._mjrNameCollision = !1;
 		}
-		function bt() {
-			for (let e of b.renderedFilenameMap.keys()) yt(e);
+		function xt() {
+			for (let e of b.renderedFilenameMap.keys()) bt(e);
 		}
-		function xt(e, t) {
+		function St(e, t) {
 			let i = String(e?.id || "").trim();
 			if (!i) return;
 			if (!t) {
 				let e = b.cardElements.get(i), t = e ? c.get(e) : "";
-				vt(e), b.cardElements.delete(i), yt(t);
+				yt(e), b.cardElements.delete(i), bt(t);
 				return;
 			}
 			let a = t?.$el ?? t;
 			if (a instanceof HTMLElement) {
-				b.cardElements.set(i, a), a._mjrIsVue = !0, a._mjrAsset = e, a._mjrReactiveAsset = e, a.dataset.mjrKind = String(e?.kind || ""), _t(a, e), yt(String(e?.filename || "").trim().toLowerCase());
+				b.cardElements.set(i, a), a._mjrIsVue = !0, a._mjrAsset = e, a._mjrReactiveAsset = e, a.dataset.mjrKind = String(e?.kind || ""), vt(a, e), bt(String(e?.filename || "").trim().toLowerCase());
 				try {
 					n.onCardRendered?.(a, e, r.value);
 				} catch (e) {
@@ -8196,10 +8418,10 @@ var Ru = {
 				}
 			}
 		}
-		function St(e) {
-			return (t) => xt(e, t);
+		function Ct(e) {
+			return (t) => St(e, t);
 		}
-		function Ct(e, t) {
+		function wt(e, t) {
 			try {
 				let n = e?.closest?.("a, button, input, textarea, select, label");
 				return !!(n && t?.contains?.(n));
@@ -8207,21 +8429,21 @@ var Ru = {
 				return !1;
 			}
 		}
-		let wt = {
+		let Tt = {
 			assetId: "",
 			at: 0
 		};
-		function Tt(e, t) {
+		function Et(e, t) {
 			let n = String(t?.id || "").trim();
 			if (!n) return;
 			if (e?.type === "click" && Number(e?.detail || 0) > 0) {
-				let e = Date.now() - Number(wt.at || 0);
-				if (wt.assetId === n && e >= 0 && e < 500) {
-					wt.assetId = "", wt.at = 0;
+				let e = Date.now() - Number(Tt.at || 0);
+				if (Tt.assetId === n && e >= 0 && e < 500) {
+					Tt.assetId = "", Tt.at = 0;
 					return;
 				}
 			}
-			if (Ct(e?.target, e?.currentTarget)) return;
+			if (wt(e?.target, e?.currentTarget)) return;
 			let r = Array.isArray(b.assets) ? b.assets : [], i = r.findIndex((e) => String(e?.id || "") === n), a = Array.isArray(b.selectedIds) ? b.selectedIds.slice() : [];
 			if (e?.shiftKey && i >= 0) {
 				let e = String(b.selectionAnchorId || b.activeId || n).trim(), t = r.findIndex((t) => String(t?.id || "") === e), a = t >= 0 ? t : i, o = Math.min(a, i), s = Math.max(a, i);
@@ -8241,21 +8463,21 @@ var Ru = {
 			} catch (e) {
 				console.debug?.(e);
 			}
-			ue() && ce(t) && v().then((e) => e?.floatingViewerManager?.isGraphModeVisible?.() ? kt(t) : null).catch((e) => console.debug?.(e));
+			de() && ue(t) && v().then((e) => e?.floatingViewerManager?.isGraphModeVisible?.() ? At(t) : null).catch((e) => console.debug?.(e));
 		}
-		function Et(e, t) {
+		function Dt(e, t) {
 			if (Number(e?.button ?? 0) !== 0) return;
 			let n = String(t?.id || "").trim();
 			if (!n) return;
 			let r = Array.isArray(b.selectedIds) ? b.selectedIds.map(String).filter(Boolean) : [];
 			if (r.includes(n) && r.length > 1 && !e?.ctrlKey && !e?.metaKey && !e?.shiftKey) {
-				wt.assetId = n, wt.at = Date.now();
+				Tt.assetId = n, Tt.at = Date.now();
 				return;
 			}
-			wt.assetId = n, wt.at = Date.now(), Tt(e, t);
+			Tt.assetId = n, Tt.at = Date.now(), Et(e, t);
 		}
-		async function Dt(e) {
-			let t = (Array.isArray(b.assets) ? b.assets : []).filter((e) => !se(e)), n = t.findIndex((t) => String(t?.id || "") === String(e?.id || ""));
+		async function Ot(e) {
+			let t = (Array.isArray(b.assets) ? b.assets : []).filter((e) => !ce(e)), n = t.findIndex((t) => String(t?.id || "") === String(e?.id || ""));
 			if (!t.length || n < 0) return;
 			let { requestViewerOpen: r } = await _();
 			r({
@@ -8263,7 +8485,7 @@ var Ru = {
 				index: n
 			});
 		}
-		function Ot(e, t = null) {
+		function kt(e, t = null) {
 			let n = String(e?.id || "").trim();
 			if (!n) return;
 			let r = b.cardElements.get(n);
@@ -8280,13 +8502,13 @@ var Ru = {
 				console.debug?.(e);
 			}
 		}
-		async function kt(e, { select: t = !1 } = {}) {
+		async function At(e, { select: t = !1 } = {}) {
 			try {
 				let n = String(e?.id || "").trim();
 				t && n && O([n], n);
 				let r = String(e?.filepath || e?.path || e?.full_path || "").trim(), i = e;
 				if (r) try {
-					let t = await w(r, { timeoutMs: 25e3 }), n = t?.data?.workflow || t?.workflow || null, a = t?.data?.prompt || t?.prompt || null;
+					let t = await C(r, { timeoutMs: 25e3 }), n = t?.data?.workflow || t?.workflow || null, a = t?.data?.prompt || t?.prompt || null;
 					(n || a) && (i = {
 						...e,
 						workflow: n || e?.workflow,
@@ -8307,18 +8529,18 @@ var Ru = {
 					mode: "graph"
 				});
 			} catch (e) {
-				console.debug?.(e), Me();
+				console.debug?.(e), Pe();
 			}
 		}
-		async function At(e, t) {
+		async function jt(e, t) {
 			let n = String(e?.type || "").trim().toLowerCase();
 			if (!(!n || String(t?.kind || "").toLowerCase() !== "workflow")) {
 				if (n === "load") {
-					await jt(t);
+					await Mt(t);
 					return;
 				}
 				if (n === "inspect") {
-					await kt(t, { select: !0 });
+					await At(t, { select: !0 });
 					return;
 				}
 				if (n === "favorite") {
@@ -8340,38 +8562,38 @@ var Ru = {
 							}
 						}));
 					} catch (n) {
-						console.debug?.(n), t.favorite = e, A(R("toast.workflowFavoriteFailed", "Failed to update workflow favorite."), "error");
+						console.debug?.(n), t.favorite = e, k(L("toast.workflowFavoriteFailed", "Failed to update workflow favorite."), "error");
 					}
 					return;
 				}
-				n === "menu" && Ot(t, e?.event || null);
+				n === "menu" && kt(t, e?.event || null);
 			}
 		}
-		async function jt(e) {
+		async function Mt(e) {
 			let t = String(e?.filepath || e?.path || e?.full_path || "").trim();
 			if (!t) {
-				A(R("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+				k(L("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 				return;
 			}
-			let n = tt();
-			if (Re(n) === !0 && !await Gt(R("dialog.workflowLoadReplaceDirty", "Current canvas has unsaved changes. Replace it with this workflow?"), R("tab.workflow", "Workflow"))) return;
-			let r = await w(t, { timeoutMs: 3e4 }), i = r?.data?.workflow || r?.workflow || null;
-			if (!r?.ok || !i || typeof i != "object") {
-				A(r?.error || R("toast.workflowLoadFailed", "Failed to load workflow."), "error");
+			let n = nt();
+			if (ze(n) === !0 && !await Gt(L("dialog.workflowLoadReplaceDirty", "Current canvas has unsaved changes. Replace it with this workflow?"), L("tab.workflow", "Workflow"))) return;
+			let r = await C(t, { timeoutMs: 3e4 }), a = r?.data?.workflow || r?.workflow || null;
+			if (!r?.ok || !a || typeof a != "object") {
+				k(r?.error || L("toast.workflowLoadFailed", "Failed to load workflow."), "error");
 				return;
 			}
-			if (!Pe(i, n).ok) {
-				A(R("toast.workflowImportUnavailable", "ComfyUI workflow import is unavailable in this frontend."), "error");
+			if (!Fe(a, n).ok) {
+				k(L("toast.workflowImportUnavailable", "ComfyUI workflow import is unavailable in this frontend."), "error");
 				return;
 			}
 			try {
-				await a({ filepath: t }, { timeoutMs: 1e4 });
+				await i({ filepath: t }, { timeoutMs: 1e4 });
 			} catch (e) {
 				console.debug?.(e);
 			}
-			A(R("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
+			k(L("toast.workflowLoaded", "Workflow loaded"), "success", 1800);
 		}
-		function Mt(e) {
+		function Nt(e) {
 			try {
 				if (typeof n.onCardDblclick == "function") {
 					n.onCardDblclick({
@@ -8384,7 +8606,7 @@ var Ru = {
 			} catch (e) {
 				console.debug?.(e);
 			}
-			if (se(e)) {
+			if (ce(e)) {
 				try {
 					r.value?.dispatchEvent?.(new CustomEvent("mjr:open-folder-asset", {
 						bubbles: !0,
@@ -8396,26 +8618,39 @@ var Ru = {
 				return;
 			}
 			if (String(e?.kind || "").toLowerCase() === "workflow") {
-				jt(e);
+				Mt(e);
 				return;
 			}
-			Dt(e);
+			Ot(e);
 		}
-		let Nt = null, Pt = null, Ft = 0, Lt = "";
-		function Rt() {
-			ut();
+		async function Pt({ asset: e, folderPath: t }) {
+			let n = String(e?.filepath || "").trim();
+			if (!(!n || !t)) try {
+				let e = await Ae({
+					op: "move_file",
+					path: n,
+					destination: t
+				});
+				e?.ok ? (k("Moved to folder", "success"), F.reload()) : k(e?.error || "Failed to move file", "error");
+			} catch (e) {
+				k(e?.message || "Failed to move file", "error");
+			}
+		}
+		let Ft = null, Lt = null, Rt = 0, zt = "";
+		function Bt() {
+			dt();
 			try {
-				Xe.value?.measure?.();
+				Qe.value?.measure?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		function zt() {
+		function Vt() {
 			if (!l) try {
 				l = requestAnimationFrame(() => {
 					l = 0;
 					try {
-						Xe.value?.measure?.();
+						Qe.value?.measure?.();
 					} catch (e) {
 						console.debug?.(e);
 					}
@@ -8423,34 +8658,34 @@ var Ru = {
 			} catch (e) {
 				console.debug?.(e), l = 0;
 				try {
-					Xe.value?.measure?.();
+					Qe.value?.measure?.();
 				} catch (e) {
 					console.debug?.(e);
 				}
 			}
 		}
-		function Bt() {
-			Rt(), requestAnimationFrame(() => {
+		function Ht() {
+			Bt(), requestAnimationFrame(() => {
 				requestAnimationFrame(() => {
-					Rt(), Ut();
+					Bt(), Kt();
 				});
 			}), setTimeout(() => {
-				Rt(), Ut();
+				Bt(), Kt();
 			}, 150);
 		}
-		function Vt(e) {
+		function Ut(e) {
 			if (!e || !n.virtualize) return () => {};
 			let t = () => {
-				Ge(e);
+				qe(e);
 			};
 			e.addEventListener("scroll", t, { passive: !0 });
 			try {
 				requestAnimationFrame(() => {
-					t(), Ut();
+					t(), Kt();
 				});
 			} catch {
 				setTimeout(() => {
-					t(), Ut();
+					t(), Kt();
 				}, 0);
 			}
 			return () => {
@@ -8459,18 +8694,18 @@ var Ru = {
 				} catch (e) {
 					console.debug?.(e);
 				}
-				Ke();
+				Je();
 			};
 		}
 		ir(ee, (e) => {
 			try {
-				Nt?.();
+				Ft?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
-			Nt = Vt(e);
+			Ft = Ut(e);
 		}, { immediate: !0 });
-		function Ht(e) {
+		function Wt(e) {
 			let t = Number(e?.clientHeight || 0) || 0;
 			if (t > 0) return t;
 			let n = Number(r.value?.clientHeight || 0) || 0;
@@ -8481,43 +8716,43 @@ var Ru = {
 				return 0;
 			}
 		}
-		async function Ut() {
-			if (!n.virtualize || !Be.value || b.loading || b.done) return;
+		async function Kt() {
+			if (!n.virtualize || !He.value || b.loading || b.done) return;
 			let e = ee.value;
 			if (!e) return;
-			let t = Array.isArray(b.assets) ? b.assets.length : 0, r = `${t}::${ze.value}`;
-			if (!Pt && !(r === Lt && Date.now() - Ft < 500) && (await or(), (Number(e.scrollHeight || 0) || 0) <= Ht(e) + 40)) {
+			let t = Array.isArray(b.assets) ? b.assets.length : 0, r = `${t}::${Ve.value}`;
+			if (!Lt && !(r === zt && Date.now() - Rt < 500) && (await or(), (Number(e.scrollHeight || 0) || 0) <= Wt(e) + 40)) {
 				let e = t;
-				Pt = Promise.resolve(F.loadNextPage()).catch((e) => console.debug?.(e)).finally(() => {
+				Lt = Promise.resolve(F.loadNextPage()).catch((e) => console.debug?.(e)).finally(() => {
 					let t = Array.isArray(b.assets) ? b.assets.length : 0;
-					Ft = Date.now(), Lt = t === e ? r : "", Pt = null, setTimeout(() => {
-						Ut();
+					Rt = Date.now(), zt = t === e ? r : "", Lt = null, setTimeout(() => {
+						Kt();
 					}, 0);
 				});
 			}
 		}
-		ir(() => `${Array.isArray(b.assets) ? b.assets.length : 0}::${ze.value}::${b.loading}::${b.done}`, () => {
-			Ut();
+		ir(() => `${Array.isArray(b.assets) ? b.assets.length : 0}::${Ve.value}::${b.loading}::${b.done}`, () => {
+			Kt();
 		}, { flush: "post" });
-		function Wt(e) {
+		function qt(e) {
 			if (!(!e || !n.virtualize)) try {
-				Xe.value.measureElement(e);
+				Qe.value.measureElement(e);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		function Kt() {
+		function Jt() {
 			return {
-				width: `${He.value}px`,
-				flex: `0 0 ${He.value}px`,
-				minWidth: `${He.value}px`
+				width: `${We.value}px`,
+				flex: `0 0 ${We.value}px`,
+				minWidth: `${We.value}px`
 			};
 		}
-		function qt(e) {
-			return $e.value.get(e) || null;
+		function Xt(e) {
+			return tt.value.get(e) || null;
 		}
-		function Jt(e) {
-			let t = qt(e);
+		function Zt(e) {
+			let t = Xt(e);
 			return {
 				position: "absolute",
 				left: "0",
@@ -8525,27 +8760,27 @@ var Ru = {
 				transform: `translateY(${Number(t?.start || 0)}px)`,
 				width: "100%",
 				display: "flex",
-				gap: `${Ve.value}px`,
-				paddingBottom: `${Ve.value}px`,
+				gap: `${Ue.value}px`,
+				paddingBottom: `${Ue.value}px`,
 				boxSizing: "border-box"
 			};
 		}
-		function Xt() {
+		function Qt() {
 			return {
 				display: "flex",
-				gap: `${Ve.value}px`,
-				paddingBottom: `${Ve.value}px`,
+				gap: `${Ue.value}px`,
+				paddingBottom: `${Ue.value}px`,
 				boxSizing: "border-box"
 			};
 		}
-		function Zt() {
+		function $t() {
 			o.value += 1, n.applyDefaultSettingsClasses && r.value && xi(r.value);
 		}
 		return ir(() => n.applyDefaultSettingsClasses, () => {
 			r.value && n.applyDefaultSettingsClasses && xi(r.value);
 		}, { immediate: !0 }), lr(() => {
 			try {
-				window.removeEventListener(B.VIEWER_ACTIVE_ASSET_CHANGED, Fe);
+				window.removeEventListener(z.VIEWER_ACTIVE_ASSET_CHANGED, Le);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -8560,17 +8795,17 @@ var Ru = {
 				console.debug?.(e);
 			}
 			try {
-				dt?.disconnect?.();
-			} catch (e) {
-				console.debug?.(e);
-			}
-			try {
 				ft?.disconnect?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				Nt?.();
+				pt?.disconnect?.();
+			} catch (e) {
+				console.debug?.(e);
+			}
+			try {
+				Ft?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -8579,30 +8814,30 @@ var Ru = {
 			} catch (e) {
 				console.debug?.(e);
 			}
-			l = 0, Ke();
+			l = 0, Je();
 			try {
 				F.dispose();
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				pt?.();
+				mt?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
-			pt = null;
+			mt = null;
 			try {
-				window.removeEventListener("mjr-settings-changed", Zt), mt = !1;
+				window.removeEventListener("mjr-settings-changed", $t), ht = !1;
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				window.removeEventListener("mjr:keepalive-attached", Bt);
+				window.removeEventListener("mjr:keepalive-attached", Ht);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}), ir(r, (e) => {
-			e && (mt ||= (window.addEventListener("mjr-settings-changed", Zt), window.addEventListener("mjr:keepalive-attached", Bt), !0));
+			e && (ht ||= (window.addEventListener("mjr-settings-changed", $t), window.addEventListener("mjr:keepalive-attached", Ht), !0));
 		}, { immediate: !0 }), t({
 			get gridContainer() {
 				return r.value;
@@ -8669,23 +8904,23 @@ var Ru = {
 				"min-height": "100%"
 			}
 		}, [
-			K(b).loading && !K(b).assets.length ? (V(), Y("div", Ru, [U("div", zu, [U("div", {
+			K(b).loading && !K(b).assets.length ? (V(), Y("div", Gu, [U("div", Ku, [U("div", {
 				class: "mjr-grid-skeleton-layout",
-				style: Cr(it.value)
-			}, [(V(!0), Y(H, null, ar(nt.value, (e) => (V(), Y("div", {
+				style: Cr(ot.value)
+			}, [(V(!0), Y(H, null, ar(it.value, (e) => (V(), Y("div", {
 				key: `sk-${e}`,
 				class: "mjr-grid-skeleton-card",
-				style: Cr(at.value)
+				style: Cr(st.value)
 			}, [U("div", {
 				class: "mjr-grid-skeleton-thumb mjr-grid-skeleton-shimmer",
-				style: Cr(ot.value)
-			}, null, 4), U("div", { style: Cr(lt.value) }, [U("div", {
+				style: Cr(ct.value)
+			}, null, 4), U("div", { style: Cr(ut.value) }, [U("div", {
 				class: "mjr-grid-skeleton-line mjr-grid-skeleton-line--title mjr-grid-skeleton-shimmer",
-				style: Cr(st.value)
+				style: Cr(lt.value)
 			}, null, 4), U("div", {
 				class: "mjr-grid-skeleton-line mjr-grid-skeleton-line--meta mjr-grid-skeleton-shimmer",
-				style: Cr(ct.value)
-			}, null, 4)], 4)], 4))), 128))], 4), U("div", Bu, q(K(b).loadingMessage || "Loading assets..."), 1)])])) : W("", !0),
+				style: Cr(B.value)
+			}, null, 4)], 4)], 4))), 128))], 4), U("div", qu, q(K(b).loadingMessage || "Loading assets..."), 1)])])) : W("", !0),
 			K(b).statusMessage && !K(b).assets.length && !K(b).loading ? (V(), Y("div", {
 				key: 1,
 				class: "mjr-grid-message",
@@ -8708,34 +8943,35 @@ var Ru = {
 			e.virtualize ? (V(), Y("div", {
 				key: 2,
 				style: Cr({
-					height: `${K(Qe)}px`,
+					height: `${K(et)}px`,
 					position: "relative",
 					width: "100%",
 					gridColumn: "1 / -1"
 				})
-			}, [(V(!0), Y(H, null, ar(K(Ze), (e) => (V(), Y("div", {
+			}, [(V(!0), Y(H, null, ar(K($e), (e) => (V(), Y("div", {
 				key: e.key,
 				ref_for: !0,
-				ref: Wt,
+				ref: qt,
 				"data-index": e.index,
-				style: Cr(Jt(e.index))
+				style: Cr(Zt(e.index))
 			}, [e.kind === "header" ? (V(), Y("button", {
 				key: 0,
 				type: "button",
-				class: X(["mjr-grid-group-separator", Oe(e)]),
-				"aria-expanded": Ee(e.groupKey) ? "false" : "true",
-				title: `${Ee(e.groupKey) ? "Open" : "Close"} group`,
-				onClick: (t) => De(e.groupKey)
-			}, [U("span", Uu, [U("i", { class: X(["pi", Ee(e.groupKey) ? "pi-chevron-down" : "pi-chevron-up"]) }, null, 2)]), U("span", Wu, q(e.title), 1)], 10, Hu)) : e.items.length ? (V(!0), Y(H, { key: 1 }, ar(e.items, (e) => (V(), Y(H, { key: String(e.id) }, [se(e) ? (V(), nr(vc, {
+				class: X(["mjr-grid-group-separator", ke(e)]),
+				"aria-expanded": De(e.groupKey) ? "false" : "true",
+				title: `${De(e.groupKey) ? "Open" : "Close"} group`,
+				onClick: (t) => Oe(e.groupKey)
+			}, [U("span", Xu, [U("i", { class: X(["pi", De(e.groupKey) ? "pi-chevron-down" : "pi-chevron-up"]) }, null, 2)]), U("span", Zu, q(e.title), 1)], 10, Yu)) : e.items.length ? (V(!0), Y(H, { key: 1 }, ar(e.items, (e) => (V(), Y(H, { key: String(e.id) }, [ce(e) ? (V(), nr(bc, {
 				key: 0,
 				ref_for: !0,
-				ref: St(e),
+				ref: Ct(e),
 				asset: e,
-				selected: oe(e),
-				style: Cr(Kt()),
-				onMousedown: pr((t) => Et(t, e), ["left"]),
-				onClick: (t) => Tt(t, e),
-				onDblclick: pr((t) => Mt(e), ["stop"])
+				selected: se(e),
+				style: Cr(Jt()),
+				onMousedown: pr((t) => Dt(t, e), ["left"]),
+				onClick: (t) => Et(t, e),
+				onDblclick: pr((t) => Nt(e), ["stop"]),
+				onDropAsset: Pt
 			}, null, 8, [
 				"asset",
 				"selected",
@@ -8746,53 +8982,54 @@ var Ru = {
 			])) : (V(), Y("div", {
 				key: 1,
 				ref_for: !0,
-				ref: St(e),
+				ref: Ct(e),
 				class: X(["mjr-asset-card mjr-card", {
-					"is-selected": oe(e),
-					"mjr-live-placeholder": _e(e)
+					"is-selected": se(e),
+					"mjr-live-placeholder": ve(e)
 				}]),
 				role: "button",
 				tabindex: "0",
 				draggable: "true",
-				style: Cr(Kt()),
+				style: Cr(Jt()),
 				"data-mjr-asset-id": String(e.id ?? ""),
 				"data-mjr-filename-key": String(e.filename || "").toLowerCase(),
 				"data-mjr-ext": ie(e),
 				"data-mjr-stem": ae(e),
 				"data-mjr-kind": String(e.kind || ""),
-				"data-mjr-live-placeholder": _e(e) ? "true" : void 0,
-				"data-mjr-stacked": ge(e) ? "true" : void 0,
-				"data-mjr-stack-count": ge(e) ? String(e.stack_asset_count || 0) : void 0,
+				"data-mjr-live-placeholder": ve(e) ? "true" : void 0,
+				"data-mjr-stacked": _e(e) ? "true" : void 0,
+				"data-mjr-stack-count": _e(e) ? String(e.stack_asset_count || 0) : void 0,
 				"data-mjr-dup-stacked": e._mjrDupStack ? "true" : void 0,
 				"data-mjr-dup-count": e._mjrDupStack ? String(e._mjrDupCount || 0) : void 0,
 				"aria-label": `Asset ${e.filename || ""}`,
-				"aria-selected": oe(e) ? "true" : "false",
-				onMousedown: pr((t) => Et(t, e), ["left"]),
-				onClick: (t) => Tt(t, e),
-				onDblclick: pr((t) => Mt(e), ["stop"])
-			}, [J(mc, {
+				"aria-selected": se(e) ? "true" : "false",
+				onMousedown: pr((t) => Dt(t, e), ["left"]),
+				onClick: (t) => Et(t, e),
+				onDblclick: pr((t) => Nt(e), ["stop"])
+			}, [J(hc, {
 				asset: e,
-				onWorkflowAction: (t) => At(t, e)
-			}, null, 8, ["asset", "onWorkflowAction"])], 46, Gu))], 64))), 128)) : W("", !0)], 12, Vu))), 128))], 4)) : (V(), Y("div", Ku, [(V(!0), Y(H, null, ar(We.value, (e) => (V(), Y("div", {
+				onWorkflowAction: (t) => jt(t, e)
+			}, null, 8, ["asset", "onWorkflowAction"])], 46, Qu))], 64))), 128)) : W("", !0)], 12, Ju))), 128))], 4)) : (V(), Y("div", $u, [(V(!0), Y(H, null, ar(Ke.value, (e) => (V(), Y("div", {
 				key: `${e.kind || "assets"}-${e.groupKey || ""}-${e.index ?? ""}`,
-				style: Cr(Xt())
+				style: Cr(Qt())
 			}, [e.kind === "header" ? (V(), Y("button", {
 				key: 0,
 				type: "button",
-				class: X(["mjr-grid-group-separator", Oe(e)]),
-				"aria-expanded": Ee(e.groupKey) ? "false" : "true",
-				title: `${Ee(e.groupKey) ? "Open" : "Close"} group`,
-				onClick: (t) => De(e.groupKey)
-			}, [U("span", Ju, [U("i", { class: X(["pi", Ee(e.groupKey) ? "pi-chevron-down" : "pi-chevron-up"]) }, null, 2)]), U("span", Yu, q(e.title), 1)], 10, qu)) : (V(!0), Y(H, { key: 1 }, ar(e.items, (e) => (V(), Y(H, { key: String(e.id) }, [se(e) ? (V(), nr(vc, {
+				class: X(["mjr-grid-group-separator", ke(e)]),
+				"aria-expanded": De(e.groupKey) ? "false" : "true",
+				title: `${De(e.groupKey) ? "Open" : "Close"} group`,
+				onClick: (t) => Oe(e.groupKey)
+			}, [U("span", td, [U("i", { class: X(["pi", De(e.groupKey) ? "pi-chevron-down" : "pi-chevron-up"]) }, null, 2)]), U("span", nd, q(e.title), 1)], 10, ed)) : (V(!0), Y(H, { key: 1 }, ar(e.items, (e) => (V(), Y(H, { key: String(e.id) }, [ce(e) ? (V(), nr(bc, {
 				key: 0,
 				ref_for: !0,
-				ref: St(e),
+				ref: Ct(e),
 				asset: e,
-				selected: oe(e),
-				style: Cr(Kt()),
-				onMousedown: pr((t) => Et(t, e), ["left"]),
-				onClick: (t) => Tt(t, e),
-				onDblclick: pr((t) => Mt(e), ["stop"])
+				selected: se(e),
+				style: Cr(Jt()),
+				onMousedown: pr((t) => Dt(t, e), ["left"]),
+				onClick: (t) => Et(t, e),
+				onDblclick: pr((t) => Nt(e), ["stop"]),
+				onDropAsset: Pt
 			}, null, 8, [
 				"asset",
 				"selected",
@@ -8803,34 +9040,34 @@ var Ru = {
 			])) : (V(), Y("div", {
 				key: 1,
 				ref_for: !0,
-				ref: St(e),
+				ref: Ct(e),
 				class: X(["mjr-asset-card mjr-card", {
-					"is-selected": oe(e),
-					"mjr-live-placeholder": _e(e)
+					"is-selected": se(e),
+					"mjr-live-placeholder": ve(e)
 				}]),
 				role: "button",
 				tabindex: "0",
 				draggable: "true",
-				style: Cr(Kt()),
+				style: Cr(Jt()),
 				"data-mjr-asset-id": String(e.id ?? ""),
 				"data-mjr-filename-key": String(e.filename || "").toLowerCase(),
 				"data-mjr-ext": ie(e),
 				"data-mjr-stem": ae(e),
 				"data-mjr-kind": String(e.kind || ""),
-				"data-mjr-live-placeholder": _e(e) ? "true" : void 0,
-				"data-mjr-stacked": ge(e) ? "true" : void 0,
-				"data-mjr-stack-count": ge(e) ? String(e.stack_asset_count || 0) : void 0,
+				"data-mjr-live-placeholder": ve(e) ? "true" : void 0,
+				"data-mjr-stacked": _e(e) ? "true" : void 0,
+				"data-mjr-stack-count": _e(e) ? String(e.stack_asset_count || 0) : void 0,
 				"data-mjr-dup-stacked": e._mjrDupStack ? "true" : void 0,
 				"data-mjr-dup-count": e._mjrDupStack ? String(e._mjrDupCount || 0) : void 0,
 				"aria-label": `Asset ${e.filename || ""}`,
-				"aria-selected": oe(e) ? "true" : "false",
-				onMousedown: pr((t) => Et(t, e), ["left"]),
-				onClick: (t) => Tt(t, e),
-				onDblclick: pr((t) => Mt(e), ["stop"])
-			}, [J(mc, {
+				"aria-selected": se(e) ? "true" : "false",
+				onMousedown: pr((t) => Dt(t, e), ["left"]),
+				onClick: (t) => Et(t, e),
+				onDblclick: pr((t) => Nt(e), ["stop"])
+			}, [J(hc, {
 				asset: e,
-				onWorkflowAction: (t) => At(t, e)
-			}, null, 8, ["asset", "onWorkflowAction"])], 46, Xu))], 64))), 128))], 4))), 128))])),
+				onWorkflowAction: (t) => jt(t, e)
+			}, null, 8, ["asset", "onWorkflowAction"])], 46, rd))], 64))), 128))], 4))), 128))])),
 			U("div", {
 				ref_key: "infiniteSentinelRef",
 				ref: re,
@@ -8844,14 +9081,14 @@ var Ru = {
 			}, null, 512)
 		], 512));
 	}
-}, $u = 240, ed = 120, td = 80, nd = null, rd = null;
-function id() {
-	return nd ||= import("./chunks/viewerOpenRequest-DeJyXX9z.js").then((e) => e.n), nd;
+}, od = 240, sd = 120, cd = 80, ld = null, ud = null;
+function dd() {
+	return ld ||= import("./chunks/viewerOpenRequest-BcaSPESm.js").then((e) => e.n), ld;
 }
-function ad() {
-	return rd ||= import("./chunks/floatingViewerManager-CGdpmtv-.js").then((e) => e.n), rd;
+function fd() {
+	return ud ||= import("./chunks/floatingViewerManager-C0fDYFQu.js").then((e) => e.n), ud;
 }
-function od(e) {
+function pd(e) {
 	let t = document.createElement("button");
 	t.type = "button", t.className = "mjr-asset-card mjr-card mjr-feed-group-member-card", t.style.cssText = "display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-end;min-height:110px;padding:8px;border:1px solid var(--mjr-border,#444);border-radius:8px;background:var(--mjr-surface,#202020);color:inherit;text-align:left;overflow:hidden;";
 	try {
@@ -8862,7 +9099,7 @@ function od(e) {
 	let n = document.createElement("div");
 	return n.className = "mjr-feed-group-member-name", n.style.cssText = "font-size:11px;font-weight:600;line-height:1.3;word-break:break-word;", n.textContent = String(e?.filename || "Asset"), t.appendChild(n), t;
 }
-function sd(e) {
+function md(e) {
 	try {
 		if (typeof e?._mjrGetRenderedCards == "function") {
 			let t = e._mjrGetRenderedCards();
@@ -8877,11 +9114,11 @@ function sd(e) {
 		return console.debug?.(e), [];
 	}
 }
-function cd(e, t, n = "") {
+function hd(e, t, n = "") {
 	let r = Array.isArray(t) ? t.map(String).filter(Boolean) : [];
-	return $n(e, r, { activeId: n || r[0] || "" }, sd);
+	return $n(e, r, { activeId: n || r[0] || "" }, md);
 }
-function ld(e) {
+function gd(e) {
 	let t = e?.grid;
 	if (!t) return;
 	let n = (e) => {
@@ -8897,19 +9134,19 @@ function ld(e) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let a = sd(t), o = a.indexOf(n), s = Yn(t);
+		let a = md(t), o = a.indexOf(n), s = Yn(t);
 		if (e.shiftKey && o >= 0) {
 			let n = Number.isFinite(Number(t._mjrLastSelectedIndex)) ? Number(t._mjrLastSelectedIndex) : o, r = Math.min(n, o), s = Math.max(n, o);
-			cd(t, a.slice(r, s + 1).map((e) => String(e?.dataset?.mjrAssetId || "").trim()).filter(Boolean), i), t._mjrLastSelectedIndex = o, e.preventDefault(), e.stopPropagation();
+			hd(t, a.slice(r, s + 1).map((e) => String(e?.dataset?.mjrAssetId || "").trim()).filter(Boolean), i), t._mjrLastSelectedIndex = o, e.preventDefault(), e.stopPropagation();
 			return;
 		}
 		if (e.ctrlKey || e.metaKey) {
 			s.has(i) ? s.delete(i) : s.add(i);
 			let n = Array.from(s);
-			cd(t, n, s.has(i) ? i : n[0] || ""), o >= 0 && (t._mjrLastSelectedIndex = o), e.preventDefault(), e.stopPropagation();
+			hd(t, n, s.has(i) ? i : n[0] || ""), o >= 0 && (t._mjrLastSelectedIndex = o), e.preventDefault(), e.stopPropagation();
 			return;
 		}
-		cd(t, [i], i), o >= 0 && (t._mjrLastSelectedIndex = o);
+		hd(t, [i], i), o >= 0 && (t._mjrLastSelectedIndex = o);
 		try {
 			n.focus?.({ preventScroll: !0 });
 		} catch (e) {
@@ -8925,23 +9162,23 @@ function ld(e) {
 		}
 	};
 }
-var ud = {
+var _d = {
 	hosts: /* @__PURE__ */ new Set(),
 	pendingAssets: /* @__PURE__ */ new Map()
 };
-function dd(e) {
-	if (!z.EXECUTION_GROUPING_ENABLED) return Ed(e);
+function vd(e) {
+	if (!R.EXECUTION_GROUPING_ENABLED) return Nd(e);
 	let t = String(e?.stack_id || "").trim();
 	if (t) return `stack:${t}`;
 	let n = String(e?.job_id || "").trim();
-	return n ? `job:${n}` : Ed(e);
+	return n ? `job:${n}` : Nd(e);
 }
-function fd(e) {
+function yd(e) {
 	let t = /* @__PURE__ */ new Map();
 	for (let n of Array.isArray(e) ? e : []) {
-		let e = Od(n);
+		let e = Fd(n);
 		if (!e) continue;
-		let r = dd(e), i = t.get(r);
+		let r = vd(e), i = t.get(r);
 		i || (i = {
 			key: r,
 			members: []
@@ -8966,16 +9203,16 @@ function fd(e) {
 		return (Number(t?.mtime || t?.created_at || 0) || 0) - n;
 	}), n;
 }
-function pd(e) {
+function bd(e) {
 	return Array.from(e?.assetsByKey?.values?.() || []);
 }
-function md(e) {
+function xd(e) {
 	return String(e ?? "").trim().toLowerCase();
 }
-function hd(e) {
+function Sd(e) {
 	return e?._mjrLivePlaceholder === !0 || e?.is_live_placeholder === !0 || String(e?.id || "").trim().toLowerCase().startsWith("live:");
 }
-function gd(e) {
+function Cd(e) {
 	if (!e || typeof e != "object") return e;
 	try {
 		delete e._mjrLivePlaceholder, delete e._mjrLiveStatus, delete e._mjrLiveLabel, delete e.is_live_placeholder;
@@ -8984,19 +9221,19 @@ function gd(e) {
 	}
 	return e;
 }
-function _d(e) {
+function wd(e) {
 	if (!e || typeof e != "object") return "";
-	let t = md(e?.type || e?.source || "output"), n = md(e?.root_id || e?.custom_root_id || ""), r = md(e?.subfolder || ""), i = md(e?.filename || "");
+	let t = xd(e?.type || e?.source || "output"), n = xd(e?.root_id || e?.custom_root_id || ""), r = xd(e?.subfolder || ""), i = xd(e?.filename || "");
 	if (i) return `${t}|${n}|${r}|${i}`;
-	let a = md(e?.filepath || e?.path || e?.fullpath || e?.full_path || "");
+	let a = xd(e?.filepath || e?.path || e?.fullpath || e?.full_path || "");
 	return a ? `${t}|${n}|path|${a}` : "";
 }
-function vd(e, t) {
-	let n = Od(t);
+function Td(e, t) {
+	let n = Fd(t);
 	if (!e || typeof e.set != "function" || !n) return null;
-	let r = Ed(n), i = _d(n), a = "";
+	let r = Nd(n), i = wd(n), a = "";
 	if (i) {
-		for (let [t, n] of e.entries()) if (_d(n) === i) {
+		for (let [t, n] of e.entries()) if (wd(n) === i) {
 			a = t;
 			break;
 		}
@@ -9005,17 +9242,17 @@ function vd(e, t) {
 		...o,
 		...n
 	} : n;
-	return hd(n) || gd(s), a && a !== r && e.delete(a), e.set(r, s), s;
+	return Sd(n) || Cd(s), a && a !== r && e.delete(a), e.set(r, s), s;
 }
-function yd(e, t) {
-	return e ? (e.assetsByKey ||= /* @__PURE__ */ new Map(), vd(e.assetsByKey, t)) : null;
+function Ed(e, t) {
+	return e ? (e.assetsByKey ||= /* @__PURE__ */ new Map(), Td(e.assetsByKey, t)) : null;
 }
-function bd(e) {
+function Dd(e) {
 	!e?.grid || !e.loaded || (e._renderTimer ||= setTimeout(() => {
-		e._renderTimer = null, Td(e);
-	}, td));
+		e._renderTimer = null, Md(e);
+	}, cd));
 }
-function xd(e, t, n = 0) {
+function Od(e, t, n = 0) {
 	let r = Array.isArray(t?._mjrFeedGroupAssets) ? t._mjrFeedGroupAssets.filter(Boolean) : [t].filter(Boolean);
 	if (!r.length) return;
 	let i = Math.max(0, Math.min(n, r.length - 1)), a = r[i] || null, o = String(a?.id || "").trim();
@@ -9025,52 +9262,52 @@ function xd(e, t, n = 0) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		cd(e.grid, [o], o);
+		hd(e.grid, [o], o);
 	}
-	id().then((e) => e.requestViewerOpen({
+	dd().then((e) => e.requestViewerOpen({
 		assets: r,
 		index: i
 	})).catch((e) => console.debug?.(e));
 }
-function Sd(e, t) {
+function kd(e, t) {
 	let n = document.createElement("div");
 	n.className = "mjr-popover mjr-feed-group-popover", n.style.cssText = "display:none; width:min(440px, 92vw); padding:10px;";
 	let r = document.createElement("div");
-	r.className = "mjr-feed-group-popover-title", r.textContent = R("bottomFeed.groupTitle", "Generation group"), r.style.cssText = "font-size:12px; font-weight:700; opacity:0.92; margin-bottom:8px;", n.appendChild(r);
+	r.className = "mjr-feed-group-popover-title", r.textContent = L("bottomFeed.groupTitle", "Generation group"), r.style.cssText = "font-size:12px; font-weight:700; opacity:0.92; margin-bottom:8px;", n.appendChild(r);
 	let i = document.createElement("div");
 	i.className = "mjr-feed-group-popover-grid", i.style.cssText = "display:grid; grid-template-columns:repeat(auto-fill, minmax(110px, 1fr)); gap:8px; max-height:360px; overflow-y:auto; overscroll-behavior:contain;";
 	let a = Array.isArray(t?._mjrFeedGroupAssets) ? t._mjrFeedGroupAssets : [];
 	for (let r = 0; r < a.length; r += 1) {
-		let o = a[r], s = od(o);
+		let o = a[r], s = pd(o);
 		s.classList.add("mjr-feed-group-member-card"), r === 0 && s.classList.add("mjr-feed-group-member-card--cover"), s.addEventListener("click", (i) => {
-			i.preventDefault(), i.stopPropagation(), e.popoverManager?.close?.(n), xd(e, t, r);
+			i.preventDefault(), i.stopPropagation(), e.popoverManager?.close?.(n), Od(e, t, r);
 		}), i.appendChild(s);
 	}
 	return n.appendChild(i), e.root.appendChild(n), n;
 }
-function Cd(e, t, n) {
+function Ad(e, t, n) {
 	if (!t || !n) return;
 	let r = Number(n?._mjrFeedGroupCount || 0) || 0;
 	if (r <= 1 || (t.dataset.mjrFeedGrouped = "true", t.dataset.mjrFeedGroupCount = String(r), t.dataset.mjrStacked = "true", t.dataset.mjrStackCount = String(r), t.querySelector(".mjr-feed-group-button"))) return;
 	let i = document.createElement("button");
-	i.type = "button", i.className = "mjr-feed-group-button", i.title = R("bottomFeed.groupOpen", "Show other assets from this generation"), i.setAttribute("aria-label", `${r} assets`);
+	i.type = "button", i.className = "mjr-feed-group-button", i.title = L("bottomFeed.groupOpen", "Show other assets from this generation"), i.setAttribute("aria-label", `${r} assets`);
 	let a = document.createElement("span");
 	a.className = "mjr-feed-group-button-icon pi pi-clone", i.appendChild(a);
 	let o = document.createElement("span");
-	o.className = "mjr-feed-group-button-count", o.textContent = String(r), i.appendChild(o), i.style.cssText = "position:absolute; top:34px; right:6px; z-index:11;", Qa(i);
-	let s = Sd(e, n);
+	o.className = "mjr-feed-group-button-count", o.textContent = String(r), i.appendChild(o), i.style.cssText = "position:absolute; top:34px; right:6px; z-index:11;", $a(i);
+	let s = kd(e, n);
 	i.addEventListener("click", (t) => {
 		t.preventDefault(), t.stopPropagation(), e.popoverManager?.toggle?.(s, i);
 	}), t.appendChild(i);
 }
-function wd(e, t) {
+function jd(e, t) {
 	let n = new Map((Array.isArray(t) ? t : []).map((e) => [String(e?.id || "").trim(), e]).filter(([e]) => !!e));
-	for (let t of sd(e?.grid)) {
+	for (let t of md(e?.grid)) {
 		let r = String(t?.dataset?.mjrAssetId || "").trim(), i = n.get(r);
-		i && Cd(e, t, i);
+		i && Ad(e, t, i);
 	}
 }
-async function Td(e) {
+async function Md(e) {
 	if (!e?.grid) return;
 	try {
 		e.popoverManager?.closeAll?.();
@@ -9083,19 +9320,19 @@ async function Td(e) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let t = fd(pd(e)), n = await Ei(e.grid, t, {
-		title: R("bottomFeed.title", "Generated Feed"),
+	let t = yd(bd(e)), n = await Ei(e.grid, t, {
+		title: L("bottomFeed.title", "Generated Feed"),
 		reset: !0
 	});
-	wd(e, t), Number(n?.count || 0) <= 0 ? (e.empty.textContent = R("bottomFeed.empty", "No generated assets yet."), e.empty.style.display = "") : e.empty.style.display = "none";
+	jd(e, t), Number(n?.count || 0) <= 0 ? (e.empty.textContent = L("bottomFeed.empty", "No generated assets yet."), e.empty.style.display = "") : e.empty.style.display = "none";
 }
-function Ed(e) {
+function Nd(e) {
 	let t = String(e?.id || "").trim();
 	if (t) return `id:${t}`;
 	let n = String(e?.filename || "").trim(), r = String(e?.subfolder || "").trim();
 	return `file:${String(e?.source || e?.type || "").trim()}:${r}:${n}`;
 }
-function Dd(e) {
+function Pd(e) {
 	let t = String(e || "").split(".").pop()?.toUpperCase() ?? "", n = new Set([
 		"MP4",
 		"WEBM",
@@ -9122,41 +9359,41 @@ function Dd(e) {
 	]);
 	return n.has(t) ? "video" : r.has(t) ? "audio" : i.has(t) ? "model3d" : "image";
 }
-function Od(e) {
+function Fd(e) {
 	if (!e || typeof e != "object") return null;
 	let t = { ...e };
-	return !t.type && t.source && (t.type = t.source), !t.source && t.type && (t.source = t.type), t.kind ||= Dd(t.ext || t.filename || ""), t;
+	return !t.type && t.source && (t.type = t.source), !t.source && t.type && (t.source = t.type), t.kind ||= Pd(t.ext || t.filename || ""), t;
 }
-function kd(e) {
-	let t = Od(e);
+function Id(e) {
+	let t = Fd(e);
 	if (!t) return null;
-	let n = Ed(t);
+	let n = Nd(t);
 	if (!n) return null;
-	let r = _d(t), i = null;
-	if (r) for (let [e, t] of ud.pendingAssets.entries()) e !== n && _d(t) === r && (i = t, ud.pendingAssets.delete(e));
-	let a = ud.pendingAssets.get(n) || i || null, o = a ? {
+	let r = wd(t), i = null;
+	if (r) for (let [e, t] of _d.pendingAssets.entries()) e !== n && wd(t) === r && (i = t, _d.pendingAssets.delete(e));
+	let a = _d.pendingAssets.get(n) || i || null, o = a ? {
 		...a,
 		...t
 	} : t;
-	if (hd(t) || gd(o), ud.pendingAssets.set(n, o), ud.pendingAssets.size > 64) {
-		let e = ud.pendingAssets.keys().next().value;
-		e && ud.pendingAssets.delete(e);
+	if (Sd(t) || Cd(o), _d.pendingAssets.set(n, o), _d.pendingAssets.size > 64) {
+		let e = _d.pendingAssets.keys().next().value;
+		e && _d.pendingAssets.delete(e);
 	}
 	return o;
 }
-function Ad() {
-	return Array.from(ud.pendingAssets.values());
+function Ld() {
+	return Array.from(_d.pendingAssets.values());
 }
-async function jd(e) {
+async function Rd(e) {
 	if (e?.grid) {
-		e.empty.style.display = "none", e.empty.textContent = R("bottomFeed.loading", "Loading recent assets...");
+		e.empty.style.display = "none", e.empty.textContent = L("bottomFeed.loading", "Loading recent assets...");
 		try {
 			e.assetsByKey = /* @__PURE__ */ new Map();
 			let t = [], n = 0;
-			for (; n < $u;) {
-				let r = await I(L({
+			for (; n < od;) {
+				let r = await oe(I({
 					q: "*",
-					limit: Math.min(ed, $u - n),
+					limit: Math.min(sd, od - n),
 					offset: n,
 					scope: "output",
 					sort: "mtime_desc",
@@ -9166,41 +9403,41 @@ async function jd(e) {
 				let i = Array.isArray(r?.data?.assets) ? r.data.assets : [];
 				if (!i.length) break;
 				for (let n of i) {
-					let r = yd(e, n);
+					let r = Ed(e, n);
 					r && t.push(r);
 				}
-				if (i.length < ed) break;
+				if (i.length < sd) break;
 				n += i.length;
 			}
-			for (let t of Ad()) yd(e, t);
-			ud.pendingAssets.clear();
-			let r = fd(pd(e)), i = await Ei(e.grid, r, {
-				title: R("bottomFeed.title", "Generated Feed"),
+			for (let t of Ld()) Ed(e, t);
+			_d.pendingAssets.clear();
+			let r = yd(bd(e)), i = await Ei(e.grid, r, {
+				title: L("bottomFeed.title", "Generated Feed"),
 				reset: !0
 			});
-			wd(e, r), Number(i?.count || 0) <= 0 ? (e.empty.textContent = R("bottomFeed.empty", "No generated assets yet."), e.empty.style.display = "") : e.empty.style.display = "none";
+			jd(e, r), Number(i?.count || 0) <= 0 ? (e.empty.textContent = L("bottomFeed.empty", "No generated assets yet."), e.empty.style.display = "") : e.empty.style.display = "none";
 		} catch (t) {
-			console.debug?.(t), e.empty.textContent = R("bottomFeed.loadFailed", "Failed to load generated assets."), e.empty.style.display = "";
+			console.debug?.(t), e.empty.textContent = L("bottomFeed.loadFailed", "Failed to load generated assets."), e.empty.style.display = "";
 		} finally {
 			e.loaded = !0;
 		}
 	}
 }
-async function Md() {
-	for (let e of Array.from(ud.hosts)) try {
-		await jd(e);
+async function zd() {
+	for (let e of Array.from(_d.hosts)) try {
+		await Rd(e);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Nd() {
-	Md();
+function Bd() {
+	zd();
 }
-function Pd(e) {
+function Vd(e) {
 	let t = document.createElement("div");
-	t.textContent = R("bottomFeed.loading", "Loading recent assets..."), t.style.cssText = "font-size:11px; opacity:0.65; padding:4px 2px 8px 2px;", e.root.appendChild(t), e.empty = t;
+	t.textContent = L("bottomFeed.loading", "Loading recent assets..."), t.style.cssText = "font-size:11px; opacity:0.65; padding:4px 2px 8px 2px;", e.root.appendChild(t), e.empty = t;
 }
-function Fd(e) {
+function Hd(e) {
 	if (!e) return;
 	let t = [
 		e,
@@ -9218,14 +9455,14 @@ function Fd(e) {
 		console.debug?.(e);
 	}
 }
-function Id(e) {
+function Ud(e) {
 	if (!e) return;
 	let t = (t, n) => {
 		n ? e.classList.add(t) : e.classList.remove(t);
 	};
-	t("mjr-feed-show-info", z.FEED_SHOW_INFO), t("mjr-feed-show-filename", z.FEED_SHOW_FILENAME), t("mjr-feed-show-dimensions", z.FEED_SHOW_DIMENSIONS), t("mjr-feed-show-date", z.FEED_SHOW_DATE), t("mjr-feed-show-gentime", z.FEED_SHOW_GENTIME), t("mjr-show-hover-info", z.GRID_SHOW_HOVER_INFO), t("mjr-feed-show-dot", z.FEED_SHOW_WORKFLOW_DOT), t("mjr-feed-show-badges-ext", z.FEED_SHOW_BADGES_EXTENSION), t("mjr-feed-show-badges-rating", z.FEED_SHOW_BADGES_RATING), t("mjr-feed-show-badges-tags", z.FEED_SHOW_BADGES_TAGS);
+	t("mjr-feed-show-info", R.FEED_SHOW_INFO), t("mjr-feed-show-filename", R.FEED_SHOW_FILENAME), t("mjr-feed-show-dimensions", R.FEED_SHOW_DIMENSIONS), t("mjr-feed-show-date", R.FEED_SHOW_DATE), t("mjr-feed-show-gentime", R.FEED_SHOW_GENTIME), t("mjr-show-hover-info", R.GRID_SHOW_HOVER_INFO), t("mjr-feed-show-dot", R.FEED_SHOW_WORKFLOW_DOT), t("mjr-feed-show-badges-ext", R.FEED_SHOW_BADGES_EXTENSION), t("mjr-feed-show-badges-rating", R.FEED_SHOW_BADGES_RATING), t("mjr-feed-show-badges-tags", R.FEED_SHOW_BADGES_TAGS);
 }
-function Ld(e, t = null) {
+function Wd(e, t = null) {
 	let n = t || document.createElement("div");
 	n.classList.add("mjr-am-grid-scroll"), n.style.position = "relative", n.style.flex = "1 1 auto", n.style.minHeight = "0", n.style.height = "100%", n.style.overflow = "auto", n.style.scrollbarGutter = "stable", n.style.overscrollBehavior = "contain", n.style.webkitOverflowScrolling = "touch";
 	let r = () => {
@@ -9237,20 +9474,20 @@ function Ld(e, t = null) {
 	}, i = () => {
 		r();
 		try {
-			window.dispatchEvent(new Event(B.MFV_OPEN));
+			window.dispatchEvent(new Event(z.MFV_OPEN));
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}, a = document.createElement("div");
 	n.appendChild(a), e.root.appendChild(n);
-	let { app: o } = Vn(Qu, {
+	let { app: o } = Vn(ad, {
 		scrollElement: n,
 		virtualize: !1,
 		applyDefaultSettingsClasses: !1,
 		emitWindowSelectionEvents: !0,
 		onCardRendered: (t, n) => {
 			try {
-				Cd(e, t, n);
+				Ad(e, t, n);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -9261,7 +9498,7 @@ function Ld(e, t = null) {
 	}), s = o.mount(a), c = s?.gridContainer || a.querySelector?.(".mjr-grid") || null;
 	if (e.gridApp = o, e.gridVm = s, e.grid = c, !c) return;
 	c.style.minHeight = "100%", c.style.height = "auto", c.dataset.mjrScope = "output", c.dataset.mjrQuery = "*", c.dataset.mjrSort = "mtime_desc", c.dataset.mjrBottomFeed = "true";
-	let l = Number(z.FEED_GRID_MIN_SIZE || z.GRID_MIN_SIZE || 120);
+	let l = Number(R.FEED_GRID_MIN_SIZE || R.GRID_MIN_SIZE || 120);
 	c.dataset.mjrFeedMinItemWidth = String(l), c.style.setProperty("--mjr-grid-min-size", `${l}px`), c.addEventListener("keydown", (e) => {
 		let t = e?.key?.toLowerCase?.() || "";
 		if (!(e?.ctrlKey || e?.metaKey || e?.altKey)) {
@@ -9272,7 +9509,7 @@ function Ld(e, t = null) {
 			if (t === "c") {
 				e.preventDefault?.(), e.stopPropagation?.(), r();
 				try {
-					ad().then(async ({ floatingViewerManager: e }) => {
+					fd().then(async ({ floatingViewerManager: e }) => {
 						await e.open(), e.toggleCompareAB();
 					}).catch((e) => console.debug?.(e));
 				} catch (e) {
@@ -9293,19 +9530,19 @@ function Ld(e, t = null) {
 		}
 	};
 }
-function Rd(e) {
+function Gd(e) {
 	let t = e?.grid;
 	if (!t) return [];
 	let n = Yn(t);
-	return n.size ? pd(e).filter((e) => n.has(String(e?.id || ""))) : [];
+	return n.size ? bd(e).filter((e) => n.has(String(e?.id || ""))) : [];
 }
-function zd(e) {
+function Kd(e) {
 	let t = e?.grid;
 	if (!t) return null;
 	let n = String(t.dataset?.mjrSelectedAssetId || "").trim();
-	return n ? pd(e).find((e) => String(e?.id || "") === n) || null : Rd(e)[0] || null;
+	return n ? bd(e).find((e) => String(e?.id || "") === n) || null : Gd(e)[0] || null;
 }
-function Bd(e) {
+function qd(e) {
 	let t = String(e ?? "");
 	try {
 		if (typeof CSS < "u" && typeof CSS.escape == "function") return CSS.escape(t);
@@ -9314,45 +9551,45 @@ function Bd(e) {
 	}
 	return t.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 }
-function Vd(e) {
+function Jd(e) {
 	let t = e?.grid;
 	if (!t) return;
 	let n = () => {
 		try {
-			bd(e);
+			Dd(e);
 		} catch (e) {
 			console.debug?.(e);
 		}
 	};
 	e.keyboard = Gi({
 		gridContainer: t,
-		getState: () => ({ assets: fd(pd(e)) }),
-		getSelectedAssets: () => Rd(e),
-		getActiveAsset: () => zd(e),
+		getState: () => ({ assets: yd(bd(e)) }),
+		getSelectedAssets: () => Gd(e),
+		getActiveAsset: () => Kd(e),
 		onOpenTagsEditor: (e) => {
-			let r = t.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${Bd(e?.id || "")}"]`) || null, i = null;
+			let r = t.querySelector?.(`.mjr-asset-card[data-mjr-asset-id="${qd(e?.id || "")}"]`) || null, i = null;
 			try {
 				i = r?.getBoundingClientRect?.() || t.getBoundingClientRect();
 			} catch (e) {
 				console.debug?.(e);
 			}
-			Ua(Math.round((i?.left || 0) + Math.min((i?.width || 0) * .5, 160)), Math.round((i?.top || 0) + Math.min((i?.height || 0) * .5, 120)), e, n);
+			Wa(Math.round((i?.left || 0) + Math.min((i?.width || 0) * .5, 160)), Math.round((i?.top || 0) + Math.min((i?.height || 0) * .5, 120)), e, n);
 		},
 		onAssetChanged: n
-	}), e.keyboard.bind(), e.ratingHotkeys = Za({
+	}), e.keyboard.bind(), e.ratingHotkeys = Qa({
 		gridContainer: t,
 		createRatingBadge: _t
 	}), e.ratingHotkeys.bind();
 }
-var Hd = 60, Ud = 600, Wd = 10;
-function Gd(e, t) {
-	let n = Math.max(Hd, Math.min(Ud, Math.round(Number(t) / Wd) * Wd));
+var Yd = 60, Xd = 600, Zd = 10;
+function Qd(e, t) {
+	let n = Math.max(Yd, Math.min(Xd, Math.round(Number(t) / Zd) * Zd));
 	if (e?.grid) try {
 		e.grid.style.setProperty("--mjr-grid-min-size", `${n}px`);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	z.FEED_GRID_MIN_SIZE = n;
+	R.FEED_GRID_MIN_SIZE = n;
 	try {
 		let e = mn();
 		e.feed.minSize = n, Xt(e), Cn(e);
@@ -9372,27 +9609,27 @@ function Gd(e, t) {
 	}
 	return n;
 }
-function Kd(e) {
-	let t = Math.max(Hd, Number(z.FEED_GRID_MIN_SIZE || 120) || 120), n = document.createElement("div");
+function $d(e) {
+	let t = Math.max(Yd, Number(R.FEED_GRID_MIN_SIZE || 120) || 120), n = document.createElement("div");
 	n.className = "mjr-feed-toolbar", n.style.cssText = "display:flex; align-items:center; gap:5px; padding:0 2px 5px 2px; flex-shrink:0; user-select:none;";
 	let r = document.createElement("span");
-	r.textContent = R("bottomFeed.cardSize", "Cards:"), r.style.cssText = "font-size:11px; opacity:0.65; white-space:nowrap; flex-shrink:0;", n.appendChild(r);
+	r.textContent = L("bottomFeed.cardSize", "Cards:"), r.style.cssText = "font-size:11px; opacity:0.65; white-space:nowrap; flex-shrink:0;", n.appendChild(r);
 	let i = document.createElement("button");
-	i.type = "button", i.className = "mjr-feed-size-btn", i.textContent = "-", i.title = R("bottomFeed.cardSizeDecrease", "Decrease card size"), i.style.cssText = "width:20px; height:20px; padding:0; border:1px solid var(--mjr-border,#555); border-radius:4px; background:var(--mjr-surface,#2a2a2a); color:inherit; cursor:pointer; font-size:14px; line-height:1; flex-shrink:0; display:flex; align-items:center; justify-content:center;", n.appendChild(i);
+	i.type = "button", i.className = "mjr-feed-size-btn", i.textContent = "-", i.title = L("bottomFeed.cardSizeDecrease", "Decrease card size"), i.style.cssText = "width:20px; height:20px; padding:0; border:1px solid var(--mjr-border,#555); border-radius:4px; background:var(--mjr-surface,#2a2a2a); color:inherit; cursor:pointer; font-size:14px; line-height:1; flex-shrink:0; display:flex; align-items:center; justify-content:center;", n.appendChild(i);
 	let a = document.createElement("input");
-	a.type = "range", a.className = "mjr-feed-size-slider", a.min = String(Hd), a.max = String(Ud), a.step = String(Wd), a.value = String(t), a.title = R("bottomFeed.cardSizeSlider", "Card size"), a.style.cssText = "flex:1 1 auto; min-width:40px; max-width:180px; height:4px; cursor:pointer; accent-color:var(--mjr-accent,#64b5f6);", n.appendChild(a);
+	a.type = "range", a.className = "mjr-feed-size-slider", a.min = String(Yd), a.max = String(Xd), a.step = String(Zd), a.value = String(t), a.title = L("bottomFeed.cardSizeSlider", "Card size"), a.style.cssText = "flex:1 1 auto; min-width:40px; max-width:180px; height:4px; cursor:pointer; accent-color:var(--mjr-accent,#64b5f6);", n.appendChild(a);
 	let o = document.createElement("button");
-	o.type = "button", o.className = "mjr-feed-size-btn", o.textContent = "+", o.title = R("bottomFeed.cardSizeIncrease", "Increase card size"), o.style.cssText = i.style.cssText, n.appendChild(o);
+	o.type = "button", o.className = "mjr-feed-size-btn", o.textContent = "+", o.title = L("bottomFeed.cardSizeIncrease", "Increase card size"), o.style.cssText = i.style.cssText, n.appendChild(o);
 	let s = document.createElement("span");
 	s.className = "mjr-feed-size-display", s.textContent = `${t}px`, s.style.cssText = "font-size:11px; opacity:0.65; white-space:nowrap; min-width:36px; text-align:right; flex-shrink:0; font-variant-numeric:tabular-nums;", n.appendChild(s), i.addEventListener("click", () => {
-		Gd(e, Number(a.value) - Wd);
+		Qd(e, Number(a.value) - Zd);
 	}), o.addEventListener("click", () => {
-		Gd(e, Number(a.value) + Wd);
+		Qd(e, Number(a.value) + Zd);
 	}), a.addEventListener("input", () => {
-		Gd(e, Number(a.value));
+		Qd(e, Number(a.value));
 	}), e.root.appendChild(n), e._sizeToolbar = n;
 }
-function qd(e, t = {}) {
+function ef(e, t = {}) {
 	let n = document.createElement("div");
 	n.className = "mjr-assets-manager mjr-bottom-feed", n.style.cssText = "padding:6px; height:100%; min-height:0; box-sizing:border-box; display:flex; flex-direction:column; overflow:hidden;", e.replaceChildren(n);
 	let r = {
@@ -9404,13 +9641,13 @@ function qd(e, t = {}) {
 		assetsByKey: /* @__PURE__ */ new Map(),
 		popoverManager: null
 	};
-	Kd(r), Pd(r), Ld(r, t.gridWrapper ?? null), ld(r), r.popoverManager = Li(n), r._disposeContextMenu = Wa({
+	$d(r), Vd(r), Wd(r, t.gridWrapper ?? null), gd(r), r.popoverManager = Li(n), r._disposeContextMenu = Ga({
 		gridContainer: r.grid,
 		getState: () => ({ scope: "output" })
-	}), Vd(r), Id(r.grid);
+	}), Jd(r), Ud(r.grid);
 	let i = () => {
 		try {
-			Id(r.grid);
+			Ud(r.grid);
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -9423,26 +9660,26 @@ function qd(e, t = {}) {
 		}
 	}, r;
 }
-function Jd(e) {
-	let t = kd(e);
-	if (t) for (let e of Array.from(ud.hosts)) try {
-		if (!e?.grid || (yd(e, t), !e.loaded)) continue;
-		e.empty.style.display = "none", bd(e);
+function tf(e) {
+	let t = Id(e);
+	if (t) for (let e of Array.from(_d.hosts)) try {
+		if (!e?.grid || (Ed(e, t), !e.loaded)) continue;
+		e.empty.style.display = "none", Dd(e);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Yd(e, t = {}) {
-	Fd(e);
-	let n = qd(e, t);
+function nf(e, t = {}) {
+	Hd(e);
+	let n = ef(e, t);
 	try {
 		e._mjrGeneratedFeedHost = n;
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return ud.hosts.add(n), jd(n), n;
+	return _d.hosts.add(n), Rd(n), n;
 }
-function Xd(e) {
+function rf(e) {
 	let t = e?._mjrGeneratedFeedHost || e || null;
 	if (!t) return;
 	let n = t.container || null;
@@ -9456,7 +9693,7 @@ function Xd(e) {
 		}
 		console.debug?.(e);
 	}
-	ud.hosts.delete(t);
+	_d.hosts.delete(t);
 	try {
 		t._disposeSelection?.();
 	} catch (e) {
@@ -9515,24 +9752,24 @@ function Xd(e) {
 }
 //#endregion
 //#region ui/features/stacks/executionAssetBuffer.ts
-function Zd(e) {
+function af(e) {
 	return String(e || "").trim();
 }
-function Qd(e) {
+function of(e) {
 	let t = String(e?.filename || "").trim(), n = String(e?.subfolder || "").trim();
 	return `${String(e?.type || "output").trim().toLowerCase()}|${String(e?.root_id || e?.custom_root_id || "").trim()}|${n}|${t}`;
 }
-function $d() {
+function sf() {
 	let e = /* @__PURE__ */ new Map();
 	function t(t, n) {
-		let r = Zd(t);
+		let r = af(t);
 		if (!r) return [];
 		let i = Array.isArray(n) ? n : [];
 		if (!i.length) return [];
 		let a = e.get(r);
 		a || (a = /* @__PURE__ */ new Map(), e.set(r, a));
 		for (let e of i) {
-			let t = Qd(e);
+			let t = of(e);
 			t && a.set(t, {
 				...a.get(t) || {},
 				...e || {}
@@ -9541,13 +9778,13 @@ function $d() {
 		return Array.from(a.values());
 	}
 	function n(t) {
-		let n = Zd(t);
+		let n = af(t);
 		if (!n) return [];
 		let r = e.get(n);
 		return e.delete(n), Array.from(r?.values?.() || []);
 	}
 	function r(t) {
-		let n = Zd(t);
+		let n = af(t);
 		n && e.delete(n);
 	}
 	return {
@@ -9559,7 +9796,7 @@ function $d() {
 }
 //#endregion
 //#region ui/features/stacks/finalizeQueue.ts
-function ef({ defaultDelayMs: e = 900, postJob: t } = {}) {
+function cf({ defaultDelayMs: e = 900, postJob: t } = {}) {
 	let n = /* @__PURE__ */ new Map(), r = /* @__PURE__ */ new Set(), i = !1;
 	async function a() {
 		if (!i) {
@@ -9597,27 +9834,27 @@ function ef({ defaultDelayMs: e = 900, postJob: t } = {}) {
 }
 //#endregion
 //#region ui/features/stacks/liveAssetGate.ts
-function tf(e) {
+function lf(e) {
 	return String(e || "").trim();
 }
-function nf(e) {
+function uf(e) {
 	let t = String(e?.filename || "").trim(), n = String(e?.filepath || "").trim(), r = String(e?.subfolder || "").trim();
 	return `${String(e?.type || e?.source || "output").trim().toLowerCase()}|${String(e?.root_id || e?.custom_root_id || "").trim()}|${r}|${t || n}`;
 }
-function rf(e, t) {
+function df(e, t) {
 	return !t || String(e?.job_id || "").trim() === t ? e : {
 		...e || {},
 		job_id: t
 	};
 }
-function af() {
+function ff() {
 	let e = /* @__PURE__ */ new Map();
 	function t(t, { files: n = [], expectedCount: r = null } = {}) {
-		let i = tf(t);
+		let i = lf(t);
 		if (!i) return;
 		let a = /* @__PURE__ */ new Set();
 		for (let e of Array.isArray(n) ? n : []) {
-			let t = nf(e);
+			let t = uf(e);
 			t && a.add(t);
 		}
 		e.set(i, {
@@ -9627,13 +9864,13 @@ function af() {
 		});
 	}
 	function n(t) {
-		let n = tf(t);
+		let n = lf(t);
 		n && e.delete(n);
 	}
 	function r(t) {
-		let n = tf(t?.job_id);
+		let n = lf(t?.job_id);
 		if (n) return n;
-		let r = nf(t);
+		let r = uf(t);
 		if (!r) return "";
 		let i = "", a = Infinity;
 		for (let [t, n] of e.entries()) n?.fileKeys?.has?.(r) && (n.markedAt ?? Infinity) < a && (a = n.markedAt ?? Infinity, i = t);
@@ -9646,7 +9883,7 @@ function af() {
 			jobId: "",
 			defer: !1
 		};
-		let i = rf(t, n), a = e.get(n);
+		let i = df(t, n), a = e.get(n);
 		if (!a) return {
 			detail: i,
 			jobId: n,
@@ -9669,20 +9906,20 @@ function af() {
 }
 //#endregion
 //#region ui/features/stacks/executionRuntimeController.ts
-var of = 2e3, sf = 2e3, cf = new Set([
+var pf = 2e3, mf = 2e3, hf = new Set([
 	"DB_MAINTENANCE",
 	"TIMEOUT",
 	"NETWORK_ERROR",
 	"SERVICE_UNAVAILABLE"
-]), lf = 8, uf = 1200, df = 15e3, ff = 600 * 1e3, pf = 500, mf = 6, hf = 3e4, gf = 500;
-function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensureExecutionRuntime: i, emitRuntimeStatus: a, refreshGeneratedFeedHosts: o, getActiveGridContainer: s }) {
-	let c = xe({
-		ttlMs: of,
-		maxSize: sf
-	}), l = xe({
-		ttlMs: ff,
-		maxSize: pf
-	}), u = Math.max(0, Number(z.EXECUTION_IDLE_GRACE_MS) || 6e3), d = /* @__PURE__ */ new Map(), f = $d(), p = af(), m = "", h = 0, g = null;
+]), gf = 8, _f = 1200, vf = 15e3, yf = 600 * 1e3, bf = 500, xf = 6, Sf = 3e4, Cf = 500;
+function wf({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensureExecutionRuntime: i, emitRuntimeStatus: a, refreshGeneratedFeedHosts: o, getActiveGridContainer: s }) {
+	let c = ce({
+		ttlMs: pf,
+		maxSize: mf
+	}), l = ce({
+		ttlMs: yf,
+		maxSize: bf
+	}), u = Math.max(0, Number(R.EXECUTION_IDLE_GRACE_MS) || 6e3), d = /* @__PURE__ */ new Map(), f = sf(), p = ff(), m = "", h = 0, g = null;
 	function _() {
 		try {
 			return typeof window > "u" ? !1 : window.__MJR_DEBUG_JOB_TRACKING__ === !0 ? !0 : String(window.localStorage?.getItem("mjr.debug.jobTracking") || "").trim() === "1";
@@ -9698,7 +9935,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 		}
 	}
 	function y() {
-		return !!z.EXECUTION_GROUPING_ENABLED;
+		return !!R.EXECUTION_GROUPING_ENABLED;
 	}
 	function b() {
 		let e = y();
@@ -9754,7 +9991,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			console.debug?.(e);
 		}
 	}
-	let S = ef({
+	let S = cf({
 		defaultDelayMs: 900,
 		async postJob(r) {
 			v("auto-stack:start", { job_id: r });
@@ -9792,7 +10029,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 	}
 	function T(e) {
 		let t = Math.max(1, Number(e) || 1), n = Math.min(6, t - 1);
-		return Math.min(df, uf * 2 ** n);
+		return Math.min(vf, _f * 2 ** n);
 	}
 	function E() {
 		g &&= (clearTimeout(g), null);
@@ -9810,7 +10047,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 	}
 	function O(e) {
 		let t = String(e?.code || "").trim().toUpperCase();
-		return cf.has(t);
+		return hf.has(t);
 	}
 	function k(r, i = 1, a = {}) {
 		let o = Array.isArray(r) ? r : [];
@@ -9825,7 +10062,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			files: o.map((e) => String(e?.filename || e?.filepath || ""))
 		}), e(t.INDEX_FILES, s).then((e) => {
 			if (!e?.ok) {
-				if (O(e) && i < lf) {
+				if (O(e) && i < gf) {
 					let e = T(i);
 					setTimeout(() => k(o, i + 1, a), e);
 					return;
@@ -9862,12 +10099,12 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 		let a = d.get(i);
 		a?.timer && clearTimeout(a.timer);
 		let o = a?.firstAttemptAt ?? Date.now();
-		if (Date.now() - o >= hf) {
+		if (Date.now() - o >= Sf) {
 			k(r, 1, t);
 			return;
 		}
 		let s = Math.max(1, Number(n) || 1), c = Math.min(2e3, 250 * s), l = setTimeout(() => {
-			d.delete(i), te(r, t, s + 1);
+			d.delete(i), P(r, t, s + 1);
 		}, c);
 		d.set(i, {
 			files: r,
@@ -9898,7 +10135,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			d.delete(e);
 		}
 	}
-	function te(e, t = {}, n = 1) {
+	function P(e, t = {}, n = 1) {
 		let r = A(t);
 		if (v("buffer:add", {
 			prompt_id: r,
@@ -9907,7 +10144,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			file_count: Array.isArray(e) ? e.length : 0,
 			files: Array.isArray(e) ? e.map((e) => String(e?.filename || e?.filepath || "")) : []
 		}), !r) {
-			if (n < mf) {
+			if (n < xf) {
 				M(e, t, n);
 				return;
 			}
@@ -9916,13 +10153,13 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 		}
 		f.add(r, e);
 	}
-	function ne(e, t = 900) {
+	function te(e, t = 900) {
 		y() && (v("finalize:schedule", {
 			job_id: String(e || ""),
 			delay_ms: t
 		}), S.schedule(e, t));
 	}
-	function P(r) {
+	function ne(r) {
 		let i = b(), a = String(r || "").trim();
 		if (!a) return;
 		let o = f.take(a);
@@ -9934,7 +10171,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			files: o,
 			expectedCount: o.length
 		}), !o.length) {
-			i.allowLiveStackFinalize && ne(a);
+			i.allowLiveStackFinalize && te(a);
 			return;
 		}
 		e(t.INDEX_FILES, {
@@ -9949,7 +10186,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			v("index:flush:done", {
 				prompt_id: a,
 				file_count: o.length
-			}), i.allowLiveStackFinalize && ne(a, 1800);
+			}), i.allowLiveStackFinalize && te(a, 1800);
 		}).catch((e) => {
 			i.allowLiveStackFinalize && p.clearPendingJob(a), n(e, "executionRuntime.executed.index");
 		});
@@ -10011,7 +10248,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			files: u.map((e) => String(e?.filename || e?.filepath || ""))
 		});
 		try {
-			window.dispatchEvent(new CustomEvent(B.NEW_GENERATION_OUTPUT, { detail: {
+			window.dispatchEvent(new CustomEvent(z.NEW_GENERATION_OUTPUT, { detail: {
 				files: u,
 				prompt_id: String(i || ""),
 				promptId: String(i || "")
@@ -10020,7 +10257,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			console.debug?.(e);
 		}
 		let d = u.length > 0 ? [u[0]] : [], f = u.length > 1 ? u.slice(1) : [];
-		d.length > 0 && k(d, 1, { prompt_id: i }), f.length > 0 && te(f, { prompt_id: i });
+		d.length > 0 && k(d, 1, { prompt_id: i }), f.length > 0 && P(f, { prompt_id: i });
 	}
 	function oe(e, { setCurrentJobId: t }) {
 		let n = e?.detail?.prompt_id || e?.detail?.promptId, r = e?.detail?.timestamp;
@@ -10050,10 +10287,10 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 			prompt_id: String(r || ""),
 			reason: String(e?.type || "")
 		}), E(), f.clear(r), n.allowLiveStackFinalize && p.clearPendingJob(r), ee()), String(e?.type || "") === "execution_success" && D(() => {
-			r && N(r), P(r);
-		}, F(r) ? Math.min(u, gf) : u);
+			r && N(r), ne(r);
+		}, F(r) ? Math.min(u, Cf) : u);
 	}
-	function I(e) {
+	function le(e) {
 		if (!y()) return;
 		let t = [];
 		for (let [, n] of e instanceof Map ? e.entries() : []) {
@@ -10063,7 +10300,7 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 		!t.length || !y() || (v("node-outputs:updated", {
 			prompt_id: A(),
 			file_count: t.length
-		}), te(t, { prompt_id: A() }));
+		}), P(t, { prompt_id: A() }));
 	}
 	return {
 		notifyStacksUpdated: x,
@@ -10072,12 +10309,12 @@ function _f({ post: e, ENDPOINTS: t, reportError: n, extractOutputFiles: r, ensu
 		handleExecutedEvent: ae,
 		handleExecutionStart: oe,
 		handleExecutionEnd: se,
-		handleNodeOutputsUpdated: I
+		handleNodeOutputsUpdated: le
 	};
 }
 //#endregion
 //#region ui/utils/extractOutputFiles.ts
-function vf(e) {
+function Tf(e) {
 	let t = [], n = /* @__PURE__ */ new Set(), r = 2e3, i = /\.(png|jpe?g|webp|gif|bmp|tiff?|avif|heic|heif|apng|hdr|svg|mp4|webm|mov|mkv|avi|m4v|mp3|wav|flac|ogg|glb|gltf|obj|fbx|ply|stl)$/i, a = typeof WeakSet < "u" ? /* @__PURE__ */ new WeakSet() : null, o = ({ type: e, subfolder: t, filename: n, path: r }) => r ? `path|${String(r).trim().toLowerCase()}` : `${e || ""}|${t || ""}|${n || ""}`.toLowerCase(), s = (e) => {
 		if (!e) return;
 		let r = e.path || e.filepath || e.fullpath || e.fullPath || e.full_path, i = e.filename;
@@ -10163,15 +10400,15 @@ function vf(e) {
 }
 //#endregion
 //#region ui/features/runtime/sidebarAssetBadge.ts
-var yf = "mjr-sidebar-asset-badge", bf = "mjr-sidebar-tab-has-badge", xf = "mjr-sidebar-asset-badge-style", Sf = 99, Cf = 0, wf = "majoor-assets", Tf = !1, Ef = /* @__PURE__ */ new Set();
-function Df() {
-	if (typeof document > "u" || document.getElementById(xf)) return;
+var Ef = "mjr-sidebar-asset-badge", Df = "mjr-sidebar-tab-has-badge", Of = "mjr-sidebar-asset-badge-style", kf = 99, Af = 0, jf = "majoor-assets", Mf = !1, Nf = /* @__PURE__ */ new Set();
+function Pf() {
+	if (typeof document > "u" || document.getElementById(Of)) return;
 	let e = document.createElement("style");
-	e.id = xf, e.textContent = `
-        .${bf} {
+	e.id = Of, e.textContent = `
+        .${Df} {
             position: relative !important;
         }
-        .${yf} {
+        .${Ef} {
             position: absolute;
             top: 3px;
             right: 3px;
@@ -10195,7 +10432,7 @@ function Df() {
         }
     `, document.head?.appendChild(e);
 }
-function Of(e) {
+function Ff(e) {
 	let t = String(e || "").trim();
 	if (!t) return [];
 	let n = (() => {
@@ -10214,81 +10451,81 @@ function Of(e) {
 		`[href="#${n}"]`
 	];
 }
-function kf(e) {
+function If(e) {
 	let t = `${e?.textContent || ""} ${e?.title || ""} ${e?.getAttribute?.("aria-label") || ""}`;
 	return /assets\s*manager|majoor/i.test(t);
 }
-function Af(e) {
+function Lf(e) {
 	return !e || typeof e != "object" ? !1 : typeof HTMLElement < "u" ? e instanceof HTMLElement : typeof e.querySelector == "function" && typeof e.appendChild == "function";
 }
-function jf() {
+function Rf() {
 	if (typeof document > "u") return null;
-	for (let e of Of(wf)) {
+	for (let e of Ff(jf)) {
 		let t = document.querySelector(e);
-		if (Af(t)) return t;
+		if (Lf(t)) return t;
 	}
 	let e = Array.from(document.querySelectorAll(".pi-folder, .pi-folder-open"));
 	for (let t of e) {
 		let e = t.closest?.("button,[role='tab'],a,.p-button,.comfyui-button,.sidebar-tab");
-		if (Af(e) && kf(e)) return e;
+		if (Lf(e) && If(e)) return e;
 	}
-	return Array.from(document.querySelectorAll("button,[role='tab'],a,.p-button,.comfyui-button,.sidebar-tab")).find((e) => Af(e) && kf(e)) || null;
+	return Array.from(document.querySelectorAll("button,[role='tab'],a,.p-button,.comfyui-button,.sidebar-tab")).find((e) => Lf(e) && If(e)) || null;
 }
-function Mf() {
-	Df();
-	let e = jf();
+function zf() {
+	Pf();
+	let e = Rf();
 	if (!e) return !1;
-	let t = e.querySelector(`:scope > .${yf}`);
-	return !Pf() || Cf <= 0 ? (t?.remove(), e.classList.remove(bf), !0) : (t || (t = document.createElement("span"), t.className = yf, t.setAttribute("aria-hidden", "true"), e.appendChild(t)), e.classList.add(bf), t.textContent = Cf > Sf ? `${Sf}+` : String(Cf), !0);
+	let t = e.querySelector(`:scope > .${Ef}`);
+	return !Vf() || Af <= 0 ? (t?.remove(), e.classList.remove(Df), !0) : (t || (t = document.createElement("span"), t.className = Ef, t.setAttribute("aria-hidden", "true"), e.appendChild(t)), e.classList.add(Df), t.textContent = Af > kf ? `${kf}+` : String(Af), !0);
 }
-function Nf() {
-	Mf(), typeof requestAnimationFrame == "function" && requestAnimationFrame(() => Mf()), setTimeout(() => Mf(), 250), setTimeout(() => Mf(), 1e3);
+function Bf() {
+	zf(), typeof requestAnimationFrame == "function" && requestAnimationFrame(() => zf()), setTimeout(() => zf(), 250), setTimeout(() => zf(), 1e3);
 }
-function Pf() {
-	return z.SIDEBAR_ASSET_BADGE_ENABLED !== !1;
+function Vf() {
+	return R.SIDEBAR_ASSET_BADGE_ENABLED !== !1;
 }
-function Ff(e = null) {
+function Hf(e = null) {
 	let t = String(e?.id || e?.asset_id || "").trim();
 	if (t) return `id:${t}`;
 	let n = String(e?.type || e?.source || "output").trim().toLowerCase(), r = String(e?.root_id || e?.custom_root_id || "").trim().toLowerCase(), i = String(e?.subfolder || e?.sub_folder || e?.subFolder || "").trim().toLowerCase(), a = String(e?.filename || "").trim().toLowerCase(), o = String(e?.filepath || e?.path || e?.fullpath || e?.full_path || "").trim().toLowerCase(), s = a || o;
 	return s ? `file:${n}|${r}|${i}|${s}` : "";
 }
-function If(e) {
+function Uf(e) {
 	if (!e) return !0;
-	if (Ef.has(e)) return !1;
-	if (Ef.add(e), Ef.size > 1e3) {
-		let e = Array.from(Ef).slice(-500);
-		Ef.clear();
-		for (let t of e) Ef.add(t);
+	if (Nf.has(e)) return !1;
+	if (Nf.add(e), Nf.size > 1e3) {
+		let e = Array.from(Nf).slice(-500);
+		Nf.clear();
+		for (let t of e) Nf.add(t);
 	}
 	return !0;
 }
-function Lf({ sidebarTabId: e } = {}) {
+function Wf({ sidebarTabId: e } = {}) {
 	let t = String(e || "").trim();
-	t && (wf = t), !Tf && typeof window < "u" && (Tf = !0, window.addEventListener?.("mjr-settings-changed", (e) => {
-		e?.detail?.key === "sidebar.assetBadgeEnabled" && (Pf() || (Cf = 0, Ef.clear()), Nf());
-	})), Nf();
+	t && (jf = t), !Mf && typeof window < "u" && (Mf = !0, window.addEventListener?.("mjr-settings-changed", (e) => {
+		e?.detail?.key === "sidebar.assetBadgeEnabled" && (Vf() || (Af = 0, Nf.clear()), Bf());
+	})), Bf();
 }
-function Rf(e = null) {
-	Pf() && If(Ff(e)) && (Cf += 1, Nf());
+function Gf(e = null) {
+	Vf() && Uf(Hf(e)) && (Af += 1, Bf());
 }
-function zf() {
-	Cf = 0, Ef.clear(), Nf();
+function Kf() {
+	Af = 0, Nf.clear(), Bf();
 }
 //#endregion
 //#region ui/features/runtime/pendingGeneratedAssets.ts
-var Bf = 0;
-function Vf(e = 1) {
+var qf = 0;
+function Jf(e = 1) {
 	let t = Math.max(1, Number(e) || 1);
-	Bf += t;
+	qf += t;
 	try {
-		window.__mjrPendingGeneratedAssetCount = Bf;
+		window.__mjrPendingGeneratedAssetCount = qf;
 	} catch {}
-	return Bf;
+	return qf;
 }
-function Hf() {
-	let e = Bf;
-	Bf = 0;
+function Yf() {
+	let e = qf;
+	qf = 0;
 	try {
 		window.__mjrPendingGeneratedAssetCount = 0;
 	} catch {}
@@ -10296,11 +10533,11 @@ function Hf() {
 }
 //#endregion
 //#region ui/features/runtime/registerRealtimeListeners.ts
-var Uf = 3e4, Wf = /* @__PURE__ */ new Map(), Gf = "live";
-function Kf(e) {
+var Xf = 3e4, Zf = /* @__PURE__ */ new Map(), Qf = "live";
+function $f(e) {
 	return e === !0 || e === 1 || e === "1" ? !0 : e === !1 || e === 0 || e === "0" ? !1 : null;
 }
-function qf(e) {
+function ep(e) {
 	let t = [
 		e?.has_ai_vector,
 		e?.hasAiVector,
@@ -10310,25 +10547,25 @@ function qf(e) {
 		e?.vectorIndexed
 	];
 	for (let e of t) {
-		let t = Kf(e);
+		let t = $f(e);
 		if (t !== null) return t;
 	}
 	return !1;
 }
-function Jf(e) {
-	let t = Date.now(), n = Number(Wf.get(e) || 0);
-	if (n > 0 && t - n < Uf) return !0;
-	if (Wf.set(e, t), Wf.size > 500) {
-		let e = t - 5 * Uf;
-		for (let [t, n] of Wf.entries()) Number(n) < e && Wf.delete(t);
+function tp(e) {
+	let t = Date.now(), n = Number(Zf.get(e) || 0);
+	if (n > 0 && t - n < Xf) return !0;
+	if (Zf.set(e, t), Zf.size > 500) {
+		let e = t - 5 * Xf;
+		for (let [t, n] of Zf.entries()) Number(n) < e && Zf.delete(t);
 	}
 	return !1;
 }
-function Yf(e) {
+function np(e) {
 	let t = String(e?.id || "").trim();
-	t && (qf(e) || Jf(t) || k(t).catch((e) => console.debug?.("[Majoor] auto vector index failed", e)));
+	t && (ep(e) || tp(t) || c(t).catch((e) => console.debug?.("[Majoor] auto vector index failed", e)));
 }
-function Xf(e) {
+function rp(e) {
 	let t = String(e?.kind || "").trim().toLowerCase();
 	if (t) return t;
 	let n = String(e?.filename || e?.filepath || e?.path || e?.fullpath || "").trim(), r = n.includes(".") && n.split(".").pop()?.toLowerCase?.() || "";
@@ -10368,8 +10605,8 @@ function Xf(e) {
 		"spz"
 	].includes(r) ? "model3d" : "unknown" : "";
 }
-function Zf(e, { jobId: t = "" } = {}) {
-	let n = String(e?.filename || "").trim(), r = String(e?.filepath || e?.path || e?.fullpath || e?.full_path || "").trim(), i = String(e?.subfolder || e?.sub_folder || e?.subFolder || "").trim(), a = String(e?.type || e?.source || "output").trim().toLowerCase(), o = String(e?.root_id || e?.custom_root_id || "").trim(), s = Xf(e);
+function ip(e, { jobId: t = "" } = {}) {
+	let n = String(e?.filename || "").trim(), r = String(e?.filepath || e?.path || e?.fullpath || e?.full_path || "").trim(), i = String(e?.subfolder || e?.sub_folder || e?.subFolder || "").trim(), a = String(e?.type || e?.source || "output").trim().toLowerCase(), o = String(e?.root_id || e?.custom_root_id || "").trim(), s = rp(e);
 	if (!s || !n && !r) return null;
 	let c = n || r.split(/[/\\]/).filter(Boolean).pop() || "";
 	if (!c) return null;
@@ -10380,7 +10617,7 @@ function Zf(e, { jobId: t = "" } = {}) {
 		c
 	].map((e) => String(e || "").trim().toLowerCase()).join("|"), d = Date.now() / 1e3, f = String(e?.job_id || t || "").trim();
 	return {
-		id: `${Gf}:${u || l.toLowerCase()}`,
+		id: `${Qf}:${u || l.toLowerCase()}`,
 		filename: c,
 		filepath: l,
 		path: l,
@@ -10403,7 +10640,7 @@ function Zf(e, { jobId: t = "" } = {}) {
 		_mjrLiveLabel: "In progress"
 	};
 }
-function Qf(e) {
+function ap(e) {
 	let t = String(e || "");
 	try {
 		if (typeof CSS < "u" && typeof CSS.escape == "function") return CSS.escape(t);
@@ -10412,11 +10649,11 @@ function Qf(e) {
 	}
 	return t.replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 }
-function $f(e, t) {
+function op(e, t) {
 	let n = String(e || "").trim().toLowerCase();
 	return n === "delete_db" ? t("btn.deleteDb", "Delete DB") : n === "reset_index" ? t("btn.resetIndex", "Reset index") : n === "restore_db" ? t("btn.dbRestore", "Restore DB") : t("btn.maintenance", "Maintenance");
 }
-function ep(e, t) {
+function sp(e, t) {
 	let n = String(e || "").trim().toLowerCase(), r = String(t || "").trim().toLowerCase(), i = {
 		delete_db: [
 			"started",
@@ -10450,7 +10687,7 @@ function ep(e, t) {
 		label: r.replace(/[_-]+/g, " ")
 	};
 }
-async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStreamModule: i, ensureExecutionRuntime: a, emitRuntimeStatus: o, getActiveGridContainer: s, pushGeneratedAsset: c, upsertAsset: l, upsertAssetNow: u, removeAssetsFromGrid: d, getEnrichmentState: f, setEnrichmentState: p, comfyToast: m, t: h, reportError: g, registerCleanableListener: _, syncExecutionBackendState: v }) {
+async function cp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStreamModule: i, ensureExecutionRuntime: a, emitRuntimeStatus: o, getActiveGridContainer: s, pushGeneratedAsset: c, upsertAsset: l, upsertAssetNow: u, removeAssetsFromGrid: d, getEnrichmentState: f, setEnrichmentState: p, comfyToast: m, t: h, reportError: g, registerCleanableListener: _, syncExecutionBackendState: v }) {
 	e._mjrExecutedHandler = (e) => {
 		try {
 			n.handleExecutedEvent(e, { appRef: r });
@@ -10503,7 +10740,7 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 		} catch (e) {
 			g(e, "entry.execution_cached");
 		}
-	}, _(t, e, "execution_start", e._mjrExecutionStartHandler), _(t, e, "execution_success", e._mjrExecutionEndHandler), _(t, e, "execution_error", e._mjrExecutionEndHandler), _(t, e, "execution_interrupted", e._mjrExecutionEndHandler), _(t, e, "mjr.stacks.updated", e._mjrStacksUpdatedHandler), _(t, e, "progress", e._mjrRuntimeStatusHandler), _(t, e, "status", e._mjrRuntimeStatusHandler), _(t, e, B.RUNTIME_STATUS, e._mjrRuntimeStatusHandler), _(t, e, "execution_cached", e._mjrExecutionCachedHandler);
+	}, _(t, e, "execution_start", e._mjrExecutionStartHandler), _(t, e, "execution_success", e._mjrExecutionEndHandler), _(t, e, "execution_error", e._mjrExecutionEndHandler), _(t, e, "execution_interrupted", e._mjrExecutionEndHandler), _(t, e, "mjr.stacks.updated", e._mjrStacksUpdatedHandler), _(t, e, "progress", e._mjrRuntimeStatusHandler), _(t, e, "status", e._mjrRuntimeStatusHandler), _(t, e, z.RUNTIME_STATUS, e._mjrRuntimeStatusHandler), _(t, e, "execution_cached", e._mjrExecutionCachedHandler);
 	function y() {
 		try {
 			window.__mjrLastAssetUpsert = Date.now(), window.__mjrLastAssetUpsertCount = (Number(window.__mjrLastAssetUpsertCount || 0) || 0) + 1;
@@ -10514,7 +10751,7 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 	function b(e, t, { immediate: n = !1, force: r = !1 } = {}) {
 		let i = String(t?.id || "").trim(), a = String(t?.kind || "").trim(), o = String(t?.filename || "").trim(), s = String(t?.filepath || "").trim(), c = !!a && (!!o || !!s), d = !1;
 		if (i) try {
-			d = typeof e?._mjrHasAssetId == "function" ? !!e._mjrHasAssetId(i) : !!e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Qf(i)}"]`);
+			d = typeof e?._mjrHasAssetId == "function" ? !!e._mjrHasAssetId(i) : !!e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${ap(i)}"]`);
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -10543,7 +10780,7 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 			if (n !== "output" && n !== "all") return;
 			let r = Array.isArray(e?.detail?.files) ? e.detail.files : [], i = String(e?.detail?.prompt_id || e?.detail?.promptId || "").trim();
 			for (let e of r) {
-				let n = Zf(e, { jobId: i });
+				let n = ip(e, { jobId: i });
 				n && b(t, n, {
 					immediate: !0,
 					force: !0
@@ -10552,25 +10789,25 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 		} catch (e) {
 			g(e, "entry.new_generation_output");
 		}
-	}, _(t, window, B.NEW_GENERATION_OUTPUT, e._mjrNewGenerationOutputHandler), e._mjrAssetAddedHandler = (e) => {
+	}, _(t, window, z.NEW_GENERATION_OUTPUT, e._mjrNewGenerationOutputHandler), e._mjrAssetAddedHandler = (e) => {
 		try {
 			if (!e?.detail) return;
 			let t = n.prepareLiveAssetEvent(e.detail), r = t?.detail || e.detail;
 			if (t?.defer) return;
 			let i = n.isRenderableLiveAsset(r);
-			i && c(r), Yf(r);
+			i && c(r), np(r);
 			let a = s();
 			if (!a) {
-				i && Vf();
+				i && Jf();
 				return;
 			}
 			let o = a.dataset?.mjrScope || "output";
 			if (o !== "output" && o !== "all") {
-				i && Vf();
+				i && Jf();
 				return;
 			}
 			let l = a.dataset?.mjrQuery || "*";
-			String(l).trim() === "*" && i ? b(a, r, { immediate: !0 }) || Vf() : i && Vf();
+			String(l).trim() === "*" && i ? b(a, r, { immediate: !0 }) || Jf() : i && Jf();
 		} catch (e) {
 			g(e, "entry.asset_added");
 		}
@@ -10589,23 +10826,23 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 	}, _(t, e, "mjr-asset-updated", e._mjrAssetUpdatedHandler), e._mjrStructuredEventHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			window.dispatchEvent(new CustomEvent(B.STRUCTURED_EVENT, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.STRUCTURED_EVENT, { detail: t }));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.STRUCTURED_EVENT, e._mjrStructuredEventHandler), e._mjrScanCompleteHandler = (e) => {
+	}, _(t, e, z.STRUCTURED_EVENT, e._mjrStructuredEventHandler), e._mjrScanCompleteHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			window.dispatchEvent(new CustomEvent(B.SCAN_COMPLETE, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.SCAN_COMPLETE, { detail: t }));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.SCAN_COMPLETE, e._mjrScanCompleteHandler), e._mjrCoreExecutionAssetsReadyHandler = (e) => {
+	}, _(t, e, z.SCAN_COMPLETE, e._mjrScanCompleteHandler), e._mjrCoreExecutionAssetsReadyHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			window.dispatchEvent(new CustomEvent(B.CORE_EXECUTION_ASSETS_READY, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.CORE_EXECUTION_ASSETS_READY, { detail: t }));
 			let n = Number(t?.indexed || 0);
-			Number.isFinite(n) && n > 0 && window.dispatchEvent(new CustomEvent(B.RELOAD_GRID, { detail: {
+			Number.isFinite(n) && n > 0 && window.dispatchEvent(new CustomEvent(z.RELOAD_GRID, { detail: {
 				reason: "core-execution-assets-ready",
 				prompt_id: t?.prompt_id || t?.promptId || "",
 				indexed: n
@@ -10613,27 +10850,27 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.CORE_EXECUTION_ASSETS_READY, e._mjrCoreExecutionAssetsReadyHandler), e._mjrScanProgressHandler = (e) => {
+	}, _(t, e, z.CORE_EXECUTION_ASSETS_READY, e._mjrCoreExecutionAssetsReadyHandler), e._mjrScanProgressHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			window.dispatchEvent(new CustomEvent(B.SCAN_PROGRESS, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.SCAN_PROGRESS, { detail: t }));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.SCAN_PROGRESS, e._mjrScanProgressHandler), e._mjrAssetIndexingHandler = (e) => {
+	}, _(t, e, z.SCAN_PROGRESS, e._mjrScanProgressHandler), e._mjrAssetIndexingHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			window.dispatchEvent(new CustomEvent(B.ASSET_INDEXING, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.ASSET_INDEXING, { detail: t }));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.ASSET_INDEXING, e._mjrAssetIndexingHandler), e._mjrAssetIndexedHandler = (e) => {
+	}, _(t, e, z.ASSET_INDEXING, e._mjrAssetIndexingHandler), e._mjrAssetIndexedHandler = (e) => {
 		try {
 			let t = e?.detail || {};
-			if (window.dispatchEvent(new CustomEvent(B.ASSET_INDEXED, { detail: t })), !t) return;
+			if (window.dispatchEvent(new CustomEvent(z.ASSET_INDEXED, { detail: t })), !t) return;
 			let r = n.prepareLiveAssetEvent(t), i = r?.detail || t;
 			if (r?.defer) return;
-			n.isRenderableLiveAsset(i) && (c(i), Rf(i)), Yf(i);
+			n.isRenderableLiveAsset(i) && (c(i), Gf(i)), np(i);
 			let a = s();
 			if (!a) return;
 			b(a, i, {
@@ -10643,17 +10880,17 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.ASSET_INDEXED, e._mjrAssetIndexedHandler), e._mjrEnrichmentStatusHandler = (e) => {
+	}, _(t, e, z.ASSET_INDEXED, e._mjrAssetIndexedHandler), e._mjrEnrichmentStatusHandler = (e) => {
 		try {
 			let t = e?.detail || {}, n = Number(t?.queued), r = Number(t?.queue_left), i = Number.isFinite(n) ? Math.max(0, Math.floor(n)) : Number.isFinite(r) ? Math.max(0, Math.floor(r)) : 0, a = !!t?.active || i > 0, o = f().active;
-			p(a, i), window.dispatchEvent(new CustomEvent(B.ENRICHMENT_STATUS, { detail: t })), o && !a && m(h("toast.enrichmentComplete", "Metadata enrichment complete"), "success", 2600);
+			p(a, i), window.dispatchEvent(new CustomEvent(z.ENRICHMENT_STATUS, { detail: t })), o && !a && m(h("toast.enrichmentComplete", "Metadata enrichment complete"), "success", 2600);
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.ENRICHMENT_STATUS, e._mjrEnrichmentStatusHandler), e._mjrDbRestoreStatusHandler = (e) => {
+	}, _(t, e, z.ENRICHMENT_STATUS, e._mjrEnrichmentStatusHandler), e._mjrDbRestoreStatusHandler = (e) => {
 		try {
 			let t = e?.detail || {}, n = String(t?.step || ""), r = String(t?.level || "info"), i = String(t?.operation || "");
-			window.dispatchEvent(new CustomEvent(B.DB_RESTORE_STATUS, { detail: t }));
+			window.dispatchEvent(new CustomEvent(z.DB_RESTORE_STATUS, { detail: t }));
 			let a = i === "delete_db", o = i === "reset_index", s = {
 				started: a ? h("toast.dbDeleteTriggered", "Deleting database and rebuilding...") : o ? h("toast.resetTriggered", "Reset triggered: Reindexing all files...") : h("toast.dbRestoreStarted", "DB restore started"),
 				stopping_workers: h("toast.dbRestoreStopping", "Stopping running workers"),
@@ -10668,11 +10905,11 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 			if (!s) return;
 			let c = r === "error" || n === "failed" ? "error" : n === "done" ? "success" : "info", l = { history: {
 				trackId: `maintenance:${String(i || "db_restore").trim().toLowerCase() || "db_restore"}`,
-				title: $f(i, h),
+				title: op(i, h),
 				detail: s,
 				status: n,
 				operation: String(i || "db_restore").trim().toLowerCase(),
-				progress: ep(i, n),
+				progress: sp(i, n),
 				source: String(t?.name || "").trim() || "maintenance",
 				forceStore: !0
 			} };
@@ -10681,15 +10918,15 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 				"done",
 				"failed"
 			].includes(n)) {
-				j(s, c, 0, l);
+				x(s, c, 0, l);
 				return;
 			}
 			m(s, c, n === "done" || n === "failed" ? 2800 : 1800, l);
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, _(t, e, B.DB_RESTORE_STATUS, e._mjrDbRestoreStatusHandler);
-	let x = (e) => {
+	}, _(t, e, z.DB_RESTORE_STATUS, e._mjrDbRestoreStatusHandler);
+	let S = (e) => {
 		try {
 			let t = Array.isArray(e?.detail?.ids) ? e.detail.ids.map((e) => String(e || "")).filter(Boolean) : [];
 			if (!t.length) return;
@@ -10699,11 +10936,11 @@ async function tp({ api: e, runtime: t, executionRuntime: n, appRef: r, liveStre
 			console.debug?.(e);
 		}
 	};
-	_(t, window, B.ASSETS_DELETED, x), t && typeof t == "object" && (t.api = e, t.assetsDeletedHandler = x), console.debug("[Majoor] Real-time listener registered");
+	_(t, window, z.ASSETS_DELETED, S), t && typeof t == "object" && (t.api = e, t.assetsDeletedHandler = S), console.debug("[Majoor] Real-time listener registered");
 }
 //#endregion
 //#region ui/features/runtime/entryDebugApi.ts
-function np({ resolveNodeStreamModule: e }) {
+function lp({ resolveNodeStreamModule: e }) {
 	typeof window > "u" || (window.MajoorDebug = {
 		exportMetrics: () => window.MajoorMetrics?.exportMetrics?.(),
 		getMetrics: () => window.MajoorMetrics?.getMetricsReport?.(),
@@ -10719,16 +10956,16 @@ function np({ resolveNodeStreamModule: e }) {
 }
 //#endregion
 //#region ui/features/runtime/benignConsoleNoise.ts
-var rp = ["ResizeObserver loop completed with undelivered notifications.", "ResizeObserver loop limit exceeded"];
-function ip(e) {
+var up = ["ResizeObserver loop completed with undelivered notifications.", "ResizeObserver loop limit exceeded"];
+function dp(e) {
 	try {
 		let t = String(e?.message || e || "");
-		return rp.some((e) => t.includes(e));
+		return up.some((e) => t.includes(e));
 	} catch {
 		return !1;
 	}
 }
-function ap() {
+function fp() {
 	if (typeof window > "u") return null;
 	try {
 		window.__MJR_BENIGN_CONSOLE_NOISE_FILTER__?.abort?.();
@@ -10743,7 +10980,7 @@ function ap() {
 	}
 	let t = (e) => {
 		try {
-			if (!ip(e?.message || e?.error)) return;
+			if (!dp(e?.message || e?.error)) return;
 			e.preventDefault?.(), e.stopImmediatePropagation?.();
 		} catch (e) {
 			console.debug?.(e);
@@ -10769,7 +11006,7 @@ function ap() {
 }
 //#endregion
 //#region ui/features/geninfo/genInfoOverridePicker.ts
-var op = "Majoor.GenInfoOverridePicker", sp = "MajoorGenInfoOverride", cp = R("genInfoOverride.autoFillFromWorkflow", "Auto fill from workflow"), lp = R("genInfoOverride.pick", "Pick"), up = {
+var pp = "Majoor.GenInfoOverridePicker", mp = "MajoorGenInfoOverride", hp = L("genInfoOverride.autoFillFromWorkflow", "Auto fill from workflow"), gp = L("genInfoOverride.pick", "Pick"), _p = {
 	positive_prompt: [
 		"positive_prompt",
 		"prompt",
@@ -10792,7 +11029,7 @@ var op = "Majoor.GenInfoOverridePicker", sp = "MajoorGenInfoOverride", cp = R("g
 	],
 	vae: ["vae", "vae_name"],
 	clip: ["clip", "clip_name"]
-}, dp = [
+}, vp = [
 	{
 		field: "positive_prompt",
 		label: "prompt"
@@ -10837,14 +11074,14 @@ var op = "Majoor.GenInfoOverridePicker", sp = "MajoorGenInfoOverride", cp = R("g
 		field: "denoise",
 		label: "denoise"
 	}
-], fp = 0x10000000000000000, pp = !1, mp = !1;
-function hp(e, t) {
+], yp = 0x10000000000000000, bp = !1, xp = !1;
+function Sp(e, t) {
 	let n = (e.widgets ?? []).find((e) => e?.name === t);
 	if (n && n.value !== void 0 && n.value !== null && String(n.value).trim() !== "") return n.value;
 	let r = Array.isArray(e.widgets_values) ? e.widgets_values : [], i = (Array.isArray(e.widgets) ? e.widgets : []).findIndex((e) => e?.name === t);
 	return i >= 0 ? r[i] : void 0;
 }
-function gp(e, t, n, r, i) {
+function Cp(e, t, n, r, i) {
 	if (r == null || String(r).trim() === "") return;
 	let a = `${n}:${String(r).trim()}`;
 	t.has(a) || (t.add(a), e.push({
@@ -10854,42 +11091,42 @@ function gp(e, t, n, r, i) {
 		source: i
 	}));
 }
-function _p(e, t, n) {
+function wp(e, t, n) {
 	let r = t.toLowerCase();
-	return !!((up[e] ?? [e]).some((e) => r === e || r.includes(e)) || e === "positive_prompt" && r === "text" && n.toLowerCase().includes("positive") || e === "negative_prompt" && (r.includes("negative") || n.toLowerCase().includes("negative")));
+	return !!((_p[e] ?? [e]).some((e) => r === e || r.includes(e)) || e === "positive_prompt" && r === "text" && n.toLowerCase().includes("positive") || e === "negative_prompt" && (r.includes("negative") || n.toLowerCase().includes("negative")));
 }
-function vp(e, t = null) {
+function Tp(e, t = null) {
 	let n = [], r = /* @__PURE__ */ new Set();
 	for (let { graph: i, label: a } of gt(e)) for (let e of mt(i)) {
-		if (String(e?.comfyClass || e?.type || "") === sp) continue;
+		if (String(e?.comfyClass || e?.type || "") === mp) continue;
 		let i = String(e?.title || e?.comfyClass || e?.type || `Node ${e?.id ?? ""}`).trim(), o = a === "Workflow" ? i : `${a} / ${i}`;
-		for (let [t, i] of Object.entries(up)) for (let a of i) gp(n, r, t, hp(e, a), o);
+		for (let [t, i] of Object.entries(_p)) for (let a of i) Cp(n, r, t, Sp(e, a), o);
 		let s = Array.isArray(e.widgets) ? e.widgets : [], c = Array.isArray(e.widgets_values) ? e.widgets_values : [];
 		s.forEach((e, a) => {
 			let s = String(e?.name || "").toLowerCase(), l = e?.value ?? c[a];
-			s.includes("positive") || s === "text" && String(i).toLowerCase().includes("positive") ? gp(n, r, "positive_prompt", l, o) : s.includes("negative") && gp(n, r, "negative_prompt", l, o), t && _p(t, s, i) && gp(n, r, t, l, `${o} / ${e?.name || `widget ${a + 1}`}`);
+			s.includes("positive") || s === "text" && String(i).toLowerCase().includes("positive") ? Cp(n, r, "positive_prompt", l, o) : s.includes("negative") && Cp(n, r, "negative_prompt", l, o), t && wp(t, s, i) && Cp(n, r, t, l, `${o} / ${e?.name || `widget ${a + 1}`}`);
 		});
 	}
 	return t ? n.filter((e) => e.field === t).slice(0, 120) : n.slice(0, 80);
 }
-function yp(e, t) {
+function Ep(e, t) {
 	return (e.widgets ?? []).find((e) => e?.name === t);
 }
-function bp(e) {
-	let t = yp(e, "seed");
+function Dp(e) {
+	let t = Ep(e, "seed");
 	t && (t.options = {
 		...t.options ?? {},
 		min: -1,
-		max: fp,
+		max: yp,
 		control_after_generate: !1
 	});
 }
-function xp(e, t) {
+function Op(e, t) {
 	return t === "positive_prompt" ? e?.prompt ?? e?.positive_prompt : t === "negative_prompt" ? e?.negative_prompt ?? e?.negative : t === "loras_json" && Array.isArray(e?.loras) ? JSON.stringify(e.loras) : t === "custom_info_json" && Array.isArray(e?.custom_info) ? JSON.stringify(e.custom_info) : e?.[t];
 }
-function Sp(e, t) {
+function kp(e, t) {
 	if (!e || !t || typeof t != "object") return 0;
-	bp(e);
+	Dp(e);
 	let n = 0;
 	for (let r of [
 		"positive_prompt",
@@ -10907,14 +11144,14 @@ function Sp(e, t) {
 		"workflow_notes",
 		"custom_info_json"
 	]) {
-		let i = xp(t, r);
+		let i = Op(t, r);
 		if (i == null) continue;
-		let a = yp(e, r);
-		a && (Cp(a, i, e, r), wp(a, i), n += 1);
+		let a = Ep(e, r);
+		a && (Ap(a, i, e, r), jp(a, i), n += 1);
 	}
 	return n;
 }
-function Cp(e, t, n, r) {
+function Ap(e, t, n, r) {
 	if (r !== "seed") {
 		Gn(e, t, n);
 		return;
@@ -10924,15 +11161,15 @@ function Cp(e, t, n, r) {
 		e.options = {
 			...e.options ?? {},
 			min: -1,
-			max: fp,
+			max: yp,
 			control_after_generate: !1
 		}, e.value = Math.trunc(i);
 		try {
-			e.callback?.(e.value, tt()?.canvas ?? null, n, null, e);
+			e.callback?.(e.value, nt()?.canvas ?? null, n, null, e);
 		} catch {}
 	}
 }
-function wp(e, t) {
+function jp(e, t) {
 	let n = String(t ?? ""), r = [
 		e?.inputEl,
 		e?.element,
@@ -10945,26 +11182,26 @@ function wp(e, t) {
 		e.value = n;
 	} catch {}
 }
-function Tp(e, t, n) {
-	let r = Ap({ detail: { output: t } });
-	if (r && Sp(e, r)) try {
+function Mp(e, t, n) {
+	let r = Lp({ detail: { output: t } });
+	if (r && kp(e, r)) try {
 		e.setSize?.(e.computeSize?.()), e.graph?.setDirtyCanvas?.(!0, !0), e.graph?.change?.(), n?.graph?.setDirtyCanvas?.(!0, !0), n?.graph?.change?.(), n?.canvas?.setDirty?.(!0, !0), n?.canvas?.draw?.(!0, !0);
 	} catch {}
 }
-function Ep(e, t, n = null) {
-	let r = n || t.field, i = yp(e, r);
-	i && (Cp(i, t.value, e, r), wp(i, t.value));
+function Np(e, t, n = null) {
+	let r = n || t.field, i = Ep(e, r);
+	i && (Ap(i, t.value, e, r), jp(i, t.value));
 }
-function Dp(e) {
+function Pp(e) {
 	return !e || e.value === void 0 || e.value === null || String(e.value).trim() === "";
 }
-function Op(e, t) {
-	let n = vp(t), r = 0;
-	for (let t of Object.keys(up)) {
-		let i = yp(e, t);
-		if (!i || !Dp(i)) continue;
+function Fp(e, t) {
+	let n = Tp(t), r = 0;
+	for (let t of Object.keys(_p)) {
+		let i = Ep(e, t);
+		if (!i || !Pp(i)) continue;
 		let a = n.find((e) => e.field === t);
-		a && (Cp(i, a.value, e, t), wp(i, a.value), r += 1);
+		a && (Ap(i, a.value, e, t), jp(i, a.value), r += 1);
 	}
 	return t?.graph?.setDirtyCanvas?.(!0, !0), t?.graph?.change?.(), t?.extensionManager?.toast?.add?.({
 		severity: r ? "success" : "warn",
@@ -10973,34 +11210,34 @@ function Op(e, t) {
 		life: 3e3
 	}), r;
 }
-function kp(e, t) {
-	if (!(!e || String(e?.comfyClass || e?.type || "") !== sp) && (bp(e), !(e.widgets ?? []).some((e) => e?.name === cp) && typeof e.addWidget == "function")) {
-		e.addWidget("button", cp, null, () => Op(e, t));
-		for (let n of dp) {
-			let r = `${lp} ${n.label}`;
-			(e.widgets ?? []).some((e) => e?.name === r) || e.addWidget("button", r, null, () => Mp(e, t, n.field));
+function Ip(e, t) {
+	if (!(!e || String(e?.comfyClass || e?.type || "") !== mp) && (Dp(e), !(e.widgets ?? []).some((e) => e?.name === hp) && typeof e.addWidget == "function")) {
+		e.addWidget("button", hp, null, () => Fp(e, t));
+		for (let n of vp) {
+			let r = `${gp} ${n.label}`;
+			(e.widgets ?? []).some((e) => e?.name === r) || e.addWidget("button", r, null, () => zp(e, t, n.field));
 		}
 		try {
 			e.setSize?.(e.computeSize?.()), t?.graph?.setDirtyCanvas?.(!0, !0);
 		} catch {}
 	}
 }
-function Ap(e) {
+function Lp(e) {
 	let t = e?.detail?.output, n = t?.majoor_geninfo_override ?? t?.ui?.majoor_geninfo_override, r = Array.isArray(n) ? n[0] : n;
 	return r && typeof r == "object" ? r : null;
 }
-function jp(e) {
-	if (mp) return;
+function Rp(e) {
+	if (xp) return;
 	let t = e?.api;
-	!t || typeof t.addEventListener != "function" || (mp = !0, t.addEventListener("executed", (t) => {
+	!t || typeof t.addEventListener != "function" || (xp = !0, t.addEventListener("executed", (t) => {
 		let n = t?.detail?.node ?? t?.detail?.display_node;
 		if (!n) return;
 		let r = ht(e, n);
-		!r || String(r?.comfyClass || r?.type || "") !== sp || Tp(r, t?.detail?.output, e);
+		!r || String(r?.comfyClass || r?.type || "") !== mp || Mp(r, t?.detail?.output, e);
 	}));
 }
-function Mp(e, t, n = null) {
-	let r = vp(t, n);
+function zp(e, t, n = null) {
+	let r = Tp(t, n);
 	if (!r.length) {
 		t?.extensionManager?.toast?.add?.({
 			severity: "warn",
@@ -11014,63 +11251,63 @@ function Mp(e, t, n = null) {
 	i.style.cssText = "position:fixed;inset:0;z-index:1000000;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center";
 	let a = document.createElement("div");
 	a.style.cssText = "width:min(720px,92vw);max-height:80vh;overflow:auto;background:#202020;color:#eee;border:1px solid #555;border-radius:8px;padding:12px;box-shadow:0 16px 48px rgba(0,0,0,.55);font:12px sans-serif";
-	let o = n ? R("genInfoOverride.pickField", "Pick {field}", { field: n.replace(/_/g, " ") }) : R("genInfoOverride.pickFromWorkflow", "Pick Gen Info from workflow");
+	let o = n ? L("genInfoOverride.pickField", "Pick {field}", { field: n.replace(/_/g, " ") }) : L("genInfoOverride.pickFromWorkflow", "Pick Gen Info from workflow");
 	a.innerHTML = "<div style=\"display:flex;justify-content:space-between;align-items:center;margin-bottom:10px\"><strong></strong><button data-close style=\"background:#333;color:#eee;border:1px solid #555;border-radius:4px;padding:4px 8px;cursor:pointer\"></button></div>";
 	let s = a.querySelector("strong");
 	s && (s.textContent = o);
 	let c = a.querySelector("[data-close]");
-	c && (c.textContent = R("dialog.close", "Close"));
+	c && (c.textContent = L("dialog.close", "Close"));
 	for (let t of r) {
 		let r = document.createElement("button");
 		r.type = "button", r.style.cssText = "width:100%;display:grid;grid-template-columns:130px 1fr 150px;gap:8px;text-align:left;background:#2b2b2b;color:#eee;border:1px solid #3d3d3d;border-radius:5px;padding:7px;margin:5px 0;cursor:pointer", r.innerHTML = `<span style="color:#7ec8ff">${t.label}</span><span style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis"></span><span style="opacity:.7;white-space:nowrap;overflow:hidden;text-overflow:ellipsis"></span>`, r.children[1].textContent = String(t.value), r.children[2].textContent = t.source, r.onclick = () => {
-			Ep(e, t, n), i.remove();
+			Np(e, t, n), i.remove();
 		}, a.appendChild(r);
 	}
 	i.appendChild(a), a.querySelector("[data-close]")?.addEventListener("click", () => i.remove()), i.addEventListener("click", (e) => {
 		e.target === i && i.remove();
 	}), document.body.appendChild(i);
 }
-function Np(e, t) {
-	if (String(e?.comfyClass || e?.type || "") !== sp) return [];
+function Bp(e, t) {
+	if (String(e?.comfyClass || e?.type || "") !== mp) return [];
 	let n = [{
-		content: R("genInfoOverride.pickFromWorkflow", "Pick Gen Info from workflow"),
-		callback: () => Mp(e, t)
+		content: L("genInfoOverride.pickFromWorkflow", "Pick Gen Info from workflow"),
+		callback: () => zp(e, t)
 	}];
-	for (let r of dp) n.push({
+	for (let r of vp) n.push({
 		content: `Pick ${r.label}`,
-		callback: () => Mp(e, t, r.field)
+		callback: () => zp(e, t, r.field)
 	});
 	return n.push({
-		content: cp,
-		callback: () => Op(e, t)
+		content: hp,
+		callback: () => Fp(e, t)
 	}), n;
 }
-function Pp(e = null) {
-	if (pp) return;
-	let t = e || tt();
+function Vp(e = null) {
+	if (bp) return;
+	let t = e || nt();
 	if (!t || typeof t.registerExtension != "function") {
-		setTimeout(() => Pp(e), 100);
+		setTimeout(() => Vp(e), 100);
 		return;
 	}
-	pp = !0, jp(t), t.registerExtension({
-		name: op,
+	bp = !0, Rp(t), t.registerExtension({
+		name: pp,
 		async nodeCreated(e) {
-			kp(e, t);
+			Ip(e, t);
 		},
 		getNodeMenuItems(e) {
-			return Np(e, t);
+			return Bp(e, t);
 		}
 	}), setTimeout(() => {
-		for (let { graph: e } of gt(t)) for (let n of mt(e)) kp(n, t);
+		for (let { graph: e } of gt(t)) for (let n of mt(e)) Ip(n, t);
 	}, 0);
 }
 //#endregion
 //#region ui/vue/composables/useDragDrop.ts
-function Fp() {
+function Hp() {
 	let e = null;
 	fr(() => {
 		try {
-			e = fs() ?? null;
+			e = ps() ?? null;
 		} catch (e) {
 			console.warn("[Majoor] useDragDrop: init failed", e);
 		}
@@ -11081,7 +11318,7 @@ function Fp() {
 			console.debug?.(e);
 		}
 		try {
-			ps({ force: !0 });
+			ms({ force: !0 });
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -11090,23 +11327,23 @@ function Fp() {
 }
 //#endregion
 //#region ui/vue/GlobalRuntime.vue
-var Ip = {
+var Up = {
 	__name: "GlobalRuntime",
 	setup(e) {
-		let t = ur(() => import("./chunks/ViewerPortal-CZwsOKUD.js")), n = Z(!1), r = [
-			B.OPEN_VIEWER,
-			B.MFV_OPEN,
-			B.MFV_TOGGLE,
-			B.MFV_LIVE_TOGGLE,
-			B.MFV_PREVIEW_TOGGLE,
-			B.MFV_NODESTREAM_TOGGLE,
-			B.MFV_POPOUT
+		let t = ur(() => import("./chunks/ViewerPortal-dpNifhYe.js")), n = Z(!1), r = [
+			z.OPEN_VIEWER,
+			z.MFV_OPEN,
+			z.MFV_TOGGLE,
+			z.MFV_LIVE_TOGGLE,
+			z.MFV_PREVIEW_TOGGLE,
+			z.MFV_NODESTREAM_TOGGLE,
+			z.MFV_POPOUT
 		];
 		function i(e) {
 			if (n.value) return;
 			n.value = !0;
 			let t = String(e?.type || ""), r = e?.detail || null;
-			!t || t === B.OPEN_VIEWER || or(() => {
+			!t || t === z.OPEN_VIEWER || or(() => {
 				try {
 					window.dispatchEvent(new CustomEvent(t, { detail: r }));
 				} catch (e) {
@@ -11114,7 +11351,7 @@ var Ip = {
 				}
 			});
 		}
-		return Fp(), fr(() => {
+		return Hp(), fr(() => {
 			for (let e of r) try {
 				window.addEventListener(e, i, { once: !1 });
 			} catch (e) {
@@ -11128,7 +11365,7 @@ var Ip = {
 			}
 		}), (e, r) => n.value ? (V(), nr(K(t), { key: 0 })) : W("", !0);
 	}
-}, Lp = {
+}, Wp = {
 	gridRenderCount: 0,
 	gridRenderTotalMs: 0,
 	searchQueryCount: 0,
@@ -11139,20 +11376,20 @@ var Ip = {
 	thumbnailLoadCount: 0,
 	thumbnailLoadFailures: 0,
 	errorCounts: {}
-}, Rp = /* @__PURE__ */ new Map();
-function zp(e) {
+}, Gp = /* @__PURE__ */ new Map();
+function Kp(e) {
 	let t = performance.now();
-	Rp.set(e, t);
+	Gp.set(e, t);
 	try {
 		performance.mark(`${e}-start`);
 	} catch {}
 }
-function Bp(e, t) {
-	let n = Rp.get(e);
+function qp(e, t) {
+	let n = Gp.get(e);
 	if (!n) return console.warn(`[Majoor Metrics] Timer not found: ${e}`), 0;
 	let r = performance.now() - n;
-	if (Rp.delete(e), t) {
-		let e = `${t}Count`, n = `${t}TotalMs`, i = Lp;
+	if (Gp.delete(e), t) {
+		let e = `${t}Count`, n = `${t}TotalMs`, i = Wp;
 		typeof i[e] == "number" && (i[e]++, i[n] += r);
 	}
 	r > 100 && console.log(`[Majoor Metrics] ${e}: ${r.toFixed(2)}ms`);
@@ -11161,15 +11398,15 @@ function Bp(e, t) {
 	} catch {}
 	return r;
 }
-function Vp(e) {
-	return Rp.has(e);
+function Jp(e) {
+	return Gp.has(e);
 }
-function Hp(e) {
+function Yp(e) {
 	try {
 		performance.mark(`${e}-start`);
 	} catch {}
 }
-function Up(e) {
+function Xp(e) {
 	try {
 		performance.mark(`${e}-end`), performance.measure(e, `${e}-start`, `${e}-end`);
 		let t = performance.getEntriesByName(e)[0]?.duration || 0;
@@ -11178,47 +11415,47 @@ function Up(e) {
 		return null;
 	}
 }
-function Wp(e, t = !1) {
-	Lp.apiCallCount++, Lp.apiCallTotalMs += e, t && Lp.apiErrorCount++;
+function Zp(e, t = !1) {
+	Wp.apiCallCount++, Wp.apiCallTotalMs += e, t && Wp.apiErrorCount++;
 }
-function Gp(e) {
-	Lp.gridRenderCount++, Lp.gridRenderTotalMs += e;
+function Qp(e) {
+	Wp.gridRenderCount++, Wp.gridRenderTotalMs += e;
 }
-function Kp(e) {
-	Lp.searchQueryCount++, Lp.searchQueryTotalMs += e;
+function $p(e) {
+	Wp.searchQueryCount++, Wp.searchQueryTotalMs += e;
 }
-function qp(e) {
-	Lp.thumbnailLoadCount++, e || Lp.thumbnailLoadFailures++;
+function em(e) {
+	Wp.thumbnailLoadCount++, e || Wp.thumbnailLoadFailures++;
 }
-function Jp(e, t) {
-	Lp.errorCounts[e] = (Lp.errorCounts[e] || 0) + 1;
+function tm(e, t) {
+	Wp.errorCounts[e] = (Wp.errorCounts[e] || 0) + 1;
 }
-function Yp() {
+function nm() {
 	return {
-		...Lp,
+		...Wp,
 		averages: {
-			gridRenderMs: Lp.gridRenderCount > 0 ? Lp.gridRenderTotalMs / Lp.gridRenderCount : 0,
-			searchQueryMs: Lp.searchQueryCount > 0 ? Lp.searchQueryTotalMs / Lp.searchQueryCount : 0,
-			apiCallMs: Lp.apiCallCount > 0 ? Lp.apiCallTotalMs / Lp.apiCallCount : 0
+			gridRenderMs: Wp.gridRenderCount > 0 ? Wp.gridRenderTotalMs / Wp.gridRenderCount : 0,
+			searchQueryMs: Wp.searchQueryCount > 0 ? Wp.searchQueryTotalMs / Wp.searchQueryCount : 0,
+			apiCallMs: Wp.apiCallCount > 0 ? Wp.apiCallTotalMs / Wp.apiCallCount : 0
 		},
 		rates: {
-			apiErrorRate: Lp.apiCallCount > 0 ? (Lp.apiErrorCount / Lp.apiCallCount * 100).toFixed(2) + "%" : "0%",
-			thumbnailFailureRate: Lp.thumbnailLoadCount > 0 ? (Lp.thumbnailLoadFailures / Lp.thumbnailLoadCount * 100).toFixed(2) + "%" : "0%"
+			apiErrorRate: Wp.apiCallCount > 0 ? (Wp.apiErrorCount / Wp.apiCallCount * 100).toFixed(2) + "%" : "0%",
+			thumbnailFailureRate: Wp.thumbnailLoadCount > 0 ? (Wp.thumbnailLoadFailures / Wp.thumbnailLoadCount * 100).toFixed(2) + "%" : "0%"
 		}
 	};
 }
-function Xp(e) {
-	let t = `${e}Count`, n = `${e}TotalMs`, r = Lp, i = r[t], a = r[n];
+function rm(e) {
+	let t = `${e}Count`, n = `${e}TotalMs`, r = Wp, i = r[t], a = r[n];
 	return i > 0 ? a / i : 0;
 }
-function Zp() {
-	let e = Lp;
+function im() {
+	let e = Wp;
 	Object.keys(e).forEach((t) => {
 		typeof e[t] == "number" ? e[t] = 0 : typeof e[t] == "object" && (e[t] = {});
-	}), Rp.clear(), console.log("[Majoor Metrics] Metrics reset");
+	}), Gp.clear(), console.log("[Majoor Metrics] Metrics reset");
 }
-function Qp() {
-	let e = Yp();
+function am() {
+	let e = nm();
 	console.group("[Majoor Assets Manager] Performance Metrics"), console.table({
 		"Grid Renders": e.gridRenderCount,
 		"Avg Grid Render": `${e.averages.gridRenderMs.toFixed(2)}ms`,
@@ -11231,27 +11468,27 @@ function Qp() {
 		"Thumbnail Loads": e.thumbnailLoadCount,
 		"Thumbnail Failures": e.thumbnailLoadFailures,
 		"Failure Rate": e.rates.thumbnailFailureRate
-	}), Object.keys(Lp.errorCounts).length > 0 && console.log("Error Counts:", Lp.errorCounts), console.groupEnd();
+	}), Object.keys(Wp.errorCounts).length > 0 && console.log("Error Counts:", Wp.errorCounts), console.groupEnd();
 }
 typeof window < "u" && (window.MajoorMetrics = {
-	startTimer: zp,
-	endTimer: Bp,
-	hasTimer: Vp,
-	mark: Hp,
-	measure: Up,
-	trackApiCall: Wp,
-	trackGridRender: Gp,
-	trackSearchQuery: Kp,
-	trackThumbnailLoad: qp,
-	trackError: Jp,
-	getMetricsReport: Yp,
-	getAverageDuration: Xp,
-	resetMetrics: Zp,
-	exportMetrics: Qp
+	startTimer: Kp,
+	endTimer: qp,
+	hasTimer: Jp,
+	mark: Yp,
+	measure: Xp,
+	trackApiCall: Zp,
+	trackGridRender: Qp,
+	trackSearchQuery: $p,
+	trackThumbnailLoad: em,
+	trackError: tm,
+	getMetricsReport: nm,
+	getAverageDuration: rm,
+	resetMetrics: im,
+	exportMetrics: am
 });
 //#endregion
 //#region ui/features/status/StatusDot.ts
-var $p = [{
+var om = [{
 	key: "exiftool",
 	labelKey: "tool.exiftool",
 	hintKey: "tool.exiftool.hint"
@@ -11259,24 +11496,24 @@ var $p = [{
 	key: "ffprobe",
 	labelKey: "tool.ffprobe",
 	hintKey: "tool.ffprobe.hint"
-}], em = !1, tm = null, nm = null, rm = "__MJR_STATUS_DOT_CACHE__", im = {
+}], sm = !1, cm = null, lm = null, um = "__MJR_STATUS_DOT_CACHE__", dm = {
 	ACTIVE: "active",
 	COOLDOWN: "cooldown",
 	IDLE: "idle"
-}, am = {
-	[im.ACTIVE]: 2e3,
-	[im.COOLDOWN]: 1e4,
-	[im.IDLE]: 6e4
+}, fm = {
+	[dm.ACTIVE]: 2e3,
+	[dm.COOLDOWN]: 1e4,
+	[dm.IDLE]: 6e4
 };
-function om(e) {
-	em = !!e;
+function pm(e) {
+	sm = !!e;
 	try {
-		globalThis._mjrMaintenanceActive = em;
+		globalThis._mjrMaintenanceActive = sm;
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function sm(e) {
+function mm(e) {
 	let t = Number(e);
 	if (!Number.isFinite(t) || t <= 0) return "0 B";
 	let n = [
@@ -11290,7 +11527,7 @@ function sm(e) {
 	let a = r >= 100 ? 0 : r >= 10 ? 1 : 2;
 	return `${r.toFixed(a)} ${n[i]}`;
 }
-function cm(e, t, n = null) {
+function hm(e, t, n = null) {
 	if (e && (e.replaceChildren(), (Array.isArray(t) ? t.filter((e) => e != null && String(e).trim() !== "") : []).forEach((t, n) => {
 		n > 0 && e.appendChild(document.createElement("br")), e.appendChild(document.createTextNode(String(t)));
 	}), n != null && String(n).trim() !== "")) {
@@ -11299,7 +11536,7 @@ function cm(e, t, n = null) {
 		t.style.fontSize = "11px", t.style.opacity = "0.6", t.textContent = String(n), e.appendChild(t);
 	}
 }
-function lm(e, t = []) {
+function gm(e, t = []) {
 	if (!e) return;
 	let n = Array.isArray(t) ? t.filter((e) => e && String(e.label || "").trim()) : [];
 	if (!n.length) return;
@@ -11319,7 +11556,7 @@ function lm(e, t = []) {
 	}
 	e.appendChild(r);
 }
-function um(e, { totalAssets: t = 0, withWorkflows: n = 0, withGenerationData: r = 0 } = {}) {
+function _m(e, { totalAssets: t = 0, withWorkflows: n = 0, withGenerationData: r = 0 } = {}) {
 	let i = Math.max(0, Number(t || e?.total_assets || 0) || 0);
 	if (i <= 0) return [];
 	let a = (e, t = i) => {
@@ -11365,13 +11602,13 @@ function um(e, { totalAssets: t = 0, withWorkflows: n = 0, withGenerationData: r
 		} : null
 	].filter(Boolean);
 }
-function dm(e, t, n) {
+function vm(e, t, n) {
 	if (!e) return;
 	e.replaceChildren(), e.appendChild(document.createTextNode(String(t || ""))), e.appendChild(document.createElement("br"));
 	let r = document.createElement("span");
 	r.style.fontSize = "11px", r.style.opacity = "0.7", r.textContent = String(n || ""), e.appendChild(r);
 }
-function fm(e, t = "neutral", n = {}) {
+function ym(e, t = "neutral", n = {}) {
 	if (!e) return;
 	let r = n?.toast !== !1, i = {
 		neutral: {
@@ -11415,38 +11652,38 @@ function fm(e, t = "neutral", n = {}) {
 		if (n - (Number(e._mjrStatusToastAt || 0) || 0) >= 4e3) {
 			e._mjrStatusToastAt = n;
 			let r = {
-				info: R("status.toast.info", "Index status: checking"),
-				success: R("status.toast.success", "Index status: ready"),
-				warning: R("status.toast.warning", "Index status: attention needed"),
-				error: R("status.toast.error", "Index status: error"),
-				browser: R("status.toast.browser", "Index status: browser scope"),
-				workflow: R("status.toast.workflow", "Index status: workflow scope")
+				info: L("status.toast.info", "Index status: checking"),
+				success: L("status.toast.success", "Index status: ready"),
+				warning: L("status.toast.warning", "Index status: attention needed"),
+				error: L("status.toast.error", "Index status: error"),
+				browser: L("status.toast.browser", "Index status: browser scope"),
+				workflow: L("status.toast.workflow", "Index status: workflow scope")
 			}, i = t === "error" ? "error" : t === "warning" ? "warning" : t === "success" ? "success" : "info";
 			try {
-				A(r[t] || r.info, i, 1800, { noHistory: !0 });
+				k(r[t] || r.info, i, 1800, { noHistory: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
 	}
 }
-function pm(e) {
+function bm(e) {
 	let t = String(e || "").toLowerCase();
-	return t === "all" ? R("scope.allFull", "All (Inputs + Outputs)") : t === "input" || t === "inputs" ? R("scope.input", "Inputs") : t === "custom" ? R("scope.custom", "Browser") : t === "workflow" ? R("scope.workflow", "Workflow") : R("scope.output", "Outputs");
+	return t === "all" ? L("scope.allFull", "All (Inputs + Outputs)") : t === "input" || t === "inputs" ? L("scope.input", "Inputs") : t === "custom" ? L("scope.custom", "Browser") : t === "workflow" ? L("scope.workflow", "Workflow") : L("scope.output", "Outputs");
 }
-function mm(e, t = "") {
-	if (!e || typeof e != "object") return t ? R("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: pm(t) }) : R("status.watcher.disabled", "Watcher: disabled");
+function xm(e, t = "") {
+	if (!e || typeof e != "object") return t ? L("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: bm(t) }) : L("status.watcher.disabled", "Watcher: disabled");
 	let n = !!e.enabled, r = e.scope ? String(e.scope) : "";
-	return n ? r ? R("status.watcher.enabledScoped", `Watcher: enabled (${r})`, { scope: pm(r) }) : R("status.watcher.enabled", "Watcher: enabled") : r || t ? R("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: pm(t && r && r !== t ? t : r || t) }) : R("status.watcher.disabled", "Watcher: disabled");
+	return n ? r ? L("status.watcher.enabledScoped", `Watcher: enabled (${r})`, { scope: bm(r) }) : L("status.watcher.enabled", "Watcher: enabled") : r || t ? L("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: bm(t && r && r !== t ? t : r || t) }) : L("status.watcher.disabled", "Watcher: disabled");
 }
-function hm(e = "status-action") {
+function Sm(e = "status-action") {
 	try {
 		window?.dispatchEvent?.(new CustomEvent("mjr:reload-grid", { detail: { reason: String(e || "status-action") } }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function gm(e = "status-action", t = {}) {
+function Cm(e = "status-action", t = {}) {
 	try {
 		window?.dispatchEvent?.(new CustomEvent("mjr-grid-dirty", { detail: {
 			reason: String(e || "status-action"),
@@ -11456,241 +11693,241 @@ function gm(e = "status-action", t = {}) {
 		console.debug?.(e);
 	}
 }
-function _m(e = "") {
+function wm(e = "") {
 	try {
-		window?.dispatchEvent?.(new CustomEvent(B.OPEN_MESSAGE_HISTORY, { detail: { reason: String(e || "status-action") } }));
+		window?.dispatchEvent?.(new CustomEvent(z.OPEN_MESSAGE_HISTORY, { detail: { reason: String(e || "status-action") } }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-async function vm(e = "") {
-	return await Gt(R("dialog.vectorsReset.keepQuestion", "Keep existing AI vectors?\n\nConfirm = keep vectors\nCancel = continue without vectors"), e || R("dialog.vectorsReset.title", "AI vectors"));
+async function Tm(e = "") {
+	return await Gt(L("dialog.vectorsReset.keepQuestion", "Keep existing AI vectors?\n\nConfirm = keep vectors\nCancel = continue without vectors"), e || L("dialog.vectorsReset.title", "AI vectors"));
 }
-function ym(e = {}) {
+function Em(e = {}) {
 	let t = typeof e?.getScanContext == "function" ? e.getScanContext : null;
-	om(!1);
+	pm(!1);
 	let n = document.createElement("div");
-	n.style.cssText = "margin-bottom: 20px; padding: 12px; background: var(--bg-color, #1a1a1a); border-radius: 6px; border: 1px solid var(--border-color, #333); cursor: pointer; transition: all 0.2s;", fm(n, "info", { toast: !1 });
-	let i = document.createElement("div");
-	i.style.cssText = "display: flex; align-items: center; gap: 10px; margin-bottom: 8px;";
+	n.style.cssText = "margin-bottom: 20px; padding: 12px; background: var(--bg-color, #1a1a1a); border-radius: 6px; border: 1px solid var(--border-color, #333); cursor: pointer; transition: all 0.2s;", ym(n, "info", { toast: !1 });
+	let r = document.createElement("div");
+	r.style.cssText = "display: flex; align-items: center; gap: 10px; margin-bottom: 8px;";
+	let i = document.createElement("span");
+	i.id = "mjr-status-dot", i.style.cssText = "width: 12px; height: 12px; border-radius: 50%; background: var(--mjr-status-info, #64B5F6); display: inline-block; cursor: pointer;";
 	let a = document.createElement("span");
-	a.id = "mjr-status-dot", a.style.cssText = "width: 12px; height: 12px; border-radius: 50%; background: var(--mjr-status-info, #64B5F6); display: inline-block; cursor: pointer;";
+	a.id = "mjr-status-title", a.style.cssText = "font-weight: 500; font-size: 13px; cursor: pointer;";
 	let o = document.createElement("span");
-	o.id = "mjr-status-title", o.style.cssText = "font-weight: 500; font-size: 13px; cursor: pointer;";
-	let s = document.createElement("span");
-	s.id = "mjr-status-title-indicator", s.style.marginRight = "6px", s.textContent = "v", o.appendChild(s), o.appendChild(document.createTextNode(R("status.indexStatus", "Index Status"))), i.appendChild(a), i.appendChild(o);
+	o.id = "mjr-status-title-indicator", o.style.marginRight = "6px", o.textContent = "v", a.appendChild(o), a.appendChild(document.createTextNode(L("status.indexStatus", "Index Status"))), r.appendChild(i), r.appendChild(a);
+	let c = document.createElement("div");
+	c.id = "mjr-status-body", c.style.marginLeft = "22px";
 	let l = document.createElement("div");
-	l.id = "mjr-status-body", l.style.marginLeft = "22px";
+	l.id = "mjr-status-text", l.style.cssText = "font-size: 12px; opacity: 0.8;", l.textContent = L("status.checking");
 	let u = document.createElement("div");
-	u.id = "mjr-status-text", u.style.cssText = "font-size: 12px; opacity: 0.8;", u.textContent = R("status.checking");
+	u.id = "mjr-status-capabilities", u.style.cssText = "font-size: 11px; opacity: 0.75; margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap;", u.textContent = L("status.discoveringTools"), c.appendChild(l), c.appendChild(u);
 	let d = document.createElement("div");
-	d.id = "mjr-status-capabilities", d.style.cssText = "font-size: 11px; opacity: 0.75; margin-top: 10px; display: flex; gap: 6px; flex-wrap: wrap;", d.textContent = R("status.discoveringTools"), l.appendChild(u), l.appendChild(d);
+	d.id = "mjr-tools-status", d.style.cssText = "font-size: 11px; opacity: 0.7; margin-top: 10px;", d.textContent = L("status.toolStatusChecking", "Tool status: checking..."), c.appendChild(d);
 	let f = document.createElement("div");
-	f.id = "mjr-tools-status", f.style.cssText = "font-size: 11px; opacity: 0.7; margin-top: 10px;", f.textContent = R("status.toolStatusChecking", "Tool status: checking..."), l.appendChild(f);
-	let p = document.createElement("div");
-	p.style.cssText = "margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;";
-	let m = document.createElement("select");
-	m.style.cssText = "\n        min-width: 240px;\n        padding: 4px 8px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,255,255,0.2);\n        background: rgba(255,255,255,0.04);\n        color: inherit;\n    ", m.title = R("status.dbBackupSelectHint", "Select a DB backup to restore");
-	let h = !1, g = null, _ = (e) => {
-		m.replaceChildren();
+	f.style.cssText = "margin-top: 10px; display: flex; gap: 8px; align-items: center; flex-wrap: wrap;";
+	let p = document.createElement("select");
+	p.style.cssText = "\n        min-width: 240px;\n        padding: 4px 8px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,255,255,0.2);\n        background: rgba(255,255,255,0.04);\n        color: inherit;\n    ", p.title = L("status.dbBackupSelectHint", "Select a DB backup to restore");
+	let m = !1, h = null, g = (e) => {
+		p.replaceChildren();
 		let t = document.createElement("option");
-		t.value = "", t.textContent = String(e || ""), t.disabled = !0, t.selected = !0, m.appendChild(t), h = !1, m.disabled = !0, g && (g.disabled = !0);
+		t.value = "", t.textContent = String(e || ""), t.disabled = !0, t.selected = !0, p.appendChild(t), m = !1, p.disabled = !0, h && (h.disabled = !0);
 	};
-	_(R("status.dbBackupLoading", "Loading DB backups..."));
-	let v = async (e = "") => {
+	g(L("status.dbBackupLoading", "Loading DB backups..."));
+	let _ = async (e = "") => {
 		try {
-			let t = await ve();
+			let t = await ye();
 			if (!t?.ok) {
-				_(R("status.dbBackupNone", "No DB backup found"));
+				g(L("status.dbBackupNone", "No DB backup found"));
 				return;
 			}
 			let n = Array.isArray(t?.data?.items) ? t.data.items : [];
 			if (!n.length) {
-				_(R("status.dbBackupNone", "No DB backup found"));
+				g(L("status.dbBackupNone", "No DB backup found"));
 				return;
 			}
-			m.replaceChildren();
+			p.replaceChildren();
 			let r = !1;
 			for (let t of n) {
 				let n = String(t?.name || "");
 				if (!n) continue;
-				let i = Number(t?.mtime || 0), a = Number(t?.size_bytes || 0), o = i > 0 ? (/* @__PURE__ */ new Date(i * 1e3)).toLocaleString() : "", s = `${n}${o ? ` (${o}` : ""}${a > 0 ? `, ${sm(a)}` : ""}${o ? ")" : ""}`, c = document.createElement("option");
-				c.value = n, c.textContent = s, e && e === n && (c.selected = !0, r = !0), m.appendChild(c);
+				let i = Number(t?.mtime || 0), a = Number(t?.size_bytes || 0), o = i > 0 ? (/* @__PURE__ */ new Date(i * 1e3)).toLocaleString() : "", s = `${n}${o ? ` (${o}` : ""}${a > 0 ? `, ${mm(a)}` : ""}${o ? ")" : ""}`, c = document.createElement("option");
+				c.value = n, c.textContent = s, e && e === n && (c.selected = !0, r = !0), p.appendChild(c);
 			}
-			h = m.childNodes.length > 0, m.disabled = !h, h && !r && m.childNodes[0] && (m.value = String(m.childNodes[0]?.value || "")), g && (g.disabled = !h);
+			m = p.childNodes.length > 0, p.disabled = !m, m && !r && p.childNodes[0] && (p.value = String(p.childNodes[0]?.value || "")), h && (h.disabled = !m);
 		} catch {
-			_(R("status.dbBackupNone", "No DB backup found"));
+			g(L("status.dbBackupNone", "No DB backup found"));
 		}
 	};
-	v(), p.appendChild(m);
-	let y = document.createElement("button");
-	y.type = "button", y.textContent = R("btn.dbSave", "Save DB"), y.title = R("status.dbSaveHint", "Save a DB snapshot into archive folder"), y.style.cssText = "\n        padding: 5px 10px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(120,200,255,0.35);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n    ", y.onclick = async (e) => {
-		e.stopPropagation(), om(!0);
-		let r = y.textContent, i = !!g?.disabled;
-		y.disabled = !0, g && (g.disabled = !0), y.textContent = R("btn.saving", "Saving..."), a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
+	_(), f.appendChild(p);
+	let v = document.createElement("button");
+	v.type = "button", v.textContent = L("btn.dbSave", "Save DB"), v.title = L("status.dbSaveHint", "Save a DB snapshot into archive folder"), v.style.cssText = "\n        padding: 5px 10px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(120,200,255,0.35);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n    ", v.onclick = async (e) => {
+		e.stopPropagation(), pm(!0);
+		let r = v.textContent, a = !!h?.disabled;
+		v.disabled = !0, h && (h.disabled = !0), v.textContent = L("btn.saving", "Saving..."), i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
 		try {
-			let e = await te();
+			let e = await N();
 			if (e?.ok) {
 				let t = String(e?.data?.name || "").trim(), n = Number(e?.data?.size_bytes || 0);
-				A(R("toast.dbSaveSuccess", "Database backup saved"), "success", 2200, { history: {
-					title: R("btn.dbSave", "Save DB"),
-					detail: t ? `${t}${n > 0 ? ` | ${sm(n)}` : ""}` : R("toast.dbSaveSuccess", "Database backup saved"),
+				k(L("toast.dbSaveSuccess", "Database backup saved"), "success", 2200, { history: {
+					title: L("btn.dbSave", "Save DB"),
+					detail: t ? `${t}${n > 0 ? ` | ${mm(n)}` : ""}` : L("toast.dbSaveSuccess", "Database backup saved"),
 					operation: "save_db",
 					source: t || "archive",
 					forceStore: !0
-				} }), await v(t);
-			} else A(e?.error || R("toast.dbSaveFailed", "Failed to save DB backup"), "error");
+				} }), await _(t);
+			} else k(e?.error || L("toast.dbSaveFailed", "Failed to save DB backup"), "error");
 		} catch (e) {
-			A(e?.message || R("toast.dbSaveFailed", "Failed to save DB backup"), "error");
+			k(e?.message || L("toast.dbSaveFailed", "Failed to save DB backup"), "error");
 		} finally {
-			om(!1), y.disabled = !1, g && (g.disabled = i || !h), y.textContent = r;
+			pm(!1), v.disabled = !1, h && (h.disabled = a || !m), v.textContent = r;
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, p.appendChild(y), g = document.createElement("button"), g.type = "button", g.textContent = R("btn.dbRestore", "Restore"), g.title = R("status.dbRestoreHint", "Restore selected DB backup"), g.style.cssText = "\n        padding: 5px 10px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,180,80,0.35);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n    ", g.onclick = async (e) => {
+	}, f.appendChild(v), h = document.createElement("button"), h.type = "button", h.textContent = L("btn.dbRestore", "Restore"), h.title = L("status.dbRestoreHint", "Restore selected DB backup"), h.style.cssText = "\n        padding: 5px 10px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,180,80,0.35);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n    ", h.onclick = async (e) => {
 		e.stopPropagation();
-		let r = String(m.value || "");
+		let r = String(p.value || "");
 		if (!r) {
-			A(R("toast.dbRestoreSelect", "Select a DB backup first"), "warning", 2e3);
+			k(L("toast.dbRestoreSelect", "Select a DB backup first"), "warning", 2e3);
 			return;
 		}
-		if (!await Gt(`${R("dialog.dbRestore.confirm", "Restore selected DB backup? Current DB will be replaced.")}\n\n${r}`, R("btn.dbRestore", "Restore DB"))) return;
-		A(R("toast.dbRestoreStarted", "DB restore started"), "info", 1800, { history: {
+		if (!await Gt(`${L("dialog.dbRestore.confirm", "Restore selected DB backup? Current DB will be replaced.")}\n\n${r}`, L("btn.dbRestore", "Restore DB"))) return;
+		k(L("toast.dbRestoreStarted", "DB restore started"), "info", 1800, { history: {
 			trackId: "maintenance:restore_db",
-			title: R("btn.dbRestore", "Restore DB"),
+			title: L("btn.dbRestore", "Restore DB"),
 			detail: r,
 			operation: "restore_db",
 			source: r,
 			status: "started",
 			forceStore: !0
-		} }), om(!0);
-		let i = g.textContent, o = !!y.disabled;
-		g.disabled = !0, y.disabled = !0, m.disabled = !0, g.textContent = R("btn.restoring", "Restoring..."), a.style.background = "var(--mjr-status-warning, #FFA726)", fm(n, "warning");
+		} }), pm(!0);
+		let a = h.textContent, o = !!v.disabled;
+		h.disabled = !0, v.disabled = !0, p.disabled = !0, h.textContent = L("btn.restoring", "Restoring..."), i.style.background = "var(--mjr-status-warning, #FFA726)", ym(n, "warning");
 		try {
 			let e = await ke({
 				name: r,
 				useLatest: !1
 			});
-			e?.ok ? await v(String(e?.data?.name || r || "")) : A(e?.error || R("toast.dbRestoreFailed", "Failed to restore DB backup"), "error");
+			e?.ok ? await _(String(e?.data?.name || r || "")) : k(e?.error || L("toast.dbRestoreFailed", "Failed to restore DB backup"), "error");
 		} catch (e) {
-			A(e?.message || R("toast.dbRestoreFailed", "Failed to restore DB backup"), "error");
+			k(e?.message || L("toast.dbRestoreFailed", "Failed to restore DB backup"), "error");
 		} finally {
-			om(!1), g.disabled = !h, y.disabled = o, m.disabled = !h, g.textContent = i, hm("db-restore");
+			pm(!1), h.disabled = !m, v.disabled = o, p.disabled = !m, h.textContent = a, Sm("db-restore");
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, p.appendChild(g), l.appendChild(p);
+	}, f.appendChild(h), c.appendChild(f);
+	let y = document.createElement("div");
+	y.style.cssText = "margin-top: 10px; display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap;";
 	let b = document.createElement("div");
-	b.style.cssText = "margin-top: 10px; display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap;";
-	let x = document.createElement("div");
-	x.style.cssText = "margin-top: 8px; font-size: 11px; opacity: 0.9; line-height: 1.35; white-space: pre-wrap;", x.textContent = "";
+	b.style.cssText = "margin-top: 8px; font-size: 11px; opacity: 0.9; line-height: 1.35; white-space: pre-wrap;", b.textContent = "";
 	let S = (e, t = "neutral") => {
 		let n = String(e || "").trim();
-		if (x.textContent = n, !n) {
-			x.style.color = "inherit", x.style.opacity = "0.9";
+		if (b.textContent = n, !n) {
+			b.style.color = "inherit", b.style.opacity = "0.9";
 			return;
 		}
 		if (t === "error") {
-			x.style.color = "var(--error-text-color, #ff8a80)", x.style.opacity = "1";
+			b.style.color = "var(--error-text-color, #ff8a80)", b.style.opacity = "1";
 			return;
 		}
 		if (t === "success") {
-			x.style.color = "var(--success-text-color, #a5d6a7)", x.style.opacity = "1";
+			b.style.color = "var(--success-text-color, #a5d6a7)", b.style.opacity = "1";
 			return;
 		}
 		if (t === "info") {
-			x.style.color = "var(--input-text, #cfd8dc)", x.style.opacity = "0.95";
+			b.style.color = "var(--input-text, #cfd8dc)", b.style.opacity = "0.95";
 			return;
 		}
-		x.style.color = "inherit", x.style.opacity = "0.9";
-	}, w, T = document.createElement("button");
-	T.type = "button", T.textContent = R("btn.resetIndex"), T.title = R("status.resetIndexHint", "Reset index cache (requires allowResetIndex in settings)."), T.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,255,255,0.25);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", T.onmouseenter = () => {
-		T.style.borderColor = "rgba(255,255,255,0.6)", T.style.background = "rgba(255,255,255,0.08)";
-	}, T.onmouseleave = () => {
-		T.style.borderColor = "rgba(255,255,255,0.25)", T.style.background = "transparent";
-	}, T.onclick = async (e) => {
+		b.style.color = "inherit", b.style.opacity = "0.9";
+	}, C, w = document.createElement("button");
+	w.type = "button", w.textContent = L("btn.resetIndex"), w.title = L("status.resetIndexHint", "Reset index cache (requires allowResetIndex in settings)."), w.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,255,255,0.25);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", w.onmouseenter = () => {
+		w.style.borderColor = "rgba(255,255,255,0.6)", w.style.background = "rgba(255,255,255,0.08)";
+	}, w.onmouseleave = () => {
+		w.style.borderColor = "rgba(255,255,255,0.25)", w.style.background = "transparent";
+	}, w.onclick = async (e) => {
 		e.stopPropagation();
-		let r = await vm(R("btn.resetIndex", "Reset index"));
-		if (!await Gt(r ? R("dialog.resetIndex.confirmKeepVectors", "This will reset index data and rescan files while keeping existing AI vectors.\n\nContinue?") : R("dialog.resetIndex.msg", "This will delete the database and rescan all files. Continue?"), R("dialog.resetIndex.title", "Reset index?"))) return;
-		_m("reset-index"), om(!0);
-		let i = T.textContent;
-		T.disabled = !0, w.disabled = !0, T.textContent = R("btn.resetting"), a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
+		let r = await Tm(L("btn.resetIndex", "Reset index"));
+		if (!await Gt(r ? L("dialog.resetIndex.confirmKeepVectors", "This will reset index data and rescan files while keeping existing AI vectors.\n\nContinue?") : L("dialog.resetIndex.msg", "This will delete the database and rescan all files. Continue?"), L("dialog.resetIndex.title", "Reset index?"))) return;
+		wm("reset-index"), pm(!0);
+		let a = w.textContent;
+		w.disabled = !0, C.disabled = !0, w.textContent = L("btn.resetting"), i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
 		try {
-			let e = t ? t() : {}, i = String(e?.scope || "output").toLowerCase(), o = e?.customRootId || e?.custom_root_id || e?.root_id || null, s = i === "custom" && !o;
-			(await Te({
-				scope: s ? "all" : i,
+			let e = t ? t() : {}, a = String(e?.scope || "output").toLowerCase(), o = e?.customRootId || e?.custom_root_id || e?.root_id || null, s = a === "custom" && !o;
+			(await Ee({
+				scope: s ? "all" : a,
 				customRootId: s ? null : o,
 				reindex: !0,
 				maintenance_force: !0,
-				hard_reset_db: i === "all" && !r,
+				hard_reset_db: a === "all" && !r,
 				clear_scan_journal: !0,
 				clear_metadata_cache: !0,
 				clear_asset_metadata: !0,
 				clear_assets: !r,
 				preserve_vectors: r,
 				rebuild_fts: !0
-			}))?.ok ? (a.style.background = "var(--mjr-status-success, #4CAF50)", fm(n, "success")) : (a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error"));
+			}))?.ok ? (i.style.background = "var(--mjr-status-success, #4CAF50)", ym(n, "success")) : (i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error"));
 		} catch {
-			a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+			i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 		} finally {
-			om(!1), T.disabled = !1, w.disabled = !1, T.textContent = i, hm("index-reset");
+			pm(!1), w.disabled = !1, C.disabled = !1, w.textContent = a, Sm("index-reset");
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
 	};
-	let E = document.createElement("button");
-	E.type = "button", E.textContent = "Backfill vectors", E.title = "Compute missing AI vector embeddings for existing assets.", E.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(0, 188, 212, 0.45);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", E.onmouseenter = () => {
-		E.style.borderColor = "rgba(0, 188, 212, 0.8)", E.style.background = "rgba(0, 188, 212, 0.12)";
-	}, E.onmouseleave = () => {
-		E.style.borderColor = "rgba(0, 188, 212, 0.45)", E.style.background = "transparent";
-	}, E.onclick = async (e) => {
+	let T = document.createElement("button");
+	T.type = "button", T.textContent = "Backfill vectors", T.title = "Compute missing AI vector embeddings for existing assets.", T.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(0, 188, 212, 0.45);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", T.onmouseenter = () => {
+		T.style.borderColor = "rgba(0, 188, 212, 0.8)", T.style.background = "rgba(0, 188, 212, 0.12)";
+	}, T.onmouseleave = () => {
+		T.style.borderColor = "rgba(0, 188, 212, 0.45)", T.style.background = "transparent";
+	}, T.onclick = async (e) => {
 		e.stopPropagation();
-		let i = t ? t() : {}, o = String(i?.scope || "output").toLowerCase(), s = String(i?.customRootId || i?.custom_root_id || i?.root_id || "").trim();
-		if (o === "custom" && !s) {
-			A(R("status.customBrowserScanDisabledHint", "Use Outputs, Inputs, or All to run indexing scans"), "warning", 2600), S("Backfill skipped - Browser scope has no selected custom root.", "warning");
+		let r = t ? t() : {}, a = String(r?.scope || "output").toLowerCase(), o = String(r?.customRootId || r?.custom_root_id || r?.root_id || "").trim();
+		if (a === "custom" && !o) {
+			k(L("status.customBrowserScanDisabledHint", "Use Outputs, Inputs, or All to run indexing scans"), "warning", 2600), S("Backfill skipped - Browser scope has no selected custom root.", "warning");
 			return;
 		}
-		let c = o || "output", l = pm(c);
-		_m("vector-backfill");
-		let f = { history: {
-			trackId: `vector-backfill:status:${c}:${s || "default"}`,
+		let s = a || "output", c = bm(s);
+		wm("vector-backfill");
+		let d = { history: {
+			trackId: `vector-backfill:status:${s}:${o || "default"}`,
 			title: "Vector Backfill",
-			source: l,
+			source: c,
 			operation: "vector_backfill",
 			forceStore: !0
 		} };
-		om(!0);
-		let p = E.textContent, m = T.textContent;
-		E.disabled = !0, T.disabled = !0, w.disabled = !0, E.textContent = "Backfilling...", S(`Backfill started (${l})...`, "info"), j({
+		pm(!0);
+		let f = T.textContent, p = w.textContent;
+		T.disabled = !0, w.disabled = !0, C.disabled = !0, T.textContent = "Backfilling...", S(`Backfill started (${c})...`, "info"), x({
 			summary: "Vector Backfill",
-			detail: `Started (${l})`
+			detail: `Started (${c})`
 		}, "info", 0, { history: {
-			...f.history,
+			...d.history,
 			status: "started",
-			detail: `Started (${l})`
-		} }), a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
+			detail: `Started (${c})`
+		} }), i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
 		try {
 			let e = {
-				scope: c,
+				scope: s,
 				onProgress: (e) => {
-					let t = String(e?.status || "").toLowerCase(), n = e?.progress || e?.result || {}, r = Number(n?.candidates || n?.processed || 0), i = Number(n?.candidate_total || r || 0), a = Number(n?.eligible_total || n?.total_assets || 0), o = Number(n?.indexed || 0), s = Number(n?.skipped || 0), c = Number(n?.errors || 0);
+					let t = String(e?.status || "").toLowerCase(), n = e?.progress || e?.result || {}, r = Number(n?.candidates || n?.processed || 0), i = Number(n?.candidate_total || r || 0), a = Number(n?.eligible_total || n?.total_assets || 0), o = Number(n?.indexed || 0), s = Number(n?.skipped || 0), l = Number(n?.errors || 0);
 					if (t === "queued") {
-						S("Backfill queued...", "info"), j({
+						S("Backfill queued...", "info"), x({
 							summary: "Vector Backfill",
-							detail: `Queued (${l})`
+							detail: `Queued (${c})`
 						}, "info", 0, { history: {
-							...f.history,
+							...d.history,
 							status: "queued",
-							detail: `Queued (${l})`,
+							detail: `Queued (${c})`,
 							progress: {
 								current: 0,
 								total: 1,
@@ -11700,42 +11937,42 @@ function ym(e = {}) {
 						} });
 						return;
 					}
-					if (t === "running" || r > 0 || i > 0 || a > 0 || o > 0 || s > 0 || c > 0) {
-						let e = a > 0 ? `Indexed ${o}/${a} assets, candidates ${i}, skipped ${s}, errors ${c}` : `Candidates ${r}, indexed ${o}, skipped ${s}, errors ${c}`;
-						S(a > 0 ? `Backfill running - indexed ${o}/${a} assets, candidates ${i}, skipped ${s}, errors ${c}` : `Backfill running - candidates ${r}, indexed ${o}, skipped ${s}, errors ${c}`, "info"), j({
+					if (t === "running" || r > 0 || i > 0 || a > 0 || o > 0 || s > 0 || l > 0) {
+						let e = a > 0 ? `Indexed ${o}/${a} assets, candidates ${i}, skipped ${s}, errors ${l}` : `Candidates ${r}, indexed ${o}, skipped ${s}, errors ${l}`;
+						S(a > 0 ? `Backfill running - indexed ${o}/${a} assets, candidates ${i}, skipped ${s}, errors ${l}` : `Backfill running - candidates ${r}, indexed ${o}, skipped ${s}, errors ${l}`, "info"), x({
 							summary: "Vector Backfill",
 							detail: e
 						}, "info", 0, { history: {
-							...f.history,
+							...d.history,
 							status: "running",
 							detail: e,
 							progress: {
-								current: a > 0 ? o : o + s + c,
-								total: a > 0 ? a : Math.max(r, o + s + c),
-								percent: a > 0 ? Math.round(o / a * 100) : Math.max(r, o + s + c) > 0 ? Math.round((o + s + c) / Math.max(r, o + s + c) * 100) : null,
+								current: a > 0 ? o : o + s + l,
+								total: a > 0 ? a : Math.max(r, o + s + l),
+								percent: a > 0 ? Math.round(o / a * 100) : Math.max(r, o + s + l) > 0 ? Math.round((o + s + l) / Math.max(r, o + s + l) * 100) : null,
 								eligible_total: a > 0 ? a : void 0,
 								candidate_total: i > 0 ? i : void 0,
 								indexed: o,
 								skipped: s,
-								errors: c,
+								errors: l,
 								label: "running"
 							}
 						} });
 					}
 				}
 			};
-			c === "custom" && s && (e.customRootId = s);
-			let t = await r(64, e);
+			s === "custom" && o && (e.customRootId = o);
+			let t = await D(64, e);
 			if (t?.ok) {
 				let e = String(t?.data?.status || "").toLowerCase(), r = !!t?.data?.pending || [
 					"queued",
 					"running",
 					"pending"
-				].includes(e), i = t?.data?.progress || {}, o = Number(t?.data?.processed ?? i?.candidates ?? 0), s = Number(t?.data?.indexed ?? i?.indexed ?? 0), c = Number(t?.data?.skipped ?? i?.skipped ?? 0), l = Number(t?.data?.errors ?? i?.errors ?? 0);
+				].includes(e), a = t?.data?.progress || {}, o = Number(t?.data?.processed ?? a?.candidates ?? 0), s = Number(t?.data?.indexed ?? a?.indexed ?? 0), c = Number(t?.data?.skipped ?? a?.skipped ?? 0), l = Number(t?.data?.errors ?? a?.errors ?? 0);
 				if (r) {
 					let e = String(t?.data?.backfill_id || "").trim();
-					A(R("toast.vectorBackfillRunning", "Vector backfill still running in background{job}.", { job: e ? ` (${e.slice(0, 8)})` : "" }), "info", 4200, { history: {
-						...f.history,
+					k(L("toast.vectorBackfillRunning", "Vector backfill still running in background{job}.", { job: e ? ` (${e.slice(0, 8)})` : "" }), "info", 4200, { history: {
+						...d.history,
 						status: "running",
 						detail: `Running in background${e ? ` (${e.slice(0, 8)})` : ""}.`,
 						progress: {
@@ -11747,13 +11984,13 @@ function ym(e = {}) {
 							errors: l,
 							label: "running"
 						}
-					} }), S(`Backfill running in background - candidates ${o}, indexed ${s}, skipped ${c}, errors ${l}`, "info"), a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
-				} else A(R("toast.vectorBackfillComplete", "Vector backfill complete! Processed: {processed}, Indexed: {indexed}, Skipped: {skipped}", {
+					} }), S(`Backfill running in background - candidates ${o}, indexed ${s}, skipped ${c}, errors ${l}`, "info"), i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
+				} else k(L("toast.vectorBackfillComplete", "Vector backfill complete! Processed: {processed}, Indexed: {indexed}, Skipped: {skipped}", {
 					processed: o,
 					indexed: s,
 					skipped: c
 				}), "success", 3e3, { history: {
-					...f.history,
+					...d.history,
 					status: "succeeded",
 					detail: `Processed ${o}, indexed ${s}, skipped ${c}`,
 					progress: {
@@ -11765,85 +12002,85 @@ function ym(e = {}) {
 						errors: l,
 						label: "done"
 					}
-				} }), S(`Backfill OK - processed ${o}, indexed ${s}, skipped ${c}`, "success"), a.style.background = "var(--mjr-status-success, #4CAF50)", fm(n, "success");
+				} }), S(`Backfill OK - processed ${o}, indexed ${s}, skipped ${c}`, "success"), i.style.background = "var(--mjr-status-success, #4CAF50)", ym(n, "success");
 			} else {
-				let e = String(t?.error || R("toast.vectorBackfillFailedGeneric", "Backfill failed")), r = String(t?.code || "").trim(), i = Number(t?.status || 0) || 0, o = [
+				let e = String(t?.error || L("toast.vectorBackfillFailedGeneric", "Backfill failed")), r = String(t?.code || "").trim(), a = Number(t?.status || 0) || 0, o = [
 					r ? `code=${r}` : "",
-					i ? `status=${i}` : "",
+					a ? `status=${a}` : "",
 					e
 				].filter(Boolean).join(" | ");
-				A(o, "error", 4500, { history: {
-					...f.history,
+				k(o, "error", 4500, { history: {
+					...d.history,
 					status: "failed",
 					detail: o,
 					progress: {
 						label: "failed",
 						errors: 1
 					}
-				} }), S(`Backfill ? - ${o}\nSee console for full payload.`, "error"), console.error("[Majoor] Vector backfill failed response", t), a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+				} }), S(`Backfill ? - ${o}\nSee console for full payload.`, "error"), console.error("[Majoor] Vector backfill failed response", t), i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 			}
 		} catch (e) {
 			let t = String(e?.message || e || "Backfill failed");
-			A(t, "error", 4500, { history: {
-				...f.history,
+			k(t, "error", 4500, { history: {
+				...d.history,
 				status: "failed",
 				detail: t,
 				progress: {
 					label: "failed",
 					errors: 1
 				}
-			} }), S(`Backfill EXCEPTION - ${t}\nSee console for stack trace.`, "error"), console.error("[Majoor] Vector backfill exception", e), a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+			} }), S(`Backfill EXCEPTION - ${t}\nSee console for stack trace.`, "error"), console.error("[Majoor] Vector backfill exception", e), i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 		} finally {
-			om(!1), E.disabled = !1, T.disabled = !1, w.disabled = !1, E.textContent = p, T.textContent = m, hm("vector-backfill");
+			pm(!1), T.disabled = !1, w.disabled = !1, C.disabled = !1, T.textContent = f, w.textContent = p, Sm("vector-backfill");
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, w = document.createElement("button"), w.type = "button", w.textContent = R("btn.memoryPurge", "Memory purge"), w.title = R("tooltip.memoryPurge", "Unload Majoor AI models, ask ComfyUI to unload loaded models, and clear torch cache when idle."), w.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(156, 204, 101, 0.45);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", w.onmouseenter = () => {
-		w.style.borderColor = "rgba(156, 204, 101, 0.85)", w.style.background = "rgba(156, 204, 101, 0.12)";
-	}, w.onmouseleave = () => {
-		w.style.borderColor = "rgba(156, 204, 101, 0.45)", w.style.background = "transparent";
-	}, w.onclick = async (e) => {
+	}, C = document.createElement("button"), C.type = "button", C.textContent = L("btn.memoryPurge", "Memory purge"), C.title = L("tooltip.memoryPurge", "Unload Majoor AI models, ask ComfyUI to unload loaded models, and clear torch cache when idle."), C.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(156, 204, 101, 0.45);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", C.onmouseenter = () => {
+		C.style.borderColor = "rgba(156, 204, 101, 0.85)", C.style.background = "rgba(156, 204, 101, 0.12)";
+	}, C.onmouseleave = () => {
+		C.style.borderColor = "rgba(156, 204, 101, 0.45)", C.style.background = "transparent";
+	}, C.onclick = async (e) => {
 		e.stopPropagation();
-		let r = w.textContent;
-		w.disabled = !0, E.disabled = !0, T.disabled = !0, w.textContent = R("btn.memoryPurging", "Purging..."), S(R("status.memoryPurgeStarted", "Memory purge started..."), "info"), a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
+		let r = C.textContent;
+		C.disabled = !0, T.disabled = !0, w.disabled = !0, C.textContent = L("btn.memoryPurging", "Purging..."), S(L("status.memoryPurgeStarted", "Memory purge started..."), "info"), i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
 		try {
-			let e = await C();
+			let e = await je();
 			if (e?.ok) {
-				let t = e?.data?.comfy_models ? R("toast.memoryPurgeComplete", "Memory purge complete. Majoor AI and ComfyUI model caches were released.") : R("toast.memoryPurgeCompleteMajoorOnly", "Memory purge complete. Majoor AI caches were released.");
-				A(t, "success", 3200), S(t, "success"), a.style.background = "var(--mjr-status-success, #4CAF50)", fm(n, "success");
+				let t = e?.data?.comfy_models ? L("toast.memoryPurgeComplete", "Memory purge complete. Majoor AI and ComfyUI model caches were released.") : L("toast.memoryPurgeCompleteMajoorOnly", "Memory purge complete. Majoor AI caches were released.");
+				k(t, "success", 3200), S(t, "success"), i.style.background = "var(--mjr-status-success, #4CAF50)", ym(n, "success");
 			} else {
 				let t = String(e?.error || "Memory purge failed");
-				A(t, "error", 4500), S(t, "error"), a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+				k(t, "error", 4500), S(t, "error"), i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 			}
 		} catch (e) {
 			let t = String(e?.message || e || "Memory purge failed");
-			A(t, "error", 4500), S(t, "error"), a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+			k(t, "error", 4500), S(t, "error"), i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 		} finally {
-			w.disabled = !1, E.disabled = !1, T.disabled = !1, w.textContent = r;
+			C.disabled = !1, T.disabled = !1, w.disabled = !1, C.textContent = r;
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, b.appendChild(E), b.appendChild(w), b.appendChild(T), l.appendChild(x);
-	let D = document.createElement("button");
-	D.type = "button", D.textContent = R("btn.deleteDb"), D.title = R("tooltip.deleteDb", "Force-delete database and rebuild from scratch"), D.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,80,80,0.4);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", D.onmouseenter = () => {
-		D.style.borderColor = "rgba(255,80,80,0.8)", D.style.background = "rgba(255,80,80,0.12)";
-	}, D.onmouseleave = () => {
-		D.style.borderColor = "rgba(255,80,80,0.4)", D.style.background = "transparent";
-	}, D.onclick = async (e) => {
+	}, y.appendChild(T), y.appendChild(C), y.appendChild(w), c.appendChild(b);
+	let E = document.createElement("button");
+	E.type = "button", E.textContent = L("btn.deleteDb"), E.title = L("tooltip.deleteDb", "Force-delete database and rebuild from scratch"), E.style.cssText = "\n        padding: 5px 12px;\n        font-size: 11px;\n        border-radius: 6px;\n        border: 1px solid rgba(255,80,80,0.4);\n        background: transparent;\n        color: inherit;\n        cursor: pointer;\n        transition: border 0.2s, background 0.2s;\n    ", E.onmouseenter = () => {
+		E.style.borderColor = "rgba(255,80,80,0.8)", E.style.background = "rgba(255,80,80,0.12)";
+	}, E.onmouseleave = () => {
+		E.style.borderColor = "rgba(255,80,80,0.4)", E.style.background = "transparent";
+	}, E.onclick = async (e) => {
 		e.stopPropagation();
-		let r = await vm(R("btn.deleteDb", "Delete DB"));
-		if (!await Gt(r ? R("dialog.dbDelete.keepVectorsConfirm", "This will reset index data and keep existing AI vectors. Database files will not be force-deleted.\n\nContinue?") : R("dialog.dbDelete.confirm", "This will permanently delete the index database and rebuild it from scratch. All ratings, tags, and cached metadata will be lost.\n\nContinue?"), R("btn.deleteDb", "Delete DB"))) return;
-		om(!0);
-		let i = D.textContent;
-		D.disabled = !0, D.textContent = r ? R("btn.resetting", "Resetting...") : R("btn.deletingDb"), T.disabled = !0, w.disabled = !0, a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info");
+		let r = await Tm(L("btn.deleteDb", "Delete DB"));
+		if (!await Gt(r ? L("dialog.dbDelete.keepVectorsConfirm", "This will reset index data and keep existing AI vectors. Database files will not be force-deleted.\n\nContinue?") : L("dialog.dbDelete.confirm", "This will permanently delete the index database and rebuild it from scratch. All ratings, tags, and cached metadata will be lost.\n\nContinue?"), L("btn.deleteDb", "Delete DB"))) return;
+		pm(!0);
+		let a = E.textContent;
+		E.disabled = !0, E.textContent = r ? L("btn.resetting", "Resetting...") : L("btn.deletingDb"), w.disabled = !0, C.disabled = !0, i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info");
 		try {
-			(r ? await Te({
+			(r ? await Ee({
 				scope: "all",
 				reindex: !0,
 				maintenance_force: !0,
@@ -11854,50 +12091,50 @@ function ym(e = {}) {
 				clear_assets: !1,
 				preserve_vectors: !0,
 				rebuild_fts: !0
-			}) : await c())?.ok ? (globalThis._mjrCorruptToastShown = !1, a.style.background = "var(--mjr-status-success, #4CAF50)", fm(n, "success")) : (a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error"));
+			}) : await s())?.ok ? (globalThis._mjrCorruptToastShown = !1, i.style.background = "var(--mjr-status-success, #4CAF50)", ym(n, "success")) : (i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error"));
 		} catch {
-			a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error");
+			i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error");
 		} finally {
-			om(!1), D.disabled = !1, D.textContent = i, T.disabled = !1, w.disabled = !1, hm(r ? "index-reset-preserve-vectors" : "db-force-delete");
+			pm(!1), E.disabled = !1, E.textContent = a, w.disabled = !1, C.disabled = !1, Sm(r ? "index-reset-preserve-vectors" : "db-force-delete");
 			try {
-				await Om(a, u, d, t ? t() : null, null, { force: !0 });
+				await Fm(i, l, u, t ? t() : null, null, { force: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, b.appendChild(D), l.appendChild(b), n.appendChild(i), n.appendChild(l);
+	}, y.appendChild(E), c.appendChild(y), n.appendChild(r), n.appendChild(c);
 	let O = n.querySelector("#mjr-status-title");
 	O && O.addEventListener("click", (e) => {
 		e.stopPropagation();
 		let t = n.querySelector("#mjr-status-body");
-		t && Tm(n, t.style.display !== "none");
-	}), Tm(n, !0), n.onmouseenter = () => {
+		t && Mm(n, t.style.display !== "none");
+	}), Mm(n, !0), n.onmouseenter = () => {
 		n.style.transform = "translateY(-1px)";
 	}, n.onmouseleave = () => {
-		n.style.transform = "", fm(n, n.dataset?.mjrStatusTone || "neutral", { toast: !1 });
+		n.style.transform = "", ym(n, n.dataset?.mjrStatusTone || "neutral", { toast: !1 });
 	};
-	let k = async (e) => {
+	let A = async (e) => {
 		try {
-			let r = e?.detail || {}, i = String(r?.step || "");
-			if (!i) return;
-			let o = i === "started" || i === "stopping_workers" || i === "resetting_db" || i === "delete_db" || i === "recreate_db" || i === "replacing_files" || i === "restarting_scan";
-			if (o ? om(!0) : (i === "failed" || i === "done") && om(!1), !n?.isConnected || !a?.isConnected || !u?.isConnected) return;
+			let r = e?.detail || {}, a = String(r?.step || "");
+			if (!a) return;
+			let o = a === "started" || a === "stopping_workers" || a === "resetting_db" || a === "delete_db" || a === "recreate_db" || a === "replacing_files" || a === "restarting_scan";
+			if (o ? pm(!0) : (a === "failed" || a === "done") && pm(!1), !n?.isConnected || !i?.isConnected || !l?.isConnected) return;
 			if (o) {
-				a.style.background = "var(--mjr-status-info, #64B5F6)", fm(n, "info", { toast: !1 }), dm(u, R("status.pending", "Pending..."), R("status.dbRestoreInProgress", "Database restore in progress"));
+				i.style.background = "var(--mjr-status-info, #64B5F6)", ym(n, "info", { toast: !1 }), vm(l, L("status.pending", "Pending..."), L("status.dbRestoreInProgress", "Database restore in progress"));
 				return;
 			}
-			if (i === "failed") {
-				a.style.background = "var(--mjr-status-error, #f44336)", fm(n, "error", { toast: !1 }), cm(u, [R("status.error", "Error"), String(r?.message || R("toast.dbRestoreFailed", "Failed to restore DB backup"))]);
+			if (a === "failed") {
+				i.style.background = "var(--mjr-status-error, #f44336)", ym(n, "error", { toast: !1 }), hm(l, [L("status.error", "Error"), String(r?.message || L("toast.dbRestoreFailed", "Failed to restore DB backup"))]);
 				return;
 			}
-			if (i === "done") {
-				a.style.background = "var(--mjr-status-success, #4CAF50)", fm(n, "success", { toast: !1 });
-				let e = String(r?.operation || ""), i = e === "delete_db" ? R("toast.dbDeleteSuccess", "Database deleted and rebuilt. Files are being reindexed.") : e === "reset_index" ? R("toast.resetStarted", "Index reset started. Files will be reindexed in the background.") : R("toast.dbRestoreSuccess", "Database backup restored");
-				dm(u, R("status.ready", "Ready"), i);
+			if (a === "done") {
+				i.style.background = "var(--mjr-status-success, #4CAF50)", ym(n, "success", { toast: !1 });
+				let e = String(r?.operation || ""), a = e === "delete_db" ? L("toast.dbDeleteSuccess", "Database deleted and rebuilt. Files are being reindexed.") : e === "reset_index" ? L("toast.resetStarted", "Index reset started. Files will be reindexed in the background.") : L("toast.dbRestoreSuccess", "Database backup restored");
+				vm(l, L("status.ready", "Ready"), a);
 				try {
 					let e = t ? t() : null;
 					setTimeout(() => {
-						Om(a, u, d, e, null, { force: !0 });
+						Fm(i, l, u, e, null, { force: !0 });
 					}, 600);
 				} catch (e) {
 					console.debug?.(e);
@@ -11908,45 +12145,45 @@ function ym(e = {}) {
 		}
 	};
 	try {
-		let e = tm;
-		typeof e == "function" && window.removeEventListener("mjr-db-restore-status", e), tm = k, n._mjrDbRestoreStatusHandler = k, window.addEventListener("mjr-db-restore-status", k);
+		let e = cm;
+		typeof e == "function" && window.removeEventListener("mjr-db-restore-status", e), cm = A, n._mjrDbRestoreStatusHandler = A, window.addEventListener("mjr-db-restore-status", A);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let M = (e) => {
+	let j = (e) => {
 		try {
 			let t = e?.detail || {}, n = Number(t?.queue_remaining), r = Number(t?.progress_value), i = Number(t?.progress_max), a = Array.isArray(t?.cached_nodes) ? t.cached_nodes.length : 0, o = String(t?.active_prompt_id || "").trim(), s = [
-				Number.isFinite(r) && Number.isFinite(i) && i > 0 ? R("status.runtimeProgress", "Runtime progress: {value}/{max}", {
+				Number.isFinite(r) && Number.isFinite(i) && i > 0 ? L("status.runtimeProgress", "Runtime progress: {value}/{max}", {
 					value: r,
 					max: i
 				}) : "",
-				Number.isFinite(n) ? R("status.queueRemaining", "Queue remaining: {count}", { count: Math.max(0, n) }) : "",
-				a > 0 ? R("status.executionCached", "Cached nodes reused: {count}", { count: a }) : "",
-				o ? R("status.activePrompt", "Active prompt: {id}", { id: o }) : ""
+				Number.isFinite(n) ? L("status.queueRemaining", "Queue remaining: {count}", { count: Math.max(0, n) }) : "",
+				a > 0 ? L("status.executionCached", "Cached nodes reused: {count}", { count: a }) : "",
+				o ? L("status.activePrompt", "Active prompt: {id}", { id: o }) : ""
 			].filter(Boolean);
 			if (!s.length) return;
-			let c = u?.querySelector?.("span");
-			c ? c.textContent = s.join("  |  ") : dm(u, R("status.ready", "Ready"), s.join("  |  "));
+			let c = l?.querySelector?.("span");
+			c ? c.textContent = s.join("  |  ") : vm(l, L("status.ready", "Ready"), s.join("  |  "));
 		} catch (e) {
 			console.debug?.(e);
 		}
 	};
 	try {
-		let e = nm;
-		typeof e == "function" && window.removeEventListener(B.RUNTIME_STATUS, e), nm = M, window.addEventListener(B.RUNTIME_STATUS, M);
+		let e = lm;
+		typeof e == "function" && window.removeEventListener(z.RUNTIME_STATUS, e), lm = j, window.addEventListener(z.RUNTIME_STATUS, j);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return n;
 }
-async function bm(e, t, n = null, r = null) {
-	if (em) {
-		A(R("status.maintenanceBusy", "Database maintenance in progress. Please wait."), "warning", 2200);
+async function Dm(e, t, n = null, r = null) {
+	if (sm) {
+		k(L("status.maintenanceBusy", "Database maintenance in progress. Please wait."), "warning", 2200);
 		return;
 	}
 	let i = t?.closest?.("#mjr-status-body")?.parentElement || t?.closest?.("div"), a = String(r?.scope || "output").toLowerCase(), o = r?.customRootId || r?.custom_root_id || r?.root_id || null;
 	if (a === "custom" && !o) {
-		e.style.background = "var(--mjr-status-info, #64B5F6)", fm(i, "info"), dm(t, R("status.customBrowserScanDisabled", "Custom browser mode: scan is disabled"), R("status.customBrowserScanDisabledHint", "Use Outputs, Inputs, or All to run indexing scans"));
+		e.style.background = "var(--mjr-status-info, #64B5F6)", ym(i, "info"), vm(t, L("status.customBrowserScanDisabled", "Custom browser mode: scan is disabled"), L("status.customBrowserScanDisabledHint", "Use Outputs, Inputs, or All to run indexing scans"));
 		return;
 	}
 	try {
@@ -11954,7 +12191,7 @@ async function bm(e, t, n = null, r = null) {
 		if (n && typeof n == "object") {
 			let r = e - Number(n.at || 0);
 			if (r >= 0 && r < 10 * 6e4) {
-				dm(t, R("status.scanInProgress", "Scan already running..."), R("status.scanInProgressHint", "Please wait for the current scan to finish"));
+				vm(t, L("status.scanInProgress", "Scan already running..."), L("status.scanInProgressHint", "Please wait for the current scan to finish"));
 				return;
 			}
 		}
@@ -11974,29 +12211,29 @@ async function bm(e, t, n = null, r = null) {
 		}
 	}, c = null;
 	try {
-		let e = await I(lt.ROOTS);
+		let e = await oe(B.ROOTS);
 		e.ok && (c = e.data);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	if (!c) {
-		let n = await I(lt.CONFIG);
+		let n = await oe(B.CONFIG);
 		if (!n.ok) {
-			e.style.background = "var(--mjr-status-error, #f44336)", fm(i, "error"), t.textContent = R("status.errorGetConfig"), s();
+			e.style.background = "var(--mjr-status-error, #f44336)", ym(i, "error"), t.textContent = L("status.errorGetConfig"), s();
 			return;
 		}
 		c = { output_directory: n.data.output_directory };
 	}
-	let l = a === "all" ? R("scope.all", "Inputs + Outputs") : a === "input" ? R("scope.input", "Inputs") : a === "custom" ? R("scope.custom", "Custom") : a === "workflow" ? R("scope.workflow", "Workflow") : R("scope.output", "Outputs"), u = "";
+	let l = a === "all" ? L("scope.all", "Inputs + Outputs") : a === "input" ? L("scope.input", "Inputs") : a === "custom" ? L("scope.custom", "Custom") : a === "workflow" ? L("scope.workflow", "Workflow") : L("scope.output", "Outputs"), u = "";
 	if (a === "input") u = c?.input_directory ? ` (${c.input_directory})` : "";
 	else if (a === "custom") {
 		let e = Array.isArray(c?.custom_roots) ? c.custom_roots : [], t = o ? e.find((e) => e?.id === o) : null;
 		u = t?.path ? ` (${t.path})` : "";
 	} else a === "output" && (u = c?.output_directory ? ` (${c.output_directory})` : "");
-	e.style.background = "var(--mjr-status-info, #64B5F6)", fm(i, "info"), dm(t, R("status.scanningScope", `Scanning ${l}${u}...`, {
+	e.style.background = "var(--mjr-status-info, #64B5F6)", ym(i, "info"), vm(t, L("status.scanningScope", `Scanning ${l}${u}...`, {
 		scope: l,
 		detail: u
-	}), R("status.scanningHint", "This may take a while"));
+	}), L("status.scanningHint", "This may take a while"));
 	let d = {
 		scope: a,
 		recursive: !0,
@@ -12006,54 +12243,54 @@ async function bm(e, t, n = null, r = null) {
 	};
 	if (a === "custom") {
 		if (!o) {
-			e.style.background = "var(--mjr-status-error, #f44336)", fm(i, "error"), t.textContent = R("status.selectCustomFolder"), s();
+			e.style.background = "var(--mjr-status-error, #f44336)", ym(i, "error"), t.textContent = L("status.selectCustomFolder"), s();
 			return;
 		}
 		d.custom_root_id = o;
 	}
 	let f;
 	try {
-		f = await ue(lt.SCAN, d);
+		f = await ue(B.SCAN, d);
 	} finally {
 		s();
 	}
 	if (f?.ok) {
 		let r = f.data;
-		e.style.background = "var(--mjr-status-success, #4CAF50)", fm(i, "success"), dm(t, R("toast.scanComplete"), R("status.scanStats", `Added: ${r.added || 0}  -  Updated: ${r.updated || 0}  -  Skipped: ${r.skipped || 0}`, {
+		e.style.background = "var(--mjr-status-success, #4CAF50)", ym(i, "success"), vm(t, L("toast.scanComplete"), L("status.scanStats", `Added: ${r.added || 0}  -  Updated: ${r.updated || 0}  -  Skipped: ${r.skipped || 0}`, {
 			added: r.added || 0,
 			updated: r.updated || 0,
 			skipped: r.skipped || 0
-		})), gm("scan-complete", { stats: {
+		})), Cm("scan-complete", { stats: {
 			added: r.added || 0,
 			updated: r.updated || 0,
 			skipped: r.skipped || 0
 		} }), setTimeout(() => {
-			Om(e, t, n);
+			Fm(e, t, n);
 		}, 2e3);
-	} else e.style.background = "var(--mjr-status-error, #f44336)", fm(i, "error"), cm(t, [R("toast.scanFailed") + `: ${f?.error || "Unknown error"}`]), setTimeout(() => {
-		Om(e, t, n);
+	} else e.style.background = "var(--mjr-status-error, #f44336)", ym(i, "error"), hm(t, [L("toast.scanFailed") + `: ${f?.error || "Unknown error"}`]), setTimeout(() => {
+		Fm(e, t, n);
 	}, 3e3);
 }
-function xm(e, t, n) {
+function Om(e, t, n) {
 	let r = document.createElement("span");
-	return r.style.cssText = "\n        display: inline-flex;\n        align-items: center;\n        gap: 4px;\n        padding: 2px 6px;\n        border-radius: 999px;\n        background: rgba(255, 255, 255, 0.05);\n        border: 1px solid rgba(255, 255, 255, 0.1);\n    ", r.textContent = `${t ? "OK" : "ERR"} ${e}`, r.title = t ? R("status.toolAvailable", `${e} available`, { tool: e }) : n || R("status.toolUnavailable", `${e} unavailable`, { tool: e }), r.style.opacity = t ? "1" : "0.75", r;
+	return r.style.cssText = "\n        display: inline-flex;\n        align-items: center;\n        gap: 4px;\n        padding: 2px 6px;\n        border-radius: 999px;\n        background: rgba(255, 255, 255, 0.05);\n        border: 1px solid rgba(255, 255, 255, 0.1);\n    ", r.textContent = `${t ? "OK" : "ERR"} ${e}`, r.title = t ? L("status.toolAvailable", `${e} available`, { tool: e }) : n || L("status.toolUnavailable", `${e} unavailable`, { tool: e }), r.style.opacity = t ? "1" : "0.75", r;
 }
-function Sm(e, t = {}, n = {}) {
+function km(e, t = {}, n = {}) {
 	if (!e) return;
 	if (e.replaceChildren(), !t || Object.keys(t).length === 0) {
-		e.textContent = R("status.discoveringTools");
+		e.textContent = L("status.discoveringTools");
 		return;
 	}
 	let r = document.createElement("div");
-	r.style.display = "flex", r.style.flexWrap = "wrap", r.style.gap = "10px", r.style.alignItems = "flex-start", $p.forEach(({ key: e, labelKey: i, hintKey: a }) => {
-		let o = !!t[e], s = n[e], c = R(i, e), l = R(a, "");
-		r.appendChild(wm({
+	r.style.display = "flex", r.style.flexWrap = "wrap", r.style.gap = "10px", r.style.alignItems = "flex-start", om.forEach(({ key: e, labelKey: i, hintKey: a }) => {
+		let o = !!t[e], s = n[e], c = L(i, e), l = L(a, "");
+		r.appendChild(jm({
 			label: c,
 			hint: l
 		}, o, s));
 	}), e.appendChild(r);
 }
-function Cm(e, t = null, n = {}) {
+function Am(e, t = null, n = {}) {
 	if (!e) return;
 	let r = e.parentElement;
 	if (!r) return;
@@ -12061,35 +12298,35 @@ function Cm(e, t = null, n = {}) {
 	if (!i) return;
 	let a = n && Object.keys(n).length > 0;
 	if (!t && !a) {
-		i.textContent = R("status.toolStatusChecking", "Tool status: checking...");
+		i.textContent = L("status.toolStatusChecking", "Tool status: checking...");
 		return;
 	}
-	i.textContent = $p.map(({ key: e, labelKey: r }) => {
-		let i = R(r, e), a = t && e in t ? t[e] : void 0, o = e in n ? n[e] : void 0, s = a === void 0 ? o : a, c = s == null ? R("status.unknown", "unknown") : s ? R("status.available", "available") : R("status.missing", "missing"), l = t?.versions?.[e];
+	i.textContent = om.map(({ key: e, labelKey: r }) => {
+		let i = L(r, e), a = t && e in t ? t[e] : void 0, o = e in n ? n[e] : void 0, s = a === void 0 ? o : a, c = s == null ? L("status.unknown", "unknown") : s ? L("status.available", "available") : L("status.missing", "missing"), l = t?.versions?.[e];
 		return l ? `${i}: ${c} - ${l}` : `${i}: ${c}`;
 	}).join("  |  ");
 }
-function wm({ label: e, hint: t }, n, r) {
+function jm({ label: e, hint: t }, n, r) {
 	let i = document.createElement("div");
 	i.style.cssText = "\n        display: flex;\n        flex-direction: column;\n        gap: 3px;\n        padding: 6px 8px;\n        border-radius: 8px;\n        background: rgba(255, 255, 255, 0.03);\n        border: 1px solid rgba(255, 255, 255, 0.08);\n        min-width: 170px;\n    ";
-	let a = xm(e, n, t);
+	let a = Om(e, n, t);
 	a.style.fontWeight = "500", i.appendChild(a);
 	let o = document.createElement("span");
-	return o.style.fontSize = "10px", o.style.opacity = "0.7", o.style.wordBreak = "break-all", o.textContent = R("status.path", "Path") + `: ${r || R("status.pathAuto", "auto / not configured")}`, i.appendChild(o), i;
+	return o.style.fontSize = "10px", o.style.opacity = "0.7", o.style.wordBreak = "break-all", o.textContent = L("status.path", "Path") + `: ${r || L("status.pathAuto", "auto / not configured")}`, i.appendChild(o), i;
 }
-function Tm(e, t) {
+function Mm(e, t) {
 	let n = e.querySelector("#mjr-status-body"), r = e.querySelector("#mjr-status-title-indicator");
 	!n || !r || (t ? (n.style.display = "none", r.textContent = ">") : (n.style.display = "", r.textContent = "v"));
 }
-function Em(e, t) {
+function Nm(e, t) {
 	let n = !!e?.database?.available, r = t?.diagnostics || {}, i = !!r?.malformed, a = !!r?.locked;
-	return !n || i ? R("status.dbHealthError", "DB health: error") : a ? R("status.dbHealthLocked", "DB health: locked") : R("status.dbHealthOk", "DB health: ok");
+	return !n || i ? L("status.dbHealthError", "DB health: error") : a ? L("status.dbHealthLocked", "DB health: locked") : L("status.dbHealthOk", "DB health: ok");
 }
-function Dm(e, t) {
-	let n = Number(e?.total_assets || 0), r = e?.last_index_end, i = e?.last_scan_end, a = t === "all" ? R("scope.all", "Inputs + Outputs") : t === "input" ? R("scope.input", "Inputs") : t === "custom" ? R("scope.custom", "Custom") : t === "workflow" ? R("scope.workflow", "Workflow") : R("scope.output", "Outputs");
-	return !Number.isFinite(n) || n <= 0 ? `${R("status.indexHealthEmpty", "Index health: empty")} (${a})` : !r && !i ? `${R("status.indexHealthPartial", "Index health: partial")} (${a})` : `${R("status.indexHealthOk", "Index health: ok")} (${a})`;
+function Pm(e, t) {
+	let n = Number(e?.total_assets || 0), r = e?.last_index_end, i = e?.last_scan_end, a = t === "all" ? L("scope.all", "Inputs + Outputs") : t === "input" ? L("scope.input", "Inputs") : t === "custom" ? L("scope.custom", "Custom") : t === "workflow" ? L("scope.workflow", "Workflow") : L("scope.output", "Outputs");
+	return !Number.isFinite(n) || n <= 0 ? `${L("status.indexHealthEmpty", "Index health: empty")} (${a})` : !r && !i ? `${L("status.indexHealthPartial", "Index health: partial")} (${a})` : `${L("status.indexHealthOk", "Index health: ok")} (${a})`;
 }
-async function Om(e, t, n = null, r = null, i = null, a = {}) {
+async function Fm(e, t, n = null, r = null, i = null, a = {}) {
 	let o = t?.closest?.("#mjr-status-body")?.parentElement || t?.closest?.("div"), s = a?.signal || null, c = !!a?.force;
 	try {
 		if (!e?.isConnected || !t?.isConnected) return null;
@@ -12097,27 +12334,27 @@ async function Om(e, t, n = null, r = null, i = null, a = {}) {
 		console.debug?.(e);
 	}
 	try {
-		if (!c && em) return null;
+		if (!c && sm) return null;
 	} catch (e) {
 		console.debug?.(e);
 	}
 	i && typeof i == "object" && (i.lastCode = null, i.lastStatus = null);
-	let l = String(r?.scope || "output").toLowerCase(), u = l === "workflow" ? "all" : l, d = r?.customRootId || r?.custom_root_id || r?.root_id || null, f = l === "custom" && !d, p = f ? `${lt.HEALTH_COUNTERS}?scope=all` : u === "custom" ? `${lt.HEALTH_COUNTERS}?scope=custom&custom_root_id=${encodeURIComponent(String(d || ""))}` : `${lt.HEALTH_COUNTERS}?scope=${encodeURIComponent(u || "output")}`, m = !!a?.lightweight, h = !(!c && i && typeof i == "object" && Number(i._scanAuxBackoffUntil || 0) > Date.now()) && (c || !m || !(i && typeof i == "object" && i._auxCached)), g, _, v, y = null;
+	let l = String(r?.scope || "output").toLowerCase(), u = l === "workflow" ? "all" : l, d = r?.customRootId || r?.custom_root_id || r?.root_id || null, f = l === "custom" && !d, p = f ? `${B.HEALTH_COUNTERS}?scope=all` : u === "custom" ? `${B.HEALTH_COUNTERS}?scope=custom&custom_root_id=${encodeURIComponent(String(d || ""))}` : `${B.HEALTH_COUNTERS}?scope=${encodeURIComponent(u || "output")}`, m = !!a?.lightweight, h = !(!c && i && typeof i == "object" && Number(i._scanAuxBackoffUntil || 0) > Date.now()) && (c || !m || !(i && typeof i == "object" && i._auxCached)), g, _, v, y = null;
 	if (h) {
 		let [e, t, n] = await Promise.all([
-			I(p, s ? { signal: s } : void 0),
-			I(lt.HEALTH, s ? { signal: s } : void 0),
-			I(lt.HEALTH_DB, s ? { signal: s } : void 0)
+			oe(p, s ? { signal: s } : void 0),
+			oe(B.HEALTH, s ? { signal: s } : void 0),
+			oe(B.HEALTH_DB, s ? { signal: s } : void 0)
 		]);
 		g = e, _ = t, v = n;
 		try {
-			let e = await _e(s ? { signal: s } : void 0);
+			let e = await ve(s ? { signal: s } : void 0);
 			e?.ok && (y = e.data);
 		} catch (e) {
 			console.debug?.(e);
 		}
 		i && typeof i == "object" && (i._auxCached = !0, i._healthCache = _, i._dbDiagCache = v, i._toolsCache = y);
-	} else g = await I(p, s ? { signal: s } : void 0), _ = i?._healthCache || null, v = i?._dbDiagCache || null, y = i?._toolsCache || null;
+	} else g = await oe(p, s ? { signal: s } : void 0), _ = i?._healthCache || null, v = i?._dbDiagCache || null, y = i?._toolsCache || null;
 	try {
 		if (s?.aborted) return null;
 	} catch (e) {
@@ -12131,17 +12368,17 @@ async function Om(e, t, n = null, r = null, i = null, a = {}) {
 	if (i && typeof i == "object" && (i.lastCode = g?.code || null, i.lastStatus = typeof g?.status == "number" ? g.status : null), g.ok) {
 		let r = g.data;
 		i && typeof i == "object" && (i._scanAuxBackoffUntil = r?.scan_active ? Date.now() + 3e4 : 0);
-		let a = r.total_assets || 0, c = r.with_workflows - 0, u = r.with_generation_data - 0, p = Math.max(0, Number(c || 0) || 0), m = r.last_scan_end, h = m ? new Date(m).toLocaleString() : "N/A", b = r.tool_availability || {}, x = r.tool_paths || {}, S = R("status.dbSize", "Database size: {size}", { size: sm(r.db_size_bytes || 0) }), C = _?.ok && _?.data && _.data.vector || {}, w = C?.enabled !== !1, T = !!C?.loaded, E = !!C?.degraded, D = String(C?.last_error || "").trim(), O = w ? E ? `AI vector: degraded${D ? ` (${D})` : ""}` : T ? "AI vector: loaded" : "AI vector: initializing" : "AI vector: disabled", k = Em(_?.data || null, v?.data || null), A = Dm(r, f ? "all" : l), j = !!(_?.ok && _?.data?.database?.available), M = v?.ok && v?.data?.diagnostics || {}, N = !!M?.malformed, ee = !!M?.locked, te = !!M?.maintenance_active;
-		om(te);
-		let ne = Math.max(0, Number(r?.enrichment_queue_length || 0) || 0), P = Lt().active || ne > 0;
-		Ct(P, ne);
+		let a = r.total_assets || 0, c = r.with_workflows - 0, u = r.with_generation_data - 0, p = Math.max(0, Number(c || 0) || 0), m = r.last_scan_end, h = m ? new Date(m).toLocaleString() : "N/A", b = r.tool_availability || {}, x = r.tool_paths || {}, S = L("status.dbSize", "Database size: {size}", { size: mm(r.db_size_bytes || 0) }), C = _?.ok && _?.data && _.data.vector || {}, w = C?.enabled !== !1, T = !!C?.loaded, E = !!C?.degraded, D = String(C?.last_error || "").trim(), O = w ? E ? `AI vector: degraded${D ? ` (${D})` : ""}` : T ? "AI vector: loaded" : "AI vector: initializing" : "AI vector: disabled", k = Nm(_?.data || null, v?.data || null), A = Pm(r, f ? "all" : l), j = !!(_?.ok && _?.data?.database?.available), M = v?.ok && v?.data?.diagnostics || {}, N = !!M?.malformed, ee = !!M?.locked, P = !!M?.maintenance_active;
+		pm(P);
+		let te = Math.max(0, Number(r?.enrichment_queue_length || 0) || 0), ne = Lt().active || te > 0;
+		Ct(ne, te);
 		let F = Number(a) > 0, re = !!(r?.last_index_end || r?.last_scan_end), ie = F && re, ae = "success";
-		te || P ? ae = "info" : !j || N ? ae = "error" : (ee || !ie || E) && (ae = "warning");
-		let oe = l === "workflow", se = f && ae !== "error" ? "browser" : oe && ae !== "error" ? "workflow" : ae, I = r.watcher;
+		P || ne ? ae = "info" : !j || N ? ae = "error" : (ee || !ie || E) && (ae = "warning");
+		let oe = l === "workflow", se = f && ae !== "error" ? "browser" : oe && ae !== "error" ? "workflow" : ae, ce = r.watcher;
 		try {
-			if (!I || typeof I.enabled != "boolean") {
-				let e = await fe(s ? { signal: s } : void 0);
-				e?.ok && e.data && (I = {
+			if (!ce || typeof ce.enabled != "boolean") {
+				let e = await pe(s ? { signal: s } : void 0);
+				e?.ok && e.data && (ce = {
 					enabled: !!e.data.enabled,
 					scope: r?.watcher?.scope || l,
 					custom_root_id: d || null
@@ -12150,78 +12387,78 @@ async function Om(e, t, n = null, r = null, i = null, a = {}) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let ce = oe ? R("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: R("scope.workflow", "Workflow") }) : f ? R("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: R("scope.customBrowser", "Browser") }) : mm(I, l), le = P ? R("status.enrichmentQueue", "Metadata enrichment queue: {count}", { count: ne }) : R("status.enrichmentIdle", "Metadata enrichment: idle");
-		Sm(n, b, x), Cm(n, y, b);
-		let ue = l === "all" ? R("scope.allFull", "All (Inputs + Outputs)") : l === "input" ? R("scope.input", "Inputs") : l === "custom" ? R("scope.customBrowser", "Browser") : l === "workflow" ? R("scope.workflow", "Workflow") : R("scope.output", "Outputs");
-		return ae === "error" ? (e.style.background = "var(--mjr-status-error, #f44336)", fm(o, "error"), dm(t, R("status.dbCorrupted", "Database appears corrupted or unavailable."), [
+		let le = oe ? L("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: L("scope.workflow", "Workflow") }) : f ? L("status.watcher.disabledScoped", "Watcher: disabled ({scope})", { scope: L("scope.customBrowser", "Browser") }) : xm(ce, l), ue = ne ? L("status.enrichmentQueue", "Metadata enrichment queue: {count}", { count: te }) : L("status.enrichmentIdle", "Metadata enrichment: idle");
+		km(n, b, x), Am(n, y, b);
+		let de = l === "all" ? L("scope.allFull", "All (Inputs + Outputs)") : l === "input" ? L("scope.input", "Inputs") : l === "custom" ? L("scope.customBrowser", "Browser") : l === "workflow" ? L("scope.workflow", "Workflow") : L("scope.output", "Outputs");
+		return ae === "error" ? (e.style.background = "var(--mjr-status-error, #f44336)", ym(o, "error"), vm(t, L("status.dbCorrupted", "Database appears corrupted or unavailable."), [
 			k,
 			A,
 			S,
-			ce
-		].filter(Boolean).join("  |  ")), r) : f ? (e.style.background = "var(--mjr-status-browser, #26A69A)", fm(o, "browser"), dm(t, R("status.ready", "Ready"), [R("status.browserMetricsHidden", "Browser mode: global DB/index metrics hidden"), ce].filter(Boolean).join("  |  ")), r) : oe ? (e.style.background = "#d481c3", fm(o, se), cm(t, [
-			R("status.workflowsIndexed", `${p.toLocaleString()} workflows indexed (${ue})`, {
+			le
+		].filter(Boolean).join("  |  ")), r) : f ? (e.style.background = "var(--mjr-status-browser, #26A69A)", ym(o, "browser"), vm(t, L("status.ready", "Ready"), [L("status.browserMetricsHidden", "Browser mode: global DB/index metrics hidden"), le].filter(Boolean).join("  |  ")), r) : oe ? (e.style.background = "#d481c3", ym(o, se), hm(t, [
+			L("status.workflowsIndexed", `${p.toLocaleString()} workflows indexed (${de})`, {
 				count: p.toLocaleString(),
-				scope: ue
+				scope: de
 			}),
-			R("status.assetsCountReference", `Asset records in DB: ${a.toLocaleString()}`, { count: a.toLocaleString() }),
-			le,
+			L("status.assetsCountReference", `Asset records in DB: ${a.toLocaleString()}`, { count: a.toLocaleString() }),
+			ue,
 			O,
 			k,
 			A,
 			S,
-			ce
-		], R("status.lastScan", `Last scan: ${h}`, { date: h })), r) : (a === 0 ? (e.style.background = se === "browser" ? "var(--mjr-status-browser, #26A69A)" : ae === "info" ? "var(--mjr-status-info, #64B5F6)" : ae === "warning" ? "var(--mjr-status-warning, #FFA726)" : "var(--mjr-status-success, #4CAF50)", fm(o, se), dm(t, R("status.noAssets", `No assets indexed yet (${ue})`, { scope: ue }), [
-			R("status.clickToScan", "Click the dot to start a scan"),
+			le
+		], L("status.lastScan", `Last scan: ${h}`, { date: h })), r) : (a === 0 ? (e.style.background = se === "browser" ? "var(--mjr-status-browser, #26A69A)" : ae === "info" ? "var(--mjr-status-info, #64B5F6)" : ae === "warning" ? "var(--mjr-status-warning, #FFA726)" : "var(--mjr-status-success, #4CAF50)", ym(o, se), vm(t, L("status.noAssets", `No assets indexed yet (${de})`, { scope: de }), [
+			L("status.clickToScan", "Click the dot to start a scan"),
 			O,
 			k,
 			A,
 			S,
-			ce
-		].filter(Boolean).join("  |  "))) : (e.style.background = se === "browser" ? "var(--mjr-status-browser, #26A69A)" : ae === "info" ? "var(--mjr-status-info, #64B5F6)" : ae === "warning" ? "var(--mjr-status-warning, #FFA726)" : "var(--mjr-status-success, #4CAF50)", fm(o, se), cm(t, [
-			R("status.assetsIndexed", `${a.toLocaleString()} assets indexed (${ue})`, {
+			le
+		].filter(Boolean).join("  |  "))) : (e.style.background = se === "browser" ? "var(--mjr-status-browser, #26A69A)" : ae === "info" ? "var(--mjr-status-info, #64B5F6)" : ae === "warning" ? "var(--mjr-status-warning, #FFA726)" : "var(--mjr-status-success, #4CAF50)", ym(o, se), hm(t, [
+			L("status.assetsIndexed", `${a.toLocaleString()} assets indexed (${de})`, {
 				count: a.toLocaleString(),
-				scope: ue
+				scope: de
 			}),
-			Pm(r),
-			R("status.withWorkflows", `With workflows: ${c}  -  Generation data: ${u}`, {
+			Vm(r),
+			L("status.withWorkflows", `With workflows: ${c}  -  Generation data: ${u}`, {
 				workflows: c,
 				gendata: u
 			}),
-			le,
+			ue,
 			O,
 			k,
 			A,
 			S,
-			ce
-		], R("status.lastScan", `Last scan: ${h}`, { date: h })), lm(t, um(r, {
+			le
+		], L("status.lastScan", `Last scan: ${h}`, { date: h })), gm(t, _m(r, {
 			totalAssets: a,
 			withWorkflows: c,
 			withGenerationData: u
 		}))), r);
 	} else {
-		if (Sm(n, {}, {}), Cm(n, y), e.style.background = "var(--mjr-status-error, #f44336)", fm(o, "error"), g?.code === "INVALID_RESPONSE" && g?.status === 404) dm(t, R("status.apiNotFound", "Majoor API endpoints not found (404)"), R("status.apiNotFoundHint", "Backend routes are not loaded. Restart ComfyUI and check the terminal for Majoor import errors."));
+		if (km(n, {}, {}), Am(n, y), e.style.background = "var(--mjr-status-error, #f44336)", ym(o, "error"), g?.code === "INVALID_RESPONSE" && g?.status === 404) vm(t, L("status.apiNotFound", "Majoor API endpoints not found (404)"), L("status.apiNotFoundHint", "Backend routes are not loaded. Restart ComfyUI and check the terminal for Majoor import errors."));
 		else {
 			let e = String(g?.error || "").toLowerCase();
-			e.includes("malform") || e.includes("corrupt") || e.includes("disk image") ? (dm(t, R("status.dbCorrupted"), R("status.dbCorruptedHint")), globalThis._mjrCorruptToastShown || (globalThis._mjrCorruptToastShown = !0, A(R("toast.resetFailedCorrupt"), "error", 8e3))) : cm(t, [g.error || R("status.errorChecking", "Error checking status")]);
+			e.includes("malform") || e.includes("corrupt") || e.includes("disk image") ? (vm(t, L("status.dbCorrupted"), L("status.dbCorruptedHint")), globalThis._mjrCorruptToastShown || (globalThis._mjrCorruptToastShown = !0, k(L("toast.resetFailedCorrupt"), "error", 8e3))) : hm(t, [g.error || L("status.errorChecking", "Error checking status")]);
 		}
 		if (g.code === "SERVICE_UNAVAILABLE") {
-			let i = km(e, t, n, r);
+			let i = Im(e, t, n, r);
 			t.appendChild(document.createElement("br")), t.appendChild(i);
 		}
 	}
 	return null;
 }
-function km(e, t, n = null, r = null) {
+function Im(e, t, n = null, r = null) {
 	let i = document.createElement("button");
-	return i.textContent = R("btn.retryServices"), i.style.cssText = "\n        padding: 4px 10px;\n        margin-top: 6px;\n        font-size: 11px;\n        border-radius: 4px;\n        border: 1px solid rgba(255,255,255,0.3);\n        background: transparent;\n        color: white;\n        cursor: pointer;\n    ", i.onclick = async () => {
-		i.disabled = !0, i.textContent = R("btn.retrying");
-		let a = await ue(lt.RETRY_SERVICES, {});
-		i.disabled = !1, i.textContent = R("btn.retryServices"), a.ok ? Om(e, t, n, r) : (cm(t, [a.error || R("status.retryFailed", "Retry failed")]), t.appendChild(document.createElement("br")), t.appendChild(i));
+	return i.textContent = L("btn.retryServices"), i.style.cssText = "\n        padding: 4px 10px;\n        margin-top: 6px;\n        font-size: 11px;\n        border-radius: 4px;\n        border: 1px solid rgba(255,255,255,0.3);\n        background: transparent;\n        color: white;\n        cursor: pointer;\n    ", i.onclick = async () => {
+		i.disabled = !0, i.textContent = L("btn.retrying");
+		let a = await ue(B.RETRY_SERVICES, {});
+		i.disabled = !1, i.textContent = L("btn.retryServices"), a.ok ? Fm(e, t, n, r) : (hm(t, [a.error || L("status.retryFailed", "Retry failed")]), t.appendChild(document.createElement("br")), t.appendChild(i));
 	}, i;
 }
-function Am() {
+function Lm() {
 	try {
-		let e = localStorage?.getItem?.(rm);
+		let e = localStorage?.getItem?.(um);
 		if (!e) return null;
 		let t = JSON.parse(e);
 		return t && typeof t == "object" ? t : null;
@@ -12229,15 +12466,15 @@ function Am() {
 		return console.debug?.(e), null;
 	}
 }
-function jm(e) {
+function Rm(e) {
 	try {
 		if (!e || typeof e != "object") return;
-		localStorage?.setItem?.(rm, JSON.stringify(e));
+		localStorage?.setItem?.(um, JSON.stringify(e));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Mm(e) {
+function zm(e) {
 	let t = [], n = (e, r = 0) => {
 		if (!(!e || r > 2)) {
 			if (typeof e == "number" && Number.isFinite(e)) {
@@ -12256,23 +12493,23 @@ function Mm(e) {
 	};
 	return n(e, 0), t;
 }
-function Nm(e) {
+function Bm(e) {
 	if (!e || typeof e != "object") return !1;
-	if (em) return !0;
+	if (sm) return !0;
 	try {
 		if (Lt()?.active) return !0;
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return Mm(e).some((e) => Number(e) > 0);
+	return zm(e).some((e) => Number(e) > 0);
 }
-function Pm(e) {
+function Vm(e) {
 	let t = [];
 	e.images && t.push(`Images: ${e.images}`), e.videos && t.push(`Videos: ${e.videos}`), e.audio && t.push(`Audio: ${e.audio}`);
 	let n = e.model3d || e.by_kind?.model3d || 0;
 	return n && t.push(`3D: ${n}`), t.length ? t.join("  -  ") : "Images: 0  -  Videos: 0";
 }
-function Fm(e) {
+function Hm(e) {
 	if (!e || typeof e != "object") return "";
 	let t = (e) => e == null ? null : typeof e == "number" ? Number.isFinite(e) ? e : null : typeof e == "boolean" || typeof e == "string" ? e : null;
 	return JSON.stringify({
@@ -12290,23 +12527,23 @@ function Fm(e) {
 		}
 	});
 }
-function Im(e, t, n) {
-	let r = Am();
+function Um(e, t, n) {
+	let r = Lm();
 	if (!r) return !1;
 	try {
-		Sm(n, r.tool_availability || {}, r.tool_paths || {});
+		km(n, r.tool_availability || {}, r.tool_paths || {});
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		return e.style.background = "var(--mjr-status-info, #64B5F6)", dm(t, R("status.cached", "Last known status"), R("status.checking", "Checking status...")), !0;
+		return e.style.background = "var(--mjr-status-info, #64B5F6)", vm(t, L("status.cached", "Last known status"), L("status.checking", "Checking status...")), !0;
 	} catch (e) {
 		return console.debug?.(e), !1;
 	}
 }
-function Lm(e, t, n) {
-	let r = Fm(t), i = r && r !== String(n?.lastSignature || ""), a = Nm(t), o = e || im.ACTIVE, s = Number(n?.cooldownStablePolls || 0) || 0;
-	return a || i ? (o = im.ACTIVE, s = 0) : o === im.ACTIVE ? (o = im.COOLDOWN, s = 0) : o === im.COOLDOWN ? (s += 1, s >= 3 && (o = im.IDLE, s = 0)) : (o = i ? im.ACTIVE : im.IDLE, s = 0), {
+function Wm(e, t, n) {
+	let r = Hm(t), i = r && r !== String(n?.lastSignature || ""), a = Bm(t), o = e || dm.ACTIVE, s = Number(n?.cooldownStablePolls || 0) || 0;
+	return a || i ? (o = dm.ACTIVE, s = 0) : o === dm.ACTIVE ? (o = dm.COOLDOWN, s = 0) : o === dm.COOLDOWN ? (s += 1, s >= 3 && (o = dm.IDLE, s = 0)) : (o = i ? dm.ACTIVE : dm.IDLE, s = 0), {
 		nextState: o,
 		signature: r,
 		hasChange: i,
@@ -12314,14 +12551,14 @@ function Lm(e, t, n) {
 		cooldownStablePolls: s
 	};
 }
-function Rm(e, t, n, r = null, i = null, a = null) {
+function Gm(e, t, n, r = null, i = null, a = null) {
 	let o = "__MJR_STATUS_POLL_DISPOSE__", s = {
 		lastCode: null,
 		lastStatus: null,
 		_pollTick: 0,
 		_auxCached: !1
 	}, c = {
-		mode: im.ACTIVE,
+		mode: dm.ACTIVE,
 		cooldownStablePolls: 0,
 		lastSignature: ""
 	}, l = typeof AbortController < "u" ? new AbortController() : null, u = async () => {
@@ -12331,14 +12568,14 @@ function Rm(e, t, n, r = null, i = null, a = null) {
 			console.debug?.(e);
 		}
 		s._pollTick = Number(s._pollTick || 0) + 1;
-		let n = s._pollTick > 1 && s._pollTick % 4 != 0, o = await Om(e, t, r, typeof a == "function" ? a() : null, s, {
+		let n = s._pollTick > 1 && s._pollTick % 4 != 0, o = await Fm(e, t, r, typeof a == "function" ? a() : null, s, {
 			signal: l?.signal || null,
 			lightweight: n,
-			force: !!em || s._pollTick <= 1
+			force: !!sm || s._pollTick <= 1
 		});
 		if (o && typeof o == "object") {
-			jm(o);
-			let e = Lm(c.mode, o, c);
+			Rm(o);
+			let e = Wm(c.mode, o, c);
 			c.mode = e.nextState, c.lastSignature = e.signature, c.cooldownStablePolls = e.cooldownStablePolls;
 		}
 		if (o && typeof i == "function") try {
@@ -12348,7 +12585,7 @@ function Rm(e, t, n, r = null, i = null, a = null) {
 		}
 		return o;
 	};
-	Im(e, t, r), u();
+	Um(e, t, r), u();
 	try {
 		n._mjrStatusPollDispose?.();
 	} catch (e) {
@@ -12369,7 +12606,7 @@ function Rm(e, t, n, r = null, i = null, a = null) {
 		}
 		return 1;
 	}, h = () => {
-		let e = am[c.mode] || Math.max(250, Number(z.STATUS_POLL_INTERVAL) || 2e3), t = p ? Math.max(3e4, e) : f > 0 ? Math.min(6e4, Math.round(e * Math.min(8, 1 + f))) : e, r = Math.min(12e4, Math.round(t * m()));
+		let e = fm[c.mode] || Math.max(250, Number(R.STATUS_POLL_INTERVAL) || 2e3), t = p ? Math.max(3e4, e) : f > 0 ? Math.min(6e4, Math.round(e * Math.min(8, 1 + f))) : e, r = Math.min(12e4, Math.round(t * m()));
 		d = setTimeout(async () => {
 			try {
 				if (l?.signal?.aborted) return;
@@ -12377,7 +12614,7 @@ function Rm(e, t, n, r = null, i = null, a = null) {
 				console.debug?.(e);
 			}
 			let e = await u();
-			if (p = s.lastCode === "INVALID_RESPONSE" && s.lastStatus === 404, e ? f = 0 : p ? f = Math.min(999, f + 1) : (f = Math.min(999, f + 1), c.mode = im.ACTIVE, c.cooldownStablePolls = 0), p && f >= 3) {
+			if (p = s.lastCode === "INVALID_RESPONSE" && s.lastStatus === 404, e ? f = 0 : p ? f = Math.min(999, f + 1) : (f = Math.min(999, f + 1), c.mode = dm.ACTIVE, c.cooldownStablePolls = 0), p && f >= 3) {
 				try {
 					n._mjrStatusPollDispose?.();
 				} catch (e) {
@@ -12404,56 +12641,56 @@ function Rm(e, t, n, r = null, i = null, a = null) {
 	h();
 	let g = n.querySelector("#mjr-status-dot");
 	g && (g.onclick = (n) => {
-		n.stopPropagation(), bm(e, t, r, typeof a == "function" ? a() : null);
-	}, g.title = R("status.clickToScan", "Click to scan"));
+		n.stopPropagation(), Dm(e, t, r, typeof a == "function" ? a() : null);
+	}, g.title = L("status.clickToScan", "Click to scan"));
 }
 //#endregion
 //#region ui/vue/composables/useActiveAsset.ts
-var zm = yr(null), Bm = yr(null);
-function Vm() {
+var Km = yr(null), qm = yr(null);
+function Jm() {
 	return {
-		activeAsset: zm,
-		onUpdateCallback: Bm
+		activeAsset: Km,
+		onUpdateCallback: qm
 	};
 }
-function Hm(e, t) {
-	Bm.value = typeof t == "function" ? t : null, zm.value = e ?? null;
+function Ym(e, t) {
+	qm.value = typeof t == "function" ? t : null, Km.value = e ?? null;
 }
-function Um() {
-	zm.value = null, Bm.value = null;
+function Xm() {
+	Km.value = null, qm.value = null;
 }
-function Wm(e, t) {
-	if (!(!zm.value || !e)) {
-		zm.value = {
-			...zm.value,
+function Zm(e, t) {
+	if (!(!Km.value || !e)) {
+		Km.value = {
+			...Km.value,
 			...e
 		};
 		try {
-			let e = t ?? Bm.value;
-			typeof e == "function" && e(zm.value);
+			let e = t ?? qm.value;
+			typeof e == "function" && e(Km.value);
 		} catch {}
 	}
 }
 //#endregion
 //#region ui/components/sidebar/SidebarView.ts
-var Gm = 360, Km = 240, qm = 640;
-function Jm() {
+var Qm = 360, $m = 240, eh = 640;
+function th() {
 	try {
 		let e = mn(), t = Number(e?.sidebar?.widthPx);
-		return Number.isFinite(t) ? Math.max(Km, Math.min(qm, Math.round(t))) : Gm;
+		return Number.isFinite(t) ? Math.max($m, Math.min(eh, Math.round(t))) : Qm;
 	} catch {
-		return Gm;
+		return Qm;
 	}
 }
-function Ym(e, t) {
+function nh(e, t) {
 	if (!e) return;
 	let n = String(e?.dataset?.position || "right").toLowerCase() === "left", r = "var(--mjr-border, rgba(255,255,255,0.12))";
 	if (t) {
-		let t = `${Jm()}px`;
+		let t = `${th()}px`;
 		e.style.flex = `0 0 ${t}`, e.style.width = t, e.style.maxWidth = t, e.style.minWidth = "0", e.style.overflow = "hidden", e.style.borderLeft = n ? "none" : `1px solid ${r}`, e.style.borderRight = n ? `1px solid ${r}` : "none";
 	} else e.style.flex = "0 0 0px", e.style.width = "0", e.style.maxWidth = "0", e.style.minWidth = "0", e.style.overflow = "hidden", e.style.borderLeft = "none", e.style.borderRight = "none";
 }
-function Xm(e) {
+function rh(e) {
 	if (e == null) return !1;
 	let t = e;
 	if (typeof e == "string") {
@@ -12472,10 +12709,10 @@ function Xm(e) {
 	}
 	return !1;
 }
-function Zm(e) {
-	return e ? !!(e.geninfo || e.prompt || Xm(e.metadata_raw)) : !1;
+function ih(e) {
+	return e ? !!(e.geninfo || e.prompt || rh(e.metadata_raw)) : !1;
 }
-async function Qm(e, t, n) {
+async function ah(e, t, n) {
 	if (!e || !t) return;
 	let r = String(t?.kind || "").toLowerCase() === "folder";
 	try {
@@ -12484,7 +12721,7 @@ async function Qm(e, t, n) {
 		console.debug?.(e);
 	}
 	let i = e._requestSeq = (e._requestSeq || 0) + 1;
-	e._currentFetchAbortController?.abort?.(), e._currentFetchAbortController = null, e.classList.add("is-open"), Ym(e, !0), e._currentAsset = t, e._currentFullAsset = t, e._ratingTagsSection = null, Hm(t, n);
+	e._currentFetchAbortController?.abort?.(), e._currentFetchAbortController = null, e.classList.add("is-open"), nh(e, !0), e._currentAsset = t, e._currentFullAsset = t, e._ratingTagsSection = null, Ym(t, n);
 	let a = () => {
 		e._currentFetchAbortController?.abort?.();
 		let t = typeof AbortController < "u" ? new AbortController() : null;
@@ -12493,14 +12730,14 @@ async function Qm(e, t, n) {
 		e._requestSeq !== i || e._currentAsset !== t || (e._currentFullAsset = {
 			...e._currentFullAsset ?? t,
 			...r
-		}, Wm(r, n));
+		}, Zm(r, n));
 	};
 	(async () => {
 		if (e._requestSeq !== i || e._currentAsset !== t) return;
 		let n = a(), s = n.signal;
 		if (r) {
 			try {
-				let e = String(t?.filepath || t?.subfolder || "").trim(), r = String(t?.root_id || t?.rootId || "").trim(), i = await ee({
+				let e = String(t?.filepath || t?.subfolder || "").trim(), r = String(t?.root_id || t?.rootId || "").trim(), i = await M({
 					filepath: e,
 					root_id: r,
 					subfolder: r ? String(t?.subfolder || "").trim() : ""
@@ -12515,8 +12752,8 @@ async function Qm(e, t, n) {
 		}
 		let c = () => e._currentFullAsset ?? t;
 		try {
-			if (t.id && !Zm(c())) {
-				let e = await oe(t.id, n);
+			if (t.id && !ih(c())) {
+				let e = await ie(t.id, n);
 				if (s?.aborted) return;
 				e?.ok && e.data && o(e.data);
 			}
@@ -12524,7 +12761,7 @@ async function Qm(e, t, n) {
 			s?.aborted || console.warn("Failed to load full asset metadata:", e);
 		}
 		if (!s?.aborted) {
-			if (!Zm(c())) {
+			if (!ih(c())) {
 				let e = String(c()?.filename || "").trim(), t = String(c()?.type || "output").trim().toLowerCase(), r = String(c()?.subfolder || "").trim(), i = String(c()?.root_id || c()?.rootId || "").trim();
 				if (e) try {
 					let a = await Oe({
@@ -12553,9 +12790,9 @@ async function Qm(e, t, n) {
 		}
 	})();
 }
-function $m(e) {
+function oh(e) {
 	if (e) {
-		e._requestSeq = (e._requestSeq || 0) + 1, e.classList.remove("is-open"), Ym(e, !1), e._currentAsset = null, e._currentFullAsset = null, e._currentFetchAbortController?.abort?.(), e._currentFetchAbortController = null, Um();
+		e._requestSeq = (e._requestSeq || 0) + 1, e.classList.remove("is-open"), nh(e, !1), e._currentAsset = null, e._currentFullAsset = null, e._currentFetchAbortController?.abort?.(), e._currentFetchAbortController = null, Xm();
 		try {
 			e.dispatchEvent?.(new CustomEvent("mjr:sidebar-closed", { bubbles: !0 }));
 		} catch (e) {
@@ -12565,14 +12802,14 @@ function $m(e) {
 }
 //#endregion
 //#region ui/stores/usePanelStore.ts
-var eh = "mjr_panel_state", th = new Set([
+var sh = "mjr_panel_state", ch = new Set([
 	"output",
 	"input",
 	"all",
 	"custom",
 	"workflow"
 ]);
-function nh(e, t = !1) {
+function lh(e, t = !1) {
 	if (typeof e == "boolean") return e;
 	if (typeof e == "string") {
 		let t = e.trim().toLowerCase();
@@ -12591,70 +12828,70 @@ function nh(e, t = !1) {
 	}
 	return !!t;
 }
-function rh(e, t = 0) {
+function uh(e, t = 0) {
 	let n = Number(e);
 	return Number.isFinite(n) ? n : t;
 }
-function ih(e, t = "") {
+function dh(e, t = "") {
 	return e == null ? t : String(e);
 }
-function ah(e, t = 0, n = Infinity) {
-	return Math.max(t, Math.min(n, Math.floor(rh(e, t))));
+function fh(e, t = 0, n = Infinity) {
+	return Math.max(t, Math.min(n, Math.floor(uh(e, t))));
 }
-function oh(e) {
-	let t = ih(e || "output").toLowerCase(), n = t === "outputs" ? "output" : t === "inputs" ? "input" : t;
-	return th.has(n) ? n : "output";
+function ph(e) {
+	let t = dh(e || "output").toLowerCase(), n = t === "outputs" ? "output" : t === "inputs" ? "input" : t;
+	return ch.has(n) ? n : "output";
 }
-function sh(e) {
+function mh(e) {
 	if (!e || typeof e != "object") return {};
 	let t = e;
 	return {
-		scope: oh(t.scope),
-		customRootId: ih(t.customRootId),
-		customRootLabel: ih(t.customRootLabel),
-		currentFolderRelativePath: ih(t.currentFolderRelativePath || t.subfolder),
-		collectionId: ih(t.collectionId),
-		collectionName: ih(t.collectionName),
-		kindFilter: ih(t.kindFilter),
-		dateRangeFilter: ih(t.dateRangeFilter),
-		dateExactFilter: ih(t.dateExactFilter),
-		workflowOnly: nh(t.workflowOnly, !1),
-		minRating: ah(t.minRating, 0, 5),
-		minSizeMB: Math.max(0, rh(t.minSizeMB, 0)),
-		maxSizeMB: Math.max(0, rh(t.maxSizeMB, 0)),
+		scope: ph(t.scope),
+		customRootId: dh(t.customRootId),
+		customRootLabel: dh(t.customRootLabel),
+		currentFolderRelativePath: dh(t.currentFolderRelativePath || t.subfolder),
+		collectionId: dh(t.collectionId),
+		collectionName: dh(t.collectionName),
+		kindFilter: dh(t.kindFilter),
+		dateRangeFilter: dh(t.dateRangeFilter),
+		dateExactFilter: dh(t.dateExactFilter),
+		workflowOnly: lh(t.workflowOnly, !1),
+		minRating: fh(t.minRating, 0, 5),
+		minSizeMB: Math.max(0, uh(t.minSizeMB, 0)),
+		maxSizeMB: Math.max(0, uh(t.maxSizeMB, 0)),
 		resolutionCompare: t.resolutionCompare === "lte" ? "lte" : "gte",
-		minWidth: ah(t.minWidth),
-		minHeight: ah(t.minHeight),
-		maxWidth: ah(t.maxWidth),
-		maxHeight: ah(t.maxHeight),
-		workflowType: ih(t.workflowType),
-		workflowId: ih(t.workflowId || t.workflow_id),
-		workflowModelFilter: ih(t.workflowModelFilter || t.workflowModel || t.workflow_model),
-		workflowRunsOnFilter: ih(t.workflowRunsOnFilter || t.workflowRunsOn || t.runs_on),
-		sort: ih(t.sort || "mtime_desc"),
-		searchQuery: ih(t.searchQuery),
+		minWidth: fh(t.minWidth),
+		minHeight: fh(t.minHeight),
+		maxWidth: fh(t.maxWidth),
+		maxHeight: fh(t.maxHeight),
+		workflowType: dh(t.workflowType),
+		workflowId: dh(t.workflowId || t.workflow_id),
+		workflowModelFilter: dh(t.workflowModelFilter || t.workflowModel || t.workflow_model),
+		workflowRunsOnFilter: dh(t.workflowRunsOnFilter || t.workflowRunsOn || t.runs_on),
+		sort: dh(t.sort || "mtime_desc"),
+		searchQuery: dh(t.searchQuery),
 		metadataSearchMode: String(t.metadataSearchMode || "AND").toUpperCase() === "OR" ? "OR" : "AND",
-		scrollTop: ah(t.scrollTop),
-		activeAssetId: ih(t.activeAssetId),
-		selectedAssetIds: Array.isArray(t.selectedAssetIds) ? t.selectedAssetIds.map((e) => ih(e).trim()).filter(Boolean).slice(0, 5e3) : [],
-		sidebarOpen: nh(t.sidebarOpen, !1)
+		scrollTop: fh(t.scrollTop),
+		activeAssetId: dh(t.activeAssetId),
+		selectedAssetIds: Array.isArray(t.selectedAssetIds) ? t.selectedAssetIds.map((e) => dh(e).trim()).filter(Boolean).slice(0, 5e3) : [],
+		sidebarOpen: lh(t.sidebarOpen, !1)
 	};
 }
-function ch() {
+function hh() {
 	try {
-		let e = localStorage.getItem(eh);
-		if (e) return sh(JSON.parse(e));
+		let e = localStorage.getItem(sh);
+		if (e) return mh(JSON.parse(e));
 	} catch {}
 	return {};
 }
-function lh(e) {
+function gh(e) {
 	try {
 		let t = { ...e };
-		delete t.lastGridCount, delete t.lastGridTotal, delete t.viewScope, delete t.similarResults, delete t.similarTitle, delete t.similarSourceAssetId, localStorage.setItem(eh, JSON.stringify(t));
+		delete t.lastGridCount, delete t.lastGridTotal, delete t.viewScope, delete t.similarResults, delete t.similarTitle, delete t.similarSourceAssetId, localStorage.setItem(sh, JSON.stringify(t));
 	} catch {}
 }
-var uh = kr("mjr-panel", () => {
-	let e = ch(), t = Z(e.scope || "output"), n = Z(e.customRootId || ""), r = Z(e.customRootLabel || ""), i = Z(e.currentFolderRelativePath || ""), a = Z(e.collectionId || ""), o = Z(e.collectionName || ""), s = Z(e.kindFilter || ""), c = Z(e.dateRangeFilter || ""), l = Z(e.dateExactFilter || ""), u = Z(e.workflowOnly || !1), d = Z(e.minRating || 0), f = Z(e.minSizeMB || 0), p = Z(e.maxSizeMB || 0), m = Z(e.resolutionCompare || "gte"), h = Z(e.minWidth || 0), g = Z(e.minHeight || 0), _ = Z(e.maxWidth || 0), v = Z(e.maxHeight || 0), y = Z(e.workflowType || ""), b = Z(e.workflowId || ""), x = Z(e.workflowModelFilter || ""), S = Z(e.workflowRunsOnFilter || ""), C = Z(e.sort || "mtime_desc"), w = Z(e.searchQuery || ""), T = Z(e.metadataSearchMode || "AND"), E = Z(e.scrollTop || 0), D = Z(e.activeAssetId || ""), O = Z(e.selectedAssetIds || []), k = Z(e.sidebarOpen || !1), A = Z(0), j = Z(0), M = Z(""), N = Z([]), ee = Z(""), te = Z(""), ne = null;
+var _h = kr("mjr-panel", () => {
+	let e = hh(), t = Z(e.scope || "output"), n = Z(e.customRootId || ""), r = Z(e.customRootLabel || ""), i = Z(e.currentFolderRelativePath || ""), a = Z(e.collectionId || ""), o = Z(e.collectionName || ""), s = Z(e.kindFilter || ""), c = Z(e.dateRangeFilter || ""), l = Z(e.dateExactFilter || ""), u = Z(e.workflowOnly || !1), d = Z(e.minRating || 0), f = Z(e.minSizeMB || 0), p = Z(e.maxSizeMB || 0), m = Z(e.resolutionCompare || "gte"), h = Z(e.minWidth || 0), g = Z(e.minHeight || 0), _ = Z(e.maxWidth || 0), v = Z(e.maxHeight || 0), y = Z(e.workflowType || ""), b = Z(e.workflowId || ""), x = Z(e.workflowModelFilter || ""), S = Z(e.workflowRunsOnFilter || ""), C = Z(e.sort || "mtime_desc"), w = Z(e.searchQuery || ""), T = Z(e.metadataSearchMode || "AND"), E = Z(e.scrollTop || 0), D = Z(e.activeAssetId || ""), O = Z(e.selectedAssetIds || []), k = Z(e.sidebarOpen || !1), A = Z(0), j = Z(0), M = Z(""), N = Z([]), ee = Z(""), P = Z(""), te = null;
 	ir([
 		t,
 		n,
@@ -12686,8 +12923,8 @@ var uh = kr("mjr-panel", () => {
 		O,
 		k
 	], () => {
-		ne && clearTimeout(ne), ne = setTimeout(() => {
-			ne = null, lh({
+		te && clearTimeout(te), te = setTimeout(() => {
+			te = null, gh({
 				scope: t.value,
 				customRootId: n.value,
 				customRootLabel: r.value,
@@ -12720,18 +12957,18 @@ var uh = kr("mjr-panel", () => {
 			});
 		}, 750);
 	}, { deep: !0 });
-	let P = (e) => {
-		if (!(e.key !== eh || !e.newValue)) try {
-			let n = sh(JSON.parse(e.newValue));
+	let ne = (e) => {
+		if (!(e.key !== sh || !e.newValue)) try {
+			let n = mh(JSON.parse(e.newValue));
 			n.scope !== void 0 && (t.value = n.scope), n.customRootLabel !== void 0 && (r.value = n.customRootLabel), n.searchQuery !== void 0 && (w.value = n.searchQuery), n.metadataSearchMode !== void 0 && (T.value = n.metadataSearchMode), n.sort !== void 0 && (C.value = n.sort), n.sidebarOpen !== void 0 && (k.value = n.sidebarOpen);
 		} catch {}
 	};
 	try {
-		window.addEventListener("storage", P);
+		window.addEventListener("storage", ne);
 	} catch {}
 	vr(() => {
 		try {
-			window.removeEventListener("storage", P);
+			window.removeEventListener("storage", ne);
 		} catch {}
 	});
 	function F() {
@@ -12744,12 +12981,12 @@ var uh = kr("mjr-panel", () => {
 		O.value = Array.isArray(e) ? e.map(String).filter(Boolean) : [], D.value = t || O.value[0] || "";
 	}
 	function ae(e, s = {}) {
-		t.value = e, i.value = s.folder || "", a.value = s.collectionId || "", o.value = s.collectionName || "", n.value = s.customRootId || "", r.value = s.customRootLabel || "", M.value = "", N.value = [], ee.value = "", te.value = "", re();
+		t.value = e, i.value = s.folder || "", a.value = s.collectionId || "", o.value = s.collectionName || "", n.value = s.customRootId || "", r.value = s.customRootLabel || "", M.value = "", N.value = [], ee.value = "", P.value = "", re();
 	}
-	async function oe() {
+	async function se() {
 		let e = String(n.value || "").trim();
 		if (e) try {
-			let a = await I("/mjr/am/custom-roots"), o = (Array.isArray(a?.data) ? a.data : []).find((t) => String(t?.id || "") === e);
+			let a = await oe("/mjr/am/custom-roots"), o = (Array.isArray(a?.data) ? a.data : []).find((t) => String(t?.id || "") === e);
 			if (!o) {
 				n.value = "", r.value = "", t.value === "custom" && (t.value = "output", i.value = "");
 				return;
@@ -12793,27 +13030,27 @@ var uh = kr("mjr-panel", () => {
 		viewScope: M,
 		similarResults: N,
 		similarTitle: ee,
-		similarSourceAssetId: te,
+		similarSourceAssetId: P,
 		resetFilters: F,
 		clearSelection: re,
 		setSelection: ie,
 		navigateToScope: ae,
-		validatePersistedCustomRoot: oe
+		validatePersistedCustomRoot: se
 	};
 });
 //#endregion
 //#region ui/stores/getOptionalPanelStore.ts
-function dh() {
+function vh() {
 	try {
-		return Ar() ? uh() : null;
+		return Ar() ? _h() : null;
 	} catch {
 		return null;
 	}
 }
 //#endregion
 //#region ui/stores/panelStateBridge.ts
-function fh(e, t = []) {
-	let n = dh();
+function yh(e, t = []) {
+	let n = vh();
 	return {
 		panelStore: n,
 		hydrateStoreFromLegacy: () => {},
@@ -12841,12 +13078,12 @@ function fh(e, t = []) {
 }
 //#endregion
 //#region ui/features/panel/messages/messageCenter.ts
-var ph = "mjr_panel_messages_v1", mh = "mjr_panel_messages_last_read_v1", hh = "mjr_panel_messages_dismissed_builtin_ids_v1", gh = 120, _h = "/mjr/am/user-guide", vh = new Set([
+var bh = "mjr_panel_messages_v1", xh = "mjr_panel_messages_last_read_v1", Sh = "mjr_panel_messages_dismissed_builtin_ids_v1", Ch = 120, wh = "/mjr/am/user-guide", Th = new Set([
 	"info",
 	"success",
 	"warning",
 	"error"
-]), yh = "mjr:panel-messages-changed", bh = !1, xh = [], Sh = Object.freeze([
+]), Eh = "mjr:panel-messages-changed", Dh = !1, Oh = [], kh = Object.freeze([
 	{
 		id: "whats-new-2026-07-09-version-2-5-0",
 		title: "New Version 2.5.0",
@@ -12969,7 +13206,7 @@ var ph = "mjr_panel_messages_v1", mh = "mjr_panel_messages_last_read_v1", hh = "
 		bodyKey: "msg.whatsNew.body.localUserGuide",
 		actionLabel: "User Guide",
 		actionLabelKey: "label.userGuide",
-		actionUrl: _h
+		actionUrl: wh
 	},
 	{
 		id: "tip-2026-04-07-output-folder-override",
@@ -13151,27 +13388,27 @@ var ph = "mjr_panel_messages_v1", mh = "mjr_panel_messages_last_read_v1", hh = "
 		actionLabelKey: "label.settingsGuide",
 		actionUrl: "docs/SETTINGS_CONFIGURATION.md"
 	}
-]), Ch = new Set(Sh.map((e) => String(e?.id || "").trim()).filter(Boolean));
-function wh(e, t = 0) {
+]), Ah = new Set(kh.map((e) => String(e?.id || "").trim()).filter(Boolean));
+function jh(e, t = 0) {
 	let n = Number(e);
 	return Number.isFinite(n) ? n : t;
 }
-function Th() {
+function Mh() {
 	return Date.now();
 }
-function Eh() {
-	return dt(`msg-${Th()}-`, 6);
+function Nh() {
+	return dt(`msg-${Mh()}-`, 6);
 }
-function Dh(e) {
+function Ph(e) {
 	let t = String(e || "").trim().toLowerCase();
-	return t === "warn" ? "warning" : t === "danger" ? "error" : vh.has(t) ? t : "info";
+	return t === "warn" ? "warning" : t === "danger" ? "error" : Th.has(t) ? t : "info";
 }
-function Oh(e) {
-	return Ch.has(String(e || "").trim());
+function Fh(e) {
+	return Ah.has(String(e || "").trim());
 }
-function kh(e = {}) {
+function Ih(e = {}) {
 	return {
-		id: String(e?.id || "").trim() || Eh(),
+		id: String(e?.id || "").trim() || Nh(),
 		title: String(e?.title || "").trim() || "Info",
 		titleKey: String(e?.titleKey || "").trim(),
 		emoji: String(e?.emoji || "").trim(),
@@ -13179,14 +13416,14 @@ function kh(e = {}) {
 		bodyKey: String(e?.bodyKey || "").trim(),
 		category: String(e?.category || "").trim() || "Info",
 		categoryKey: String(e?.categoryKey || "").trim(),
-		createdAt: wh(e?.createdAt, Th()),
-		level: Dh(e?.level),
+		createdAt: jh(e?.createdAt, Mh()),
+		level: Ph(e?.level),
 		actionLabel: String(e?.actionLabel || "").trim(),
 		actionLabelKey: String(e?.actionLabelKey || "").trim(),
 		actionUrl: String(e?.actionUrl || "").trim()
 	};
 }
-function Ah(e, t) {
+function Lh(e, t) {
 	try {
 		let n = localStorage.getItem(e);
 		return n ? JSON.parse(n) : t;
@@ -13194,88 +13431,88 @@ function Ah(e, t) {
 		return t;
 	}
 }
-function jh(e, t) {
+function Rh(e, t) {
 	try {
 		localStorage.setItem(e, JSON.stringify(t));
 	} catch {}
 }
-function Mh() {
+function zh() {
 	try {
-		return wh(localStorage.getItem(mh), 0);
+		return jh(localStorage.getItem(xh), 0);
 	} catch {
 		return 0;
 	}
 }
-function Nh(e) {
+function Bh(e) {
 	try {
-		localStorage.setItem(mh, String(wh(e, Th())));
+		localStorage.setItem(xh, String(jh(e, Mh())));
 	} catch {}
 }
-function Ph() {
-	let e = Ah(hh, []);
-	return new Set((Array.isArray(e) ? e : []).map((e) => String(e || "").trim()).filter((e) => Oh(e)));
+function Vh() {
+	let e = Lh(Sh, []);
+	return new Set((Array.isArray(e) ? e : []).map((e) => String(e || "").trim()).filter((e) => Fh(e)));
 }
-function Fh() {
-	xh.sort((e, t) => Number(t.createdAt || 0) - Number(e.createdAt || 0)), xh.length > gh && (xh = xh.slice(0, gh));
+function Hh() {
+	Oh.sort((e, t) => Number(t.createdAt || 0) - Number(e.createdAt || 0)), Oh.length > Ch && (Oh = Oh.slice(0, Ch));
 }
-function Ih() {
-	jh(ph, xh);
+function Uh() {
+	Rh(bh, Oh);
 }
-function Lh() {
-	let e = Ph(), t = !1;
-	for (let n of Sh) {
-		let r = kh(n);
+function Wh() {
+	let e = Vh(), t = !1;
+	for (let n of kh) {
+		let r = Ih(n);
 		if (e.has(r.id)) continue;
-		let i = xh.findIndex((e) => e.id === r.id);
+		let i = Oh.findIndex((e) => e.id === r.id);
 		if (i < 0) {
-			xh.push(r), t = !0;
+			Oh.push(r), t = !0;
 			continue;
 		}
-		let a = xh[i], o = {
+		let a = Oh[i], o = {
 			...a,
 			...r,
-			createdAt: wh(a?.createdAt, r.createdAt)
+			createdAt: jh(a?.createdAt, r.createdAt)
 		};
-		JSON.stringify(a) !== JSON.stringify(o) && (xh[i] = o, t = !0);
+		JSON.stringify(a) !== JSON.stringify(o) && (Oh[i] = o, t = !0);
 	}
-	return t ? (Fh(), Ih(), !0) : !1;
+	return t ? (Hh(), Uh(), !0) : !1;
 }
-function Rh() {
+function Gh() {
 	try {
-		window.dispatchEvent(new CustomEvent(yh, { detail: {
-			total: xh.length,
-			unread: Hh()
+		window.dispatchEvent(new CustomEvent(Eh, { detail: {
+			total: Oh.length,
+			unread: Yh()
 		} }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function zh() {
-	if (bh) return;
-	bh = !0;
-	let e = Ah(ph, []);
-	xh = (Array.isArray(e) ? e : []).map(kh), Fh();
+function Kh() {
+	if (Dh) return;
+	Dh = !0;
+	let e = Lh(bh, []);
+	Oh = (Array.isArray(e) ? e : []).map(Ih), Hh();
 }
-function Bh() {
-	zh(), Lh() && Rh();
+function qh() {
+	Kh(), Wh() && Gh();
 }
-function Vh() {
-	return zh(), xh.map((e) => ({ ...e }));
+function Jh() {
+	return Kh(), Oh.map((e) => ({ ...e }));
 }
-function Hh() {
-	zh();
-	let e = Mh();
-	return xh.reduce((t, n) => t + +(Number(n.createdAt || 0) > e), 0);
+function Yh() {
+	Kh();
+	let e = zh();
+	return Oh.reduce((t, n) => t + +(Number(n.createdAt || 0) > e), 0);
 }
-function Uh() {
-	return zh(), Mh();
+function Xh() {
+	return Kh(), zh();
 }
-function Wh({ upTo: e = Th() } = {}) {
-	zh(), Nh(wh(e, Th())), Rh();
+function Zh({ upTo: e = Mh() } = {}) {
+	Kh(), Bh(jh(e, Mh())), Gh();
 }
 //#endregion
 //#region ui/features/panel/messages/shortcutGuide.ts
-var Gh = Object.freeze([
+var Qh = Object.freeze([
 	{
 		id: "panel",
 		titleKey: "msg.shortcuts.section.panel",
@@ -13484,22 +13721,22 @@ var Gh = Object.freeze([
 		])
 	}
 ]);
-function Kh() {
-	return Gh.map((e) => ({
+function $h() {
+	return Qh.map((e) => ({
 		...e,
 		items: Array.isArray(e.items) ? e.items.map((e) => ({ ...e })) : []
 	}));
 }
-function qh() {
+function eg() {
 	let e = document.createElement("div");
 	e.className = "mjr-shortcut-guide";
 	let t = document.createElement("div");
-	t.className = "mjr-shortcut-guide-intro", t.textContent = R("msg.shortcuts.intro", "Current keyboard shortcuts grouped by section for quick reference."), e.appendChild(t);
-	for (let t of Kh()) {
+	t.className = "mjr-shortcut-guide-intro", t.textContent = L("msg.shortcuts.intro", "Current keyboard shortcuts grouped by section for quick reference."), e.appendChild(t);
+	for (let t of $h()) {
 		let n = document.createElement("section");
 		n.className = "mjr-shortcut-section";
 		let r = document.createElement("div");
-		r.className = "mjr-shortcut-section-title", r.textContent = R(t.titleKey, t.title), n.appendChild(r);
+		r.className = "mjr-shortcut-section-title", r.textContent = L(t.titleKey, t.title), n.appendChild(r);
 		let i = document.createElement("div");
 		i.className = "mjr-shortcut-list";
 		for (let e of t.items) {
@@ -13516,18 +13753,18 @@ function qh() {
 }
 //#endregion
 //#region ui/features/panel/messages/messagePopoverController.ts
-var Jh = new Set([
+var tg = new Set([
 	"info",
 	"success",
 	"warning",
 	"error"
-]), Yh = 2200, Xh = new Set([
+]), ng = 2200, rg = new Set([
 	"started",
 	"queued",
 	"running",
 	"pending",
 	"in_progress"
-]), Zh = new Set([
+]), ig = new Set([
 	"succeeded",
 	"success",
 	"complete",
@@ -13538,7 +13775,7 @@ var Jh = new Set([
 	"cancelled",
 	"canceled"
 ]);
-function Qh(e) {
+function ag(e) {
 	let t = Number(e);
 	if (!Number.isFinite(t) || t <= 0) return "";
 	try {
@@ -13553,15 +13790,15 @@ function Qh(e) {
 		return "";
 	}
 }
-function $h(e, t, n, r) {
+function og(e, t, n, r) {
 	let i = String(e?.[t] || "").trim(), a = String(e?.[n] || r || "").trim() || String(r || "");
-	return i ? R(i, a) : a;
+	return i ? L(i, a) : a;
 }
-function eg(e) {
+function sg(e) {
 	let t = String(e || "").trim().toLowerCase();
-	return t === "warn" ? "warning" : t === "danger" ? "error" : Jh.has(t) ? t : "info";
+	return t === "warn" ? "warning" : t === "danger" ? "error" : tg.has(t) ? t : "info";
 }
-function tg(e) {
+function cg(e) {
 	let t = String(e || "").trim();
 	if (!t) return "";
 	try {
@@ -13571,13 +13808,13 @@ function tg(e) {
 		return "";
 	}
 }
-function ng(e) {
+function lg(e) {
 	let t = String(e?.emoji || "").trim();
 	if (t) return t;
-	let n = eg(e?.level);
+	let n = sg(e?.level);
 	return n === "success" ? "OK" : n === "warning" ? "WARN" : n === "error" ? "ERR" : "INFO";
 }
-function rg(e) {
+function ug(e) {
 	switch (String(e || "").toLowerCase()) {
 		case "success": return "OK";
 		case "warning": return "WARN";
@@ -13585,22 +13822,22 @@ function rg(e) {
 		default: return "Tip";
 	}
 }
-function ig(e) {
+function dg(e) {
 	if (e?.persistent) return "persistent";
 	let t = Number(e?.durationMs);
 	return !Number.isFinite(t) || t <= 0 ? "" : t < 1e4 ? `${(t / 1e3).toFixed(1)}s` : `${Math.round(t / 1e3)}s`;
 }
-function ag(e) {
+function fg(e) {
 	let t = String(e || "").trim().toLowerCase();
 	return t ? t.replace(/[_-]+/g, " ") : "";
 }
-function og(e) {
+function pg(e) {
 	let t = e?.progress;
 	if (!t || typeof t != "object") return "";
 	let n = String(t.label || "").trim(), r = Number(t.current), i = Number(t.total), a = Number(t.indexed), o = Number(t.skipped), s = Number(t.errors), c = [];
 	return n && c.push(n), Number.isFinite(r) && Number.isFinite(i) && i > 0 && c.push(`${r}/${i}`), Number.isFinite(a) && c.push(`indexed ${a}`), Number.isFinite(o) && c.push(`skipped ${o}`), Number.isFinite(s) && s > 0 && c.push(`errors ${s}`), c.join(" | ");
 }
-function sg(e) {
+function mg(e) {
 	let t = e?.progress;
 	if (!t || typeof t != "object") return null;
 	let n = Number(t.percent);
@@ -13608,15 +13845,15 @@ function sg(e) {
 	let r = Number(t.current), i = Number(t.total);
 	return Number.isFinite(r) && Number.isFinite(i) && i > 0 ? Math.max(0, Math.min(100, Math.round(r / i * 100))) : null;
 }
-function cg(e) {
+function hg(e) {
 	return String(e?.trackId || "").trim() || [
 		String(e?.operation || "").trim(),
 		String(e?.source || "").trim(),
 		String(e?.title || "").trim()
 	].filter(Boolean).join(":");
 }
-function lg({ activeTab: e = "messages", title: t = null, messagePopover: n = null, messageTabBtn: r = null, historyTabBtn: i = null, shortcutsTabBtn: a = null, messageList: o = null, historyPanel: s = null, shortcutsPanel: c = null, markReadBtn: l = null } = {}) {
-	let u = e === "messages", d = e === "history", f = e === "shortcuts", p = u ? R("label.messages", "Messages") : d ? R("label.toastHistory", "History") : R("msg.shortcuts.title", "Shortcut Guide");
+function gg({ activeTab: e = "messages", title: t = null, messagePopover: n = null, messageTabBtn: r = null, historyTabBtn: i = null, shortcutsTabBtn: a = null, messageList: o = null, historyPanel: s = null, shortcutsPanel: c = null, markReadBtn: l = null } = {}) {
+	let u = e === "messages", d = e === "history", f = e === "shortcuts", p = u ? L("label.messages", "Messages") : d ? L("label.toastHistory", "History") : L("msg.shortcuts.title", "Shortcut Guide");
 	try {
 		r?.classList.toggle("is-active", u), r?.setAttribute("aria-selected", u ? "true" : "false"), r?.setAttribute("tabindex", u ? "0" : "-1"), i?.classList.toggle("is-active", d), i?.setAttribute("aria-selected", d ? "true" : "false"), i?.setAttribute("tabindex", d ? "0" : "-1"), a?.classList.toggle("is-active", f), a?.setAttribute("aria-selected", f ? "true" : "false"), a?.setAttribute("tabindex", f ? "0" : "-1");
 	} catch (e) {
@@ -13628,8 +13865,8 @@ function lg({ activeTab: e = "messages", title: t = null, messagePopover: n = nu
 		console.debug?.(e);
 	}
 }
-function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, messageList: i = null, historyTabBtn: a = null, historyTabBadge: o = null, historyTabCount: s = null, historyPanel: c = null, shortcutsPanel: l = null, messageTabBtn: u = null, messageTabBadge: d = null, shortcutsTabBtn: f = null, markReadBtn: p = null, popovers: m = null, onBeforeToggle: h = null, signal: g = null } = {}) {
-	Bh();
+function _g({ messageBtn: t = null, messagePopover: n = null, title: r = null, messageList: i = null, historyTabBtn: a = null, historyTabBadge: o = null, historyTabCount: s = null, historyPanel: c = null, shortcutsPanel: l = null, messageTabBtn: u = null, messageTabBadge: d = null, shortcutsTabBtn: f = null, markReadBtn: p = null, popovers: m = null, onBeforeToggle: h = null, signal: g = null } = {}) {
+	qh();
 	let _ = "messages", v = !1, y = null, b = /* @__PURE__ */ new Set(), x = () => {
 		if (y) {
 			try {
@@ -13639,21 +13876,21 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			}
 			y = null;
 		}
-	}, C = () => {
+	}, S = () => {
 		if (!v || _ !== "history" || n?.style?.display !== "block") return;
-		let e = Ce();
+		let e = ge();
 		for (let t of e) {
-			let e = cg(t);
+			let e = hg(t);
 			if (!e || !b.has(e)) continue;
 			let r = String(t?.status || "").trim().toLowerCase();
-			if (Zh.has(r)) {
+			if (ig.has(r)) {
 				x(), y = setTimeout(() => {
-					y = null, !(!v || _ !== "history") && n?.style?.display === "block" && (m?.close?.(n), v = !1, b.clear(), w(), j());
-				}, Yh);
+					y = null, !(!v || _ !== "history") && n?.style?.display === "block" && (m?.close?.(n), v = !1, b.clear(), C(), A());
+				}, ng);
 				return;
 			}
 		}
-	}, w = () => {
+	}, C = () => {
 		let e = n?.style?.display === "block";
 		try {
 			t?.setAttribute("aria-expanded", e ? "true" : "false");
@@ -13665,18 +13902,18 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, T = () => {
+	}, w = () => {
 		if (!i) return;
-		let e = Vh(), t = Uh();
+		let e = Jh(), t = Xh();
 		if (i.replaceChildren(), !e.length) {
 			let e = document.createElement("div");
-			e.className = "mjr-messages-empty", e.textContent = R("msg.noMessages", "No messages for now."), i.appendChild(e);
+			e.className = "mjr-messages-empty", e.textContent = L("msg.noMessages", "No messages for now."), i.appendChild(e);
 			return;
 		}
 		for (let n of e) {
 			let e = document.createElement("article");
 			e.className = "mjr-message-item";
-			let r = eg(n?.level);
+			let r = sg(n?.level);
 			e.classList.add(`mjr-message-item--${r}`);
 			let a = Number(n?.createdAt || 0);
 			a > Number(t || 0) && e.classList.add("mjr-message-item--unread");
@@ -13685,62 +13922,62 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			let s = document.createElement("div");
 			s.className = "mjr-message-item-title-wrap";
 			let c = document.createElement("span");
-			c.className = "mjr-message-item-emoji", c.textContent = ng(n), c.setAttribute("aria-hidden", "true");
+			c.className = "mjr-message-item-emoji", c.textContent = lg(n), c.setAttribute("aria-hidden", "true");
 			let l = document.createElement("div");
-			l.className = "mjr-message-item-title", l.textContent = $h(n, "titleKey", "title", R("label.info", "Info"));
+			l.className = "mjr-message-item-title", l.textContent = og(n, "titleKey", "title", L("label.info", "Info"));
 			let u = document.createElement("span");
-			u.className = "mjr-message-item-category", u.textContent = $h(n, "categoryKey", "category", R("label.info", "Info")), s.appendChild(c), s.appendChild(l), o.appendChild(s), o.appendChild(u);
+			u.className = "mjr-message-item-category", u.textContent = og(n, "categoryKey", "category", L("label.info", "Info")), s.appendChild(c), s.appendChild(l), o.appendChild(s), o.appendChild(u);
 			let d = document.createElement("div");
-			d.className = "mjr-message-item-meta", d.textContent = Qh(a);
+			d.className = "mjr-message-item-meta", d.textContent = ag(a);
 			let f = document.createElement("div");
-			f.className = "mjr-message-item-body", f.textContent = $h(n, "bodyKey", "body", ""), e.appendChild(o), d.textContent && e.appendChild(d), f.textContent && e.appendChild(f);
-			let p = tg(n?.actionUrl), m = $h(n, "actionLabelKey", "actionLabel", R("label.readMe", "Read Me"));
+			f.className = "mjr-message-item-body", f.textContent = og(n, "bodyKey", "body", ""), e.appendChild(o), d.textContent && e.appendChild(d), f.textContent && e.appendChild(f);
+			let p = cg(n?.actionUrl), m = og(n, "actionLabelKey", "actionLabel", L("label.readMe", "Read Me"));
 			if (p && m) {
 				let t = document.createElement("a");
 				t.className = "mjr-message-item-action", t.href = p, t.target = "_blank", t.rel = "noopener noreferrer", t.textContent = m, e.appendChild(t);
 			}
 			i.appendChild(e);
 		}
-	}, E = () => {
+	}, T = () => {
 		if (!c) return;
-		let t = Ce(), n = c.querySelector(".mjr-history-list");
-		if (!n) {
-			let t = document.createElement("div");
-			t.className = "mjr-history-head";
-			let r = document.createElement("span");
-			r.className = "mjr-history-head-label", r.textContent = R("label.recentActivity", "Recent activity");
-			let i = document.createElement("button");
-			i.type = "button", i.className = "mjr-btn mjr-history-clear-btn", i.textContent = R("btn.clearHistory", "Clear"), i.title = R("tooltip.clearToastHistory", "Clear toast history"), i.addEventListener("click", (t) => {
-				t.stopPropagation(), e(), E();
-			}, g ? { signal: g } : void 0), t.appendChild(r), t.appendChild(i), n = document.createElement("div"), n.className = "mjr-history-list", c.replaceChildren(t, n);
-		}
-		if (n.replaceChildren(), !t.length) {
+		let e = ge(), t = c.querySelector(".mjr-history-list");
+		if (!t) {
 			let e = document.createElement("div");
-			e.className = "mjr-messages-empty", e.textContent = R("msg.noHistory", "No recent activity."), n.appendChild(e);
+			e.className = "mjr-history-head";
+			let n = document.createElement("span");
+			n.className = "mjr-history-head-label", n.textContent = L("label.recentActivity", "Recent activity");
+			let r = document.createElement("button");
+			r.type = "button", r.className = "mjr-btn mjr-history-clear-btn", r.textContent = L("btn.clearHistory", "Clear"), r.title = L("tooltip.clearToastHistory", "Clear toast history"), r.addEventListener("click", (e) => {
+				e.stopPropagation(), ne(), T();
+			}, g ? { signal: g } : void 0), e.appendChild(n), e.appendChild(r), t = document.createElement("div"), t.className = "mjr-history-list", c.replaceChildren(e, t);
+		}
+		if (t.replaceChildren(), !e.length) {
+			let e = document.createElement("div");
+			e.className = "mjr-messages-empty", e.textContent = L("msg.noHistory", "No recent activity."), t.appendChild(e);
 			return;
 		}
-		for (let e of t) {
-			let t = document.createElement("div");
-			t.className = `mjr-history-item mjr-history-item--${String(e.type || "info")}`;
+		for (let n of e) {
+			let e = document.createElement("div");
+			e.className = `mjr-history-item mjr-history-item--${String(n.type || "info")}`;
 			let r = document.createElement("span");
-			r.className = "mjr-history-item-icon", r.textContent = rg(e.type), r.setAttribute("aria-hidden", "true");
+			r.className = "mjr-history-item-icon", r.textContent = ug(n.type), r.setAttribute("aria-hidden", "true");
 			let i = document.createElement("div");
 			i.className = "mjr-history-item-content";
-			let a = String(e.title || "").trim(), o = String(e.detail || "").trim(), s = String(e.message || "").trim(), c = a || s, l = a && o ? o : a ? "" : o, u = document.createElement("div");
+			let a = String(n.title || "").trim(), o = String(n.detail || "").trim(), s = String(n.message || "").trim(), c = a || s, l = a && o ? o : a ? "" : o, u = document.createElement("div");
 			u.className = a ? "mjr-history-item-title" : "mjr-history-item-msg", u.textContent = c;
 			let d = document.createElement("div");
 			d.className = "mjr-history-item-detail", d.textContent = l;
 			let f = document.createElement("div");
 			f.className = "mjr-history-item-meta";
 			let p = document.createElement("span");
-			p.className = "mjr-history-item-time", p.textContent = Qh(e.createdAt);
+			p.className = "mjr-history-item-time", p.textContent = ag(n.createdAt);
 			let m = document.createElement("span");
-			m.className = "mjr-history-item-chip", m.textContent = ig(e);
+			m.className = "mjr-history-item-chip", m.textContent = dg(n);
 			let h = document.createElement("span");
-			h.className = "mjr-history-item-chip", h.textContent = String(e.source || "").trim();
+			h.className = "mjr-history-item-chip", h.textContent = String(n.source || "").trim();
 			let g = document.createElement("span");
-			g.className = "mjr-history-item-chip", g.textContent = ag(e.status), i.appendChild(u), d.textContent && i.appendChild(d), p.textContent && f.appendChild(p), m.textContent && f.appendChild(m), g.textContent && f.appendChild(g), h.textContent && f.appendChild(h), f.childNodes.length && i.appendChild(f);
-			let _ = og(e), v = sg(e);
+			g.className = "mjr-history-item-chip", g.textContent = fg(n.status), i.appendChild(u), d.textContent && i.appendChild(d), p.textContent && f.appendChild(p), m.textContent && f.appendChild(m), g.textContent && f.appendChild(g), h.textContent && f.appendChild(h), f.childNodes.length && i.appendChild(f);
+			let _ = pg(n), v = mg(n);
 			if (_ || v !== null) {
 				let e = document.createElement("div");
 				if (e.className = "mjr-history-item-progress", _) {
@@ -13755,14 +13992,14 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 				}
 				i.appendChild(e);
 			}
-			let y = tg(e?.actionUrl), b = String(e?.actionLabel || "").trim();
+			let y = cg(n?.actionUrl), b = String(n?.actionLabel || "").trim();
 			if (y && b) {
 				let e = document.createElement("a");
 				e.className = "mjr-history-item-action", e.href = y, e.target = "_blank", e.rel = "noopener noreferrer", e.textContent = b, i.appendChild(e);
 			}
-			t.appendChild(r), t.appendChild(i), n.appendChild(t);
+			e.appendChild(r), e.appendChild(i), t.appendChild(e);
 		}
-	}, D = (e, t) => {
+	}, E = (e, t) => {
 		if (!e) return;
 		let n = Math.max(0, Number(t || 0) || 0);
 		if (n <= 0) {
@@ -13770,44 +14007,44 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			return;
 		}
 		e.style.display = "inline-flex", e.textContent = n > 99 ? "99+" : String(n);
+	}, D = () => {
+		let e = we();
+		o && (o.style.display = e > 0 ? "inline-block" : "none"), E(s, e);
 	}, O = () => {
-		let e = re();
-		o && (o.style.display = e > 0 ? "inline-block" : "none"), D(s, e);
+		l && (l.childNodes.length > 0 || l.replaceChildren(eg()));
 	}, k = () => {
-		l && (l.childNodes.length > 0 || l.replaceChildren(qh()));
-	}, A = () => {
 		if (!p) return;
-		let e = Math.max(0, Number(Hh() || 0) || 0);
+		let e = Math.max(0, Number(Yh() || 0) || 0);
 		if (p.disabled = e <= 0, e > 0) {
-			p.title = R("tooltip.markMessagesRead", "Mark all messages as read");
+			p.title = L("tooltip.markMessagesRead", "Mark all messages as read");
 			return;
 		}
-		p.title = R("tooltip.noUnreadMessages", "No unread messages");
-	}, j = () => {
-		let e = Math.max(0, Number(Hh() || 0) || 0);
+		p.title = L("tooltip.noUnreadMessages", "No unread messages");
+	}, A = () => {
+		let e = Math.max(0, Number(Yh() || 0) || 0);
 		if (t) {
-			let n = t.querySelector(".mjr-message-badge"), r = e > 0 ? R("tooltip.openMessagesUnread", "Messages ({count} unread)", { count: e }) : R("tooltip.openMessages", "Messages and updates");
+			let n = t.querySelector(".mjr-message-badge"), r = e > 0 ? L("tooltip.openMessagesUnread", "Messages ({count} unread)", { count: e }) : L("tooltip.openMessages", "Messages and updates");
 			t.classList.toggle("mjr-message-has-unread", e > 0), t.title = r, t.setAttribute("aria-label", r), n && (e <= 0 ? (n.style.display = "none", n.textContent = "") : (n.style.display = "inline-flex", n.textContent = e > 9 ? "9+" : String(e)));
 		}
-		D(d, e), A();
-	}, M = () => {
-		j(), O(), n?.style?.display === "block" && (_ === "messages" && T(), _ === "history" && E());
-	}, N = g ? { signal: g } : void 0;
+		E(d, e), k();
+	}, j = () => {
+		A(), D(), n?.style?.display === "block" && (_ === "messages" && w(), _ === "history" && T());
+	}, M = g ? { signal: g } : void 0;
 	try {
-		window.addEventListener(yh, M, N);
+		window.addEventListener(Eh, j, M);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		window.addEventListener(S, () => {
-			if (O(), n?.style?.display === "block" && _ === "history" && E(), v) {
-				for (let e of Ce()) {
-					let t = String(e?.status || "").trim().toLowerCase(), n = cg(e);
-					n && Xh.has(t) && b.add(n);
+		window.addEventListener(e, () => {
+			if (D(), n?.style?.display === "block" && _ === "history" && T(), v) {
+				for (let e of ge()) {
+					let t = String(e?.status || "").trim().toLowerCase(), n = hg(e);
+					n && rg.has(t) && b.add(n);
 				}
-				C();
+				S();
 			}
-		}, N);
+		}, M);
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -13816,9 +14053,9 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let ee = null;
+	let N = null;
 	try {
-		typeof MutationObserver < "u" && n && (ee = new MutationObserver(w), ee.observe(n, {
+		typeof MutationObserver < "u" && n && (N = new MutationObserver(C), N.observe(n, {
 			attributes: !0,
 			attributeFilter: ["style"]
 		}));
@@ -13826,11 +14063,11 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 		console.debug?.(e);
 	}
 	try {
-		g?.addEventListener?.("abort", () => ee?.disconnect?.(), { once: !0 });
+		g?.addEventListener?.("abort", () => N?.disconnect?.(), { once: !0 });
 	} catch (e) {
 		console.debug?.(e);
 	}
-	j(), O(), w(), lg({
+	A(), D(), C(), gg({
 		activeTab: _,
 		title: r,
 		messagePopover: n,
@@ -13842,8 +14079,8 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 		shortcutsPanel: l,
 		markReadBtn: p
 	});
-	let te = () => {
-		_ = "messages", lg({
+	let ee = () => {
+		_ = "messages", gg({
 			activeTab: _,
 			title: r,
 			messagePopover: n,
@@ -13854,22 +14091,9 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			historyPanel: c,
 			shortcutsPanel: l,
 			markReadBtn: p
-		}), T(), Wh(), j();
-	}, ne = () => {
-		_ = "history", lg({
-			activeTab: _,
-			title: r,
-			messagePopover: n,
-			messageTabBtn: u,
-			historyTabBtn: a,
-			shortcutsTabBtn: f,
-			messageList: i,
-			historyPanel: c,
-			shortcutsPanel: l,
-			markReadBtn: p
-		}), E(), he(), O();
+		}), w(), Zh(), A();
 	}, P = () => {
-		_ = "shortcuts", lg({
+		_ = "history", gg({
 			activeTab: _,
 			title: r,
 			messagePopover: n,
@@ -13880,18 +14104,31 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			historyPanel: c,
 			shortcutsPanel: l,
 			markReadBtn: p
-		}), k();
+		}), T(), Se(), D();
+	}, te = () => {
+		_ = "shortcuts", gg({
+			activeTab: _,
+			title: r,
+			messagePopover: n,
+			messageTabBtn: u,
+			historyTabBtn: a,
+			shortcutsTabBtn: f,
+			messageList: i,
+			historyPanel: c,
+			shortcutsPanel: l,
+			markReadBtn: p
+		}), O();
 	}, F = (e) => {
 		if (e === "messages") {
-			te();
+			ee();
 			return;
 		}
 		if (e === "history") {
-			ne();
+			P();
 			return;
 		}
-		P();
-	}, ie = () => {
+		te();
+	}, re = () => {
 		if (!(!n || !m || !t)) {
 			if (n?.style?.display !== "block") {
 				try {
@@ -13901,46 +14138,46 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 				}
 				m.toggle(n, t);
 			}
-			ne(), v = !0, x(), b.clear();
-			for (let e of Ce()) {
-				let t = String(e?.status || "").trim().toLowerCase(), n = cg(e);
-				n && Xh.has(t) && b.add(n);
+			P(), v = !0, x(), b.clear();
+			for (let e of ge()) {
+				let t = String(e?.status || "").trim().toLowerCase(), n = hg(e);
+				n && rg.has(t) && b.add(n);
 			}
-			C(), w(), j();
+			S(), C(), A();
 		}
 	};
 	try {
-		window.addEventListener(B.OPEN_MESSAGE_HISTORY, () => {
-			ie();
-		}, N);
+		window.addEventListener(z.OPEN_MESSAGE_HISTORY, () => {
+			re();
+		}, M);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let ae = [
+	let ie = [
 		"messages",
 		"history",
 		"shortcuts"
-	], oe = (e, t) => {
-		let n = String(e?.key || "").toLowerCase(), r = ae.indexOf(String(t || "").toLowerCase());
+	], ae = (e, t) => {
+		let n = String(e?.key || "").toLowerCase(), r = ie.indexOf(String(t || "").toLowerCase());
 		if (!(r < 0)) {
 			if (n === "arrowright") {
 				e.preventDefault();
-				let t = ae[(r + 1) % ae.length];
+				let t = ie[(r + 1) % ie.length];
 				F(t), t === "messages" && u?.focus?.(), t === "history" && a?.focus?.(), t === "shortcuts" && f?.focus?.();
 				return;
 			}
 			if (n === "arrowleft") {
 				e.preventDefault();
-				let t = ae[(r + ae.length - 1) % ae.length];
+				let t = ie[(r + ie.length - 1) % ie.length];
 				F(t), t === "messages" && u?.focus?.(), t === "history" && a?.focus?.(), t === "shortcuts" && f?.focus?.();
 				return;
 			}
 			if (n === "home") {
-				e.preventDefault(), te(), u?.focus?.();
+				e.preventDefault(), ee(), u?.focus?.();
 				return;
 			}
 			if (n === "end") {
-				e.preventDefault(), P(), f?.focus?.();
+				e.preventDefault(), te(), f?.focus?.();
 				return;
 			}
 			(n === " " || n === "enter") && (e.preventDefault(), F(t));
@@ -13948,7 +14185,7 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 	};
 	return t?.addEventListener("click", (e) => {
 		if (!(!n || !m || !t)) {
-			e.stopPropagation(), v = !1, b.clear(), x(), _ = "messages", T(), k(), lg({
+			e.stopPropagation(), v = !1, b.clear(), x(), _ = "messages", w(), O(), gg({
 				activeTab: _,
 				title: r,
 				messagePopover: n,
@@ -13965,32 +14202,32 @@ function ug({ messageBtn: t = null, messagePopover: n = null, title: r = null, m
 			} catch (e) {
 				console.debug?.(e);
 			}
-			m.toggle(n, t), n?.style?.display === "block" && Wh(), w(), j();
+			m.toggle(n, t), n?.style?.display === "block" && Zh(), C(), A();
 		}
-	}, N), u?.addEventListener("click", (e) => {
+	}, M), u?.addEventListener("click", (e) => {
+		e.preventDefault(), e.stopPropagation(), ee();
+	}, M), u?.addEventListener("keydown", (e) => ae(e, "messages"), M), a?.addEventListener("click", (e) => {
+		e.preventDefault(), e.stopPropagation(), v = !1, b.clear(), x(), P();
+	}, M), a?.addEventListener("keydown", (e) => ae(e, "history"), M), f?.addEventListener("click", (e) => {
 		e.preventDefault(), e.stopPropagation(), te();
-	}, N), u?.addEventListener("keydown", (e) => oe(e, "messages"), N), a?.addEventListener("click", (e) => {
-		e.preventDefault(), e.stopPropagation(), v = !1, b.clear(), x(), ne();
-	}, N), a?.addEventListener("keydown", (e) => oe(e, "history"), N), f?.addEventListener("click", (e) => {
-		e.preventDefault(), e.stopPropagation(), P();
-	}, N), f?.addEventListener("keydown", (e) => oe(e, "shortcuts"), N), p?.addEventListener("click", (e) => {
-		e.preventDefault(), e.stopPropagation(), Wh(), T(), j();
-	}, N), {
-		refresh: M,
-		render: T,
-		updateButtonState: j,
-		showMessagesTab: te,
-		showHistoryTab: ne,
-		showShortcutsTab: P,
-		openHistoryPopover: ie,
+	}, M), f?.addEventListener("keydown", (e) => ae(e, "shortcuts"), M), p?.addEventListener("click", (e) => {
+		e.preventDefault(), e.stopPropagation(), Zh(), w(), A();
+	}, M), {
+		refresh: j,
+		render: w,
+		updateButtonState: A,
+		showMessagesTab: ee,
+		showHistoryTab: P,
+		showShortcutsTab: te,
+		openHistoryPopover: re,
 		close: () => {
-			!n || !m || (m.close(n), v = !1, b.clear(), x(), w());
+			!n || !m || (m.close(n), v = !1, b.clear(), x(), C());
 		}
 	};
 }
 //#endregion
 //#region ui/features/panel/controllers/query.ts
-function dg(e) {
+function vg(e) {
 	let t = e;
 	for (let e = 0; e < 3 && !(!t || typeof t != "object" || !("value" in t)); e += 1) {
 		let e = t.value;
@@ -13999,8 +14236,8 @@ function dg(e) {
 	}
 	return t;
 }
-function fg(e) {
-	let t = dg(e);
+function yg(e) {
+	let t = vg(e);
 	if (!t) return null;
 	let n = String(t?.tagName || "").toUpperCase();
 	if (n === "INPUT" || n === "TEXTAREA") return t;
@@ -14014,14 +14251,14 @@ function fg(e) {
 	}
 	return null;
 }
-function pg(e) {
-	let t = fg(e), n = t ? t.value : typeof e?.value == "string" ? e.value : "";
+function bg(e) {
+	let t = yg(e), n = t ? t.value : typeof e?.value == "string" ? e.value : "";
 	return String(n || "").trim() || "*";
 }
 //#endregion
 //#region ui/features/panel/controllers/gridController.ts
-function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollectionAssets: r, disposeGrid: i, getQuery: a, searchInputEl: o, state: s }) {
-	let { read: c, write: u } = fh(s, /* @__PURE__ */ "scope.customRootId.currentFolderRelativePath.kindFilter.workflowOnly.minRating.minSizeMB.maxSizeMB.resolutionCompare.minWidth.minHeight.maxWidth.maxHeight.workflowType.workflowId.workflowModelFilter.workflowRunsOnFilter.dateRangeFilter.dateExactFilter.sort.activeAssetId.selectedAssetIds.collectionId.collectionName.viewScope.similarResults.similarTitle.similarSourceAssetId.lastGridCount.lastGridTotal".split(".")), d = !1, f = !1, m = {}, h = 0, g = 0, _ = 3e4, v = async (e, t = _) => {
+function xg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollectionAssets: r, disposeGrid: i, getQuery: a, searchInputEl: o, state: s }) {
+	let { read: c, write: l } = yh(s, /* @__PURE__ */ "scope.customRootId.currentFolderRelativePath.kindFilter.workflowOnly.minRating.minSizeMB.maxSizeMB.resolutionCompare.minWidth.minHeight.maxWidth.maxHeight.workflowType.workflowId.workflowModelFilter.workflowRunsOnFilter.dateRangeFilter.dateExactFilter.sort.activeAssetId.selectedAssetIds.collectionId.collectionName.viewScope.similarResults.similarTitle.similarSourceAssetId.lastGridCount.lastGridTotal".split(".")), u = !1, d = !1, f = {}, p = 0, h = 0, g = 3e4, _ = async (e, t = g) => {
 		let n = null;
 		try {
 			let r = new Promise((e, r) => {
@@ -14034,19 +14271,19 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 		} finally {
 			n && clearTimeout(n);
 		}
-	}, y = () => {
+	}, v = () => {
 		try {
 			return o?.dataset?.mjrSemanticMode === "1";
 		} catch {
 			return !1;
 		}
-	}, b = () => {
+	}, y = () => {
 		try {
 			return !!(mn()?.ai?.vectorSearchEnabled ?? !0);
 		} catch {
 			return !0;
 		}
-	}, x = (e, t = "") => {
+	}, b = (e, t = "") => {
 		try {
 			if (e && typeof e == "object") return String(e.error || e.message || t || "").trim();
 		} catch {}
@@ -14055,11 +14292,11 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 		} catch {
 			return String(t || "").trim();
 		}
-	}, S = (e = []) => !Array.isArray(e) || e.length === 0 ? !1 : e.some((e) => {
+	}, x = (e = []) => !Array.isArray(e) || e.length === 0 ? !1 : e.some((e) => {
 		if (String(e?._matchType || e?.matchType || "").trim().toLowerCase().includes("semantic")) return !0;
 		let t = Number(e?._vectorScore ?? e?.vectorScore ?? NaN);
 		return Number.isFinite(t) && t > 0;
-	}), C = () => {
+	}), S = () => {
 		let e = String(c("currentFolderRelativePath", "") || "").trim();
 		return {
 			subfolder: !(c("scope", "output") === "custom" && !c("customRootId", "")) && e ? e : null,
@@ -14079,20 +14316,20 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 			dateRange: String(c("dateRangeFilter", "") || "").trim().toLowerCase() || null,
 			dateExact: String(c("dateExactFilter", "") || "").trim() || null
 		};
-	}, w = async (e = "") => {
+	}, C = async (e = "") => {
 		let t = Date.now();
-		if (!(t - Number(g || 0) < 15e3)) {
-			g = t;
+		if (!(t - Number(h || 0) < 15e3)) {
+			h = t;
 			try {
-				let e = await p();
+				let e = await xe();
 				if (e?.ok && e?.data) {
 					let t = Number(e.data?.total || 0) || 0, n = Number(e.data?.eligible_total || 0) || 0, r = Number(e.data?.coverage_ratio ?? NaN);
 					if (t <= 10) {
-						A(R("toast.aiSearchNeedsBackfill", "AI search index is almost empty ({count} vectors). Run Enrich, then Vector Backfill for existing assets.", { count: t }), "warn", 6500);
+						k(L("toast.aiSearchNeedsBackfill", "AI search index is almost empty ({count} vectors). Run Enrich, then Vector Backfill for existing assets.", { count: t }), "warn", 6500);
 						return;
 					}
 					if (n > 0 && Number.isFinite(r) && r > 0 && r < .75) {
-						A(R("toast.aiSearchPartiallyIndexed", "AI search index is only partially built ({indexed}/{eligible}, {percent}%). Run Vector Backfill for existing assets.", {
+						k(L("toast.aiSearchPartiallyIndexed", "AI search index is only partially built ({indexed}/{eligible}, {percent}%). Run Vector Backfill for existing assets.", {
 							indexed: t,
 							eligible: n,
 							percent: Math.round(r * 100)
@@ -14101,35 +14338,35 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 					}
 				}
 			} catch {}
-			A(x(e, R("toast.aiSearchUnavailable", "AI search is currently unavailable. Falling back to normal search.")), "warn", 5200);
+			k(b(e, L("toast.aiSearchUnavailable", "AI search is currently unavailable. Falling back to normal search.")), "warn", 5200);
 		}
-	}, T = async (r, i = {}) => {
+	}, w = async (r, i = {}) => {
 		let a = String(r || "").trim(), o = /^ai:\s*/i.test(a);
 		o && (a = a.replace(/^ai:\s*/i, "").trim());
-		let s = b(), u = s && y();
+		let s = y(), l = s && v();
 		if (!s) return await t(e, a || "*", i);
-		let d = u || o, f = !1, p = "";
-		if (d && a && a !== "*") {
-			f = !0;
-			let t = C();
+		let u = l || o, d = !1, f = "";
+		if (u && a && a !== "*") {
+			d = !0;
+			let t = S();
 			try {
-				let r = await F(a, {
+				let r = await te(a, {
 					topK: 100,
 					scope: c("scope", "output") || "output",
 					customRootId: c("customRootId", "") || "",
 					...t
 				});
-				if (r?.ok && Array.isArray(r.data) && r.data.length > 0 && S(r.data)) return await n(e, r.data, {
+				if (r?.ok && Array.isArray(r.data) && r.data.length > 0 && x(r.data)) return await n(e, r.data, {
 					title: `AI Search: "${a}" (${r.data.length} results)`,
 					reset: !0,
 					...i
 				});
-				r?.ok === !1 && (p = x(r?.error || r?.message, p));
+				r?.ok === !1 && (f = b(r?.error || r?.message, f));
 			} catch (e) {
-				p = x(e, p), console.debug?.("[Majoor] Hybrid search failed, trying pure semantic", e);
+				f = b(e, f), console.debug?.("[Majoor] Hybrid search failed, trying pure semantic", e);
 			}
 			try {
-				let r = await l(a, {
+				let r = await m(a, {
 					topK: 100,
 					scope: c("scope", "output") || "output",
 					customRootId: c("customRootId", "") || "",
@@ -14140,31 +14377,31 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 					reset: !0,
 					...i
 				});
-				r?.ok === !1 && (p = x(r?.error || r?.message, p));
+				r?.ok === !1 && (f = b(r?.error || r?.message, f));
 			} catch (e) {
-				p = x(e, p), console.debug?.("[Majoor] Semantic search failed, falling back to FTS", e);
+				f = b(e, f), console.debug?.("[Majoor] Semantic search failed, falling back to FTS", e);
 			}
 		}
-		let m = await t(e, a || "*", i);
-		return f && p && (Number(m?.count || 0) || 0) === 0 && w(p), m;
-	}, E = async (t = {}) => {
+		let p = await t(e, a || "*", i);
+		return d && f && (Number(p?.count || 0) || 0) === 0 && C(f), p;
+	}, T = async (t = {}) => {
 		let i = String(e.dataset.mjrViewScope || "").trim().toLowerCase(), o = String(c("viewScope", s?.viewScope || "") || "").trim().toLowerCase();
 		e.dataset.mjrScope = c("scope", "output"), e.dataset.mjrViewScope = o, e.dataset.mjrCustomRootId = c("customRootId", "") || "";
-		let l = c("currentFolderRelativePath", "") || "";
-		e.dataset.mjrSubfolder = l, e.dataset.mjrFilterKind = c("kindFilter", "") || "", e.dataset.mjrFilterWorkflowOnly = c("workflowOnly", !1) ? "1" : "0", e.dataset.mjrFilterMinRating = String(c("minRating", 0) || 0), e.dataset.mjrFilterMinSizeMB = String(c("minSizeMB", 0) || 0), e.dataset.mjrFilterMaxSizeMB = String(c("maxSizeMB", 0) || 0), e.dataset.mjrFilterResolutionCompare = String(c("resolutionCompare", "gte") || "gte"), e.dataset.mjrFilterMinWidth = String(c("minWidth", 0) || 0), e.dataset.mjrFilterMinHeight = String(c("minHeight", 0) || 0), e.dataset.mjrFilterMaxWidth = String(c("maxWidth", 0) || 0), e.dataset.mjrFilterMaxHeight = String(c("maxHeight", 0) || 0), e.dataset.mjrFilterWorkflowType = String(c("workflowType", "") || ""), e.dataset.mjrFilterWorkflowId = String(c("workflowId", "") || ""), e.dataset.mjrFilterWorkflowModel = String(c("workflowModelFilter", "") || ""), e.dataset.mjrFilterWorkflowRunsOn = String(c("workflowRunsOnFilter", "") || ""), e.dataset.mjrFilterDateRange = c("dateRangeFilter", "") || "", e.dataset.mjrFilterDateExact = c("dateExactFilter", "") || "", e.dataset.mjrSort = c("sort", "mtime_desc") || "mtime_desc", e.dataset.mjrCollectionId = c("collectionId", "") || "", e.dataset.mjrSemanticMode = y() ? "1" : "0";
+		let u = c("currentFolderRelativePath", "") || "";
+		e.dataset.mjrSubfolder = u, e.dataset.mjrFilterKind = c("kindFilter", "") || "", e.dataset.mjrFilterWorkflowOnly = c("workflowOnly", !1) ? "1" : "0", e.dataset.mjrFilterMinRating = String(c("minRating", 0) || 0), e.dataset.mjrFilterMinSizeMB = String(c("minSizeMB", 0) || 0), e.dataset.mjrFilterMaxSizeMB = String(c("maxSizeMB", 0) || 0), e.dataset.mjrFilterResolutionCompare = String(c("resolutionCompare", "gte") || "gte"), e.dataset.mjrFilterMinWidth = String(c("minWidth", 0) || 0), e.dataset.mjrFilterMinHeight = String(c("minHeight", 0) || 0), e.dataset.mjrFilterMaxWidth = String(c("maxWidth", 0) || 0), e.dataset.mjrFilterMaxHeight = String(c("maxHeight", 0) || 0), e.dataset.mjrFilterWorkflowType = String(c("workflowType", "") || ""), e.dataset.mjrFilterWorkflowId = String(c("workflowId", "") || ""), e.dataset.mjrFilterWorkflowModel = String(c("workflowModelFilter", "") || ""), e.dataset.mjrFilterWorkflowRunsOn = String(c("workflowRunsOnFilter", "") || ""), e.dataset.mjrFilterDateRange = c("dateRangeFilter", "") || "", e.dataset.mjrFilterDateExact = c("dateExactFilter", "") || "", e.dataset.mjrSort = c("sort", "mtime_desc") || "mtime_desc", e.dataset.mjrCollectionId = c("collectionId", "") || "", e.dataset.mjrSemanticMode = v() ? "1" : "0";
 		try {
 			e.dataset.mjrQuery = String(a?.() ?? "*") || "*";
 		} catch (e) {
 			console.debug?.(e);
 		}
-		e.dataset.mjrGroupStacks = z.EXECUTION_GROUPING_ENABLED && (c("scope", "output") === "output" || c("scope", "output") === "all") ? "1" : "0";
+		e.dataset.mjrGroupStacks = R.EXECUTION_GROUPING_ENABLED && (c("scope", "output") === "output" || c("scope", "output") === "all") ? "1" : "0";
 		try {
 			let t = Array.isArray(c("selectedAssetIds", [])) ? c("selectedAssetIds", []).filter(Boolean).map(String) : [];
 			t.length ? (e.dataset.mjrSelectedAssetIds = JSON.stringify(t), e.dataset.mjrSelectedAssetId = String(c("activeAssetId", "") || t[0] || "")) : (delete e.dataset.mjrSelectedAssetIds, delete e.dataset.mjrSelectedAssetId);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		if (c("scope", "output") === "custom" && !c("customRootId", "") && !c("currentFolderRelativePath", "") && u("currentFolderRelativePath", ""), c("collectionId", "")) {
+		if (c("scope", "output") === "custom" && !c("customRootId", "") && !c("currentFolderRelativePath", "") && l("currentFolderRelativePath", ""), c("collectionId", "")) {
 			let t = await r?.(c("collectionId", ""));
 			if (t?.ok && t.data && Array.isArray(t.data.assets)) {
 				let r = c("collectionName", "") ? `Collection: ${c("collectionName", "")}` : "Collection", i = await n(e, t.data.assets, {
@@ -14172,18 +14409,18 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 					reset: !0
 				});
 				try {
-					u("lastGridCount", Number(i?.count || 0) || 0), u("lastGridTotal", Number(i?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: i || {} }));
+					l("lastGridCount", Number(i?.count || 0) || 0), l("lastGridTotal", Number(i?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: i || {} }));
 				} catch (e) {
 					console.debug?.(e);
 				}
 				return;
 			}
-			u("collectionId", ""), u("collectionName", "");
+			l("collectionId", ""), l("collectionName", "");
 		}
 		let d = o;
 		if (d === "similar") {
-			let r = Array.isArray(c("similarResults", [])) ? c("similarResults", []) : [], i = Array.isArray(s?.similarResults) ? s.similarResults : [], a = r.length > 0 ? r : i, o = String(c("similarSourceAssetId", s?.similarSourceAssetId || "") || "").trim(), l = await n(e, a, {
-				title: String(c("similarTitle", s?.similarTitle || "") || R("search.similarResults", "Similar to asset #{id} ({n} results)", {
+			let r = Array.isArray(c("similarResults", [])) ? c("similarResults", []) : [], i = Array.isArray(s?.similarResults) ? s.similarResults : [], a = r.length > 0 ? r : i, o = String(c("similarSourceAssetId", s?.similarSourceAssetId || "") || "").trim(), u = await n(e, a, {
+				title: String(c("similarTitle", s?.similarTitle || "") || L("search.similarResults", "Similar to asset #{id} ({n} results)", {
 					id: o || "?",
 					n: a.length
 				})).trim() || "Similar",
@@ -14191,13 +14428,13 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 				...t
 			});
 			try {
-				u("lastGridCount", Number(l?.count || 0) || 0), u("lastGridTotal", Number(l?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: l || {} }));
+				l("lastGridCount", Number(u?.count || 0) || 0), l("lastGridTotal", Number(u?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: u || {} }));
 			} catch (e) {
 				console.debug?.(e);
 			}
 			return;
 		}
-		let f = i === "similar" && d !== "similar", p = await T(a(), {
+		let f = i === "similar" && d !== "similar", p = await w(a(), {
 			...t,
 			preserveVisibleUntilReady: t.preserveVisibleUntilReady ?? !f
 		});
@@ -14208,46 +14445,46 @@ function mg({ gridContainer: e, loadAssets: t, loadAssetsFromList: n, getCollect
 			console.debug?.(e);
 		}
 		try {
-			u("lastGridCount", Number(p?.count || 0) || 0), u("lastGridTotal", Number(p?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: p || {} }));
+			l("lastGridCount", Number(p?.count || 0) || 0), l("lastGridTotal", Number(p?.total || 0) || 0), e.dispatchEvent?.(new CustomEvent("mjr:grid-stats", { detail: p || {} }));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, D = null, O = async () => {
-		if (f = !0, !d) {
-			d = !0;
+	}, E = null, D = async () => {
+		if (d = !0, !u) {
+			u = !0;
 			try {
-				for (; f;) {
-					let e = { ...m || {} };
-					m = {}, f = !1;
+				for (; d;) {
+					let e = { ...f || {} };
+					f = {}, d = !1;
 					try {
-						await v(() => E(e), b() && (y() || String(a?.() || "").length >= 12) ? 15e4 : _);
+						await _(() => T(e), y() && (v() || String(a?.() || "").length >= 12) ? 15e4 : g);
 					} catch (e) {
 						try {
 							let t = Date.now();
-							t - Number(h || 0) > 2e3 && (h = t, console.warn("[Majoor] Grid reload failed", e));
+							t - Number(p || 0) > 2e3 && (p = t, console.warn("[Majoor] Grid reload failed", e));
 						} catch (e) {
 							console.debug?.(e);
 						}
 					}
 				}
 			} finally {
-				d = !1;
+				u = !1;
 			}
 		}
 	};
 	return { reloadGrid: (e = {}) => new Promise((t, n) => {
-		m = {
-			...m || {},
+		f = {
+			...f || {},
 			...e || {}
-		}, D && clearTimeout(D), D = setTimeout(() => {
-			D = null, O().then(t).catch(n);
+		}, E && clearTimeout(E), E = setTimeout(() => {
+			E = null, D().then(t).catch(n);
 		}, 30);
 	}) };
 }
 //#endregion
 //#region ui/features/panel/controllers/browserNavigationController.ts
-function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbController: r = null, customSelect: i, reloadGrid: a, clearSelection: o = null, onContextChanged: s = null, lifecycleSignal: c = null } = {}) {
-	let { read: l, write: u } = fh(e, [
+function Sg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbController: r = null, customSelect: i, reloadGrid: a, clearSelection: o = null, onContextChanged: s = null, lifecycleSignal: c = null } = {}) {
+	let { read: l, write: u } = yh(e, [
 		"scope",
 		"customRootId",
 		"currentFolderRelativePath"
@@ -14271,6 +14508,7 @@ function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbC
 			console.debug?.(e);
 		}
 	}, v = (e) => {
+		if (f(e?.filename || "") === "..") return y(m());
 		let t = f(e?.subfolder || "");
 		if (t) return t;
 		let n = f(e?.filepath || e?.path || "");
@@ -14383,7 +14621,7 @@ function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbC
 				}
 				await S(t);
 			}
-		}), T = [x(R("label.computer", "Computer"), "", !t)];
+		}), T = [x(L("label.computer", "Computer"), "", !t)];
 		if (a && T.push(x(o || a, "", !t)), t) {
 			let e = t.split("/").filter(Boolean), n = "";
 			for (let t = 0; t < e.length; t++) n = n ? `${n}/${e[t]}`.replace(/\/{2,}/g, "/") : p(e[t]) ? `${e[t]}/` : e[t], T.push(x(e[t], n, t === e.length - 1));
@@ -14391,12 +14629,12 @@ function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbC
 		if (w({
 			visible: !0,
 			back: {
-				label: R("btn.back", "Back"),
+				label: L("btn.back", "Back"),
 				disabled: h,
 				onClick: v
 			},
 			up: {
-				label: R("btn.up", "Up"),
+				label: L("btn.up", "Up"),
 				disabled: _,
 				onClick: b
 			},
@@ -14404,9 +14642,9 @@ function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbC
 		})) return;
 		n.style.display = "flex", n.replaceChildren();
 		let E = document.createElement("button");
-		E.type = "button", E.textContent = R("btn.back", "Back"), E.className = "mjr-btn-link mjr-folder-breadcrumb-action", E.disabled = h, E.addEventListener("click", v, { signal: c || void 0 }), n.appendChild(E);
+		E.type = "button", E.textContent = L("btn.back", "Back"), E.className = "mjr-btn-link mjr-folder-breadcrumb-action", E.disabled = h, E.addEventListener("click", v, { signal: c || void 0 }), n.appendChild(E);
 		let D = document.createElement("button");
-		D.type = "button", D.textContent = R("btn.up", "Up"), D.className = "mjr-btn-link mjr-folder-breadcrumb-action", D.disabled = _, D.addEventListener("click", b, { signal: c || void 0 }), n.appendChild(D);
+		D.type = "button", D.textContent = L("btn.up", "Up"), D.className = "mjr-btn-link mjr-folder-breadcrumb-action", D.disabled = _, D.addEventListener("click", b, { signal: c || void 0 }), n.appendChild(D);
 		let O = document.createElement("span");
 		O.textContent = "|", O.className = "mjr-folder-breadcrumb-separator", n.appendChild(O);
 		let k = (e, t, n = !1) => {
@@ -14494,8 +14732,8 @@ function hg({ state: e, gridContainer: t, folderBreadcrumb: n, folderBreadcrumbC
 }
 //#endregion
 //#region ui/features/panel/controllers/scopeController.ts
-function gg({ state: e, tabButtons: t, customMenuBtn: n, customPopover: r, popovers: i, reloadGrid: a, reconcileSelection: o = null, onChanged: s = null, onScopeChanged: c = null, onBeforeReload: l = null }) {
-	let u = 0, { panelStore: d, read: f, write: p, controllerState: m } = fh(e, [
+function Cg({ state: e, tabButtons: t, customMenuBtn: n, customPopover: r, popovers: i, reloadGrid: a, reconcileSelection: o = null, onChanged: s = null, onScopeChanged: c = null, onBeforeReload: l = null }) {
+	let u = 0, { panelStore: d, read: f, write: p, controllerState: m } = yh(e, [
 		"scope",
 		"customRootId",
 		"currentFolderRelativePath",
@@ -14611,44 +14849,44 @@ function gg({ state: e, tabButtons: t, customMenuBtn: n, customPopover: r, popov
 }
 //#endregion
 //#region ui/features/panel/controllers/contextController.ts
-var _g = (e, t) => {
+var wg = (e, t) => {
 	if (e) try {
 		e.value = t;
 	} catch (e) {
 		console.debug?.(e);
 	}
-}, vg = (e, t) => {
+}, Tg = (e, t) => {
 	if (e) try {
 		e.checked = !!t;
 	} catch (e) {
 		console.debug?.(e);
 	}
 };
-function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsBtn: i, searchInputEl: a, kindSelect: o, wfCheckbox: s, workflowTypeSelect: c, workflowIdInput: l, workflowModelInput: u, workflowRunsOnSelect: d, ratingSelect: f, minSizeInput: p, maxSizeInput: m, minWidthInput: h, minHeightInput: g, maxWidthInput: _, maxHeightInput: v, resolutionPresetSelect: y, dateRangeSelect: b, dateExactInput: x, scopeController: S, sortController: C, updateSummaryBar: w, reloadGrid: T, extraActions: E = null, getExtraContext: D = null } = {}) {
-	let O = e && typeof e == "object" ? e : {}, { read: k, write: A, controllerState: j } = fh(e, /* @__PURE__ */ "searchQuery.scope.collectionId.collectionName.customRootId.customRootLabel.currentFolderRelativePath.kindFilter.workflowOnly.minRating.minSizeMB.maxSizeMB.minWidth.minHeight.maxWidth.maxHeight.resolutionCompare.workflowType.workflowId.workflowModelFilter.workflowRunsOnFilter.dateRangeFilter.dateExactFilter.sort.viewScope.similarResults.similarTitle.similarSourceAssetId".split(".")), M = (e, t) => {
+function Eg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsBtn: i, searchInputEl: a, kindSelect: o, wfCheckbox: s, workflowTypeSelect: c, workflowIdInput: l, workflowModelInput: u, workflowRunsOnSelect: d, ratingSelect: f, minSizeInput: p, maxSizeInput: m, minWidthInput: h, minHeightInput: g, maxWidthInput: _, maxHeightInput: v, resolutionPresetSelect: y, dateRangeSelect: b, dateExactInput: x, scopeController: S, sortController: C, updateSummaryBar: w, reloadGrid: T, extraActions: E = null, getExtraContext: D = null } = {}) {
+	let O = e && typeof e == "object" ? e : {}, { read: k, write: A, controllerState: j } = yh(e, /* @__PURE__ */ "searchQuery.scope.collectionId.collectionName.customRootId.customRootLabel.currentFolderRelativePath.kindFilter.workflowOnly.minRating.minSizeMB.maxSizeMB.minWidth.minHeight.maxWidth.maxHeight.resolutionCompare.workflowType.workflowId.workflowModelFilter.workflowRunsOnFilter.dateRangeFilter.dateExactFilter.sort.viewScope.similarResults.similarTitle.similarSourceAssetId".split(".")), M = (e, t) => {
 		A(e, t);
 	}, N = (e, t = "") => k(e, t), ee = () => ({
 		...O || {},
 		...j?.() || {},
 		customRootLabel: N("customRootLabel", "")
-	}), te = () => {
+	}), P = () => {
 		try {
 			E?.resetBrowserHistory?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, ne = () => {
+	}, te = () => {
 		try {
 			let e = t?.closest?.(".mjr-assets-manager") || document.querySelector?.(".mjr-assets-manager") || document.documentElement;
 			if (!e?.style?.setProperty) return;
-			e.style.setProperty("--mjr-star-active", String(z.BADGE_STAR_COLOR || "#FFD45A")), e.style.setProperty("--mjr-badge-image", String(z.BADGE_IMAGE_COLOR || "#2196F3")), e.style.setProperty("--mjr-badge-video", String(z.BADGE_VIDEO_COLOR || "#9C27B0")), e.style.setProperty("--mjr-badge-audio", String(z.BADGE_AUDIO_COLOR || "#FF9800")), e.style.setProperty("--mjr-badge-model3d", String(z.BADGE_MODEL3D_COLOR || "#4CAF50")), e.style.setProperty("--mjr-badge-duplicate-alert", String(z.BADGE_DUPLICATE_ALERT_COLOR || "#FF1744"));
+			e.style.setProperty("--mjr-star-active", String(R.BADGE_STAR_COLOR || "#FFD45A")), e.style.setProperty("--mjr-badge-image", String(R.BADGE_IMAGE_COLOR || "#2196F3")), e.style.setProperty("--mjr-badge-video", String(R.BADGE_VIDEO_COLOR || "#9C27B0")), e.style.setProperty("--mjr-badge-audio", String(R.BADGE_AUDIO_COLOR || "#FF9800")), e.style.setProperty("--mjr-badge-model3d", String(R.BADGE_MODEL3D_COLOR || "#4CAF50")), e.style.setProperty("--mjr-badge-duplicate-alert", String(R.BADGE_DUPLICATE_ALERT_COLOR || "#FF1744"));
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, P = {
+	}, ne = {
 		clearQuery: async () => {
 			try {
-				_g(a, ""), M("searchQuery", "");
+				wg(a, ""), M("searchQuery", "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14681,7 +14919,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 			}
 			let n = !1;
 			try {
-				M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, te(), typeof S?.setScope == "function" ? (await S.setScope("output"), n = !0) : (M("scope", "output"), S?.setActiveTabStyles?.());
+				M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, P(), typeof S?.setScope == "function" ? (await S.setScope("output"), n = !0) : (M("scope", "output"), S?.setActiveTabStyles?.());
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14693,7 +14931,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearCustomRoot: async () => {
 			try {
-				M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, te();
+				M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, P();
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14705,7 +14943,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearFolder: async () => {
 			try {
-				M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, te();
+				M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, P();
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14717,7 +14955,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearKind: async () => {
 			try {
-				M("kindFilter", ""), _g(o, "");
+				M("kindFilter", ""), wg(o, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14729,7 +14967,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearMinRating: async () => {
 			try {
-				M("minRating", 0), _g(f, "0");
+				M("minRating", 0), wg(f, "0");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14741,7 +14979,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearWorkflowOnly: async () => {
 			try {
-				M("workflowOnly", !1), vg(s, !1);
+				M("workflowOnly", !1), Tg(s, !1);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14753,7 +14991,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearWorkflowType: async () => {
 			try {
-				M("workflowType", ""), _g(c, "");
+				M("workflowType", ""), wg(c, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14765,7 +15003,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearWorkflowId: async () => {
 			try {
-				M("workflowId", ""), _g(l, "");
+				M("workflowId", ""), wg(l, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14777,7 +15015,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearWorkflowModel: async () => {
 			try {
-				M("workflowModelFilter", ""), _g(u, "");
+				M("workflowModelFilter", ""), wg(u, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14789,7 +15027,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearWorkflowRunsOn: async () => {
 			try {
-				M("workflowRunsOnFilter", ""), _g(d, "");
+				M("workflowRunsOnFilter", ""), wg(d, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14801,7 +15039,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearSize: async () => {
 			try {
-				M("minSizeMB", 0), M("maxSizeMB", 0), _g(p, ""), _g(m, "");
+				M("minSizeMB", 0), M("maxSizeMB", 0), wg(p, ""), wg(m, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14813,7 +15051,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearResolution: async () => {
 			try {
-				M("minWidth", 0), M("minHeight", 0), M("maxWidth", 0), M("maxHeight", 0), _g(h, ""), _g(g, ""), _g(_, ""), _g(v, ""), _g(y, "");
+				M("minWidth", 0), M("minHeight", 0), M("maxWidth", 0), M("maxHeight", 0), wg(h, ""), wg(g, ""), wg(_, ""), wg(v, ""), wg(y, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14825,7 +15063,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearDateRange: async () => {
 			try {
-				M("dateRangeFilter", ""), _g(b, "");
+				M("dateRangeFilter", ""), wg(b, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14837,7 +15075,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		},
 		clearDateExact: async () => {
 			try {
-				M("dateExactFilter", ""), _g(x, "");
+				M("dateExactFilter", ""), wg(x, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14862,12 +15100,12 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 		clearAll: async () => {
 			let e = !1;
 			try {
-				_g(a, "");
+				wg(a, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				M("collectionId", ""), M("collectionName", ""), M("kindFilter", ""), M("workflowOnly", !1), M("minRating", 0), M("minSizeMB", 0), M("maxSizeMB", 0), M("minWidth", 0), M("minHeight", 0), M("maxWidth", 0), M("maxHeight", 0), M("resolutionCompare", "gte"), M("workflowType", ""), M("workflowId", ""), M("workflowModelFilter", ""), M("workflowRunsOnFilter", ""), M("dateRangeFilter", ""), M("dateExactFilter", ""), M("sort", "mtime_desc"), M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, te();
+				M("collectionId", ""), M("collectionName", ""), M("kindFilter", ""), M("workflowOnly", !1), M("minRating", 0), M("minSizeMB", 0), M("maxSizeMB", 0), M("minWidth", 0), M("minHeight", 0), M("maxWidth", 0), M("maxHeight", 0), M("resolutionCompare", "gte"), M("workflowType", ""), M("workflowId", ""), M("workflowModelFilter", ""), M("workflowRunsOnFilter", ""), M("dateRangeFilter", ""), M("dateExactFilter", ""), M("sort", "mtime_desc"), M("customRootId", ""), M("customRootLabel", ""), M("currentFolderRelativePath", ""), delete t?.dataset?.mjrSubfolder, P();
 				try {
 					await E?.clearTransientContext?.();
 				} catch (e) {
@@ -14878,7 +15116,7 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 				console.debug?.(e);
 			}
 			try {
-				_g(o, ""), vg(s, !1), _g(c, ""), _g(l, ""), _g(u, ""), _g(d, ""), _g(f, "0"), _g(p, ""), _g(m, ""), _g(h, ""), _g(g, ""), _g(_, ""), _g(v, ""), _g(y, ""), _g(b, ""), _g(x, "");
+				wg(o, ""), Tg(s, !1), wg(c, ""), wg(l, ""), wg(u, ""), wg(d, ""), wg(f, "0"), wg(p, ""), wg(m, ""), wg(h, ""), wg(g, ""), wg(_, ""), wg(v, ""), wg(y, ""), wg(b, ""), wg(x, "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -14900,11 +15138,11 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 			"constructor",
 			"prototype"
 		]);
-		for (let [t, n] of Object.entries(E)) e.has(String(t)) || (P[t] = n);
+		for (let [t, n] of Object.entries(E)) e.has(String(t)) || (ne[t] = n);
 	}
 	return {
 		update: () => {
-			let e = String(a?.value || "").trim(), o = pg(a), s = ee(), c = !!(N("kindFilter", "") || N("workflowOnly", !1) || (Number(N("minRating", 0) || 0) || 0) > 0 || (Number(N("minSizeMB", 0) || 0) || 0) > 0 || (Number(N("maxSizeMB", 0) || 0) || 0) > 0 || (Number(N("minWidth", 0) || 0) || 0) > 0 || (Number(N("minHeight", 0) || 0) || 0) > 0 || (Number(N("maxWidth", 0) || 0) || 0) > 0 || (Number(N("maxHeight", 0) || 0) || 0) > 0 || String(N("workflowType", "") || "").trim().length > 0 || String(N("workflowId", "") || "").trim().length > 0 || String(N("workflowModelFilter", "") || "").trim().length > 0 || String(N("workflowRunsOnFilter", "") || "").trim().length > 0 || N("dateRangeFilter", "") || N("dateExactFilter", "")), l = String(N("sort", "mtime_desc") || "mtime_desc") !== "mtime_desc", u = !!N("collectionId", "");
+			let e = String(a?.value || "").trim(), o = bg(a), s = ee(), c = !!(N("kindFilter", "") || N("workflowOnly", !1) || (Number(N("minRating", 0) || 0) || 0) > 0 || (Number(N("minSizeMB", 0) || 0) || 0) > 0 || (Number(N("maxSizeMB", 0) || 0) || 0) > 0 || (Number(N("minWidth", 0) || 0) || 0) > 0 || (Number(N("minHeight", 0) || 0) || 0) > 0 || (Number(N("maxWidth", 0) || 0) || 0) > 0 || (Number(N("maxHeight", 0) || 0) || 0) > 0 || String(N("workflowType", "") || "").trim().length > 0 || String(N("workflowId", "") || "").trim().length > 0 || String(N("workflowModelFilter", "") || "").trim().length > 0 || String(N("workflowRunsOnFilter", "") || "").trim().length > 0 || N("dateRangeFilter", "") || N("dateExactFilter", "")), l = String(N("sort", "mtime_desc") || "mtime_desc") !== "mtime_desc", u = !!N("collectionId", "");
 			try {
 				n?.classList?.toggle?.("mjr-context-active", c), r?.classList?.toggle?.("mjr-context-active", l), i?.classList?.toggle?.("mjr-context-active", u);
 			} catch (e) {
@@ -14919,30 +15157,30 @@ function yg({ state: e, gridContainer: t, filterBtn: n, sortBtn: r, collectionsB
 						rawQuery: e || o,
 						...n
 					},
-					actions: P
+					actions: ne
 				});
 			} catch (e) {
 				console.debug?.(e);
 			}
-			ne();
+			te();
 		},
-		actions: P
+		actions: ne
 	};
 }
 //#endregion
 //#region ui/features/panel/controllers/customRootsController.ts
-function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, comfyPrompt: i, comfyToast: a, get: o, post: s, ENDPOINTS: c, reloadGrid: l, onRootChanged: u = null }) {
-	let d = e && typeof e == "object" ? e : {}, { read: f, write: p } = fh(e, [
+function Dg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, comfyPrompt: i, comfyToast: a, get: o, post: s, ENDPOINTS: c, reloadGrid: l, onRootChanged: u = null }) {
+	let d = e && typeof e == "object" ? e : {}, { read: f, write: p } = yh(e, [
 		"customRootId",
 		"customRootLabel",
 		"currentFolderRelativePath"
 	]), m = (e) => {
 		p("customRootLabel", String(e || ""));
 	}, h = async (e = null) => {
-		let r = t.querySelector("option[value=\"\"]")?.textContent || R("label.selectFolder", "Select folder...");
+		let r = t.querySelector("option[value=\"\"]")?.textContent || L("label.selectFolder", "Select folder...");
 		t.innerHTML = "";
 		let i = document.createElement("option");
-		i.value = "", i.textContent = R("msg.loading"), i.disabled = !0, t.appendChild(i), t.disabled = !0;
+		i.value = "", i.textContent = L("msg.loading"), i.disabled = !0, t.appendChild(i), t.disabled = !0;
 		try {
 			let i = await o(c.CUSTOM_ROOTS), a = i && i.ok && Array.isArray(i.data) ? i.data : [];
 			t.innerHTML = "";
@@ -14965,7 +15203,7 @@ function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, co
 		} catch (e) {
 			console.warn("Majoor: failed to load custom roots", e), t.innerHTML = "";
 			let n = document.createElement("option");
-			n.value = "", n.textContent = R("msg.errorLoadingFolders"), n.disabled = !0, t.appendChild(n);
+			n.value = "", n.textContent = L("msg.errorLoadingFolders"), n.disabled = !0, t.appendChild(n);
 		} finally {
 			t.disabled = !1;
 		}
@@ -15006,7 +15244,7 @@ function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, co
 					}
 					await l();
 				}
-			}), n && (n.disabled = !1, n.title = R("btn.add", "Add")), _(n, "click", async () => {
+			}), n && (n.disabled = !1, n.title = L("btn.add", "Add")), _(n, "click", async () => {
 				let t = "";
 				try {
 					let e = await s(c.BROWSE_FOLDER, {});
@@ -15015,16 +15253,16 @@ function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, co
 					console.debug?.(e);
 				}
 				if (!t) {
-					let e = await i(R("dialog.enterFolderPath", "Enter folder path"), "");
+					let e = await i(L("dialog.enterFolderPath", "Enter folder path"), "");
 					t = String(e || "").trim();
 				}
 				if (!t) return;
-				let n = await i(R("dialog.folderLabelOptional", "Folder label (optional)"), ""), r = await s(c.CUSTOM_ROOTS, {
+				let n = await i(L("dialog.folderLabelOptional", "Folder label (optional)"), ""), r = await s(c.CUSTOM_ROOTS, {
 					path: t,
 					label: String(n || "").trim() || void 0
 				});
 				if (!r?.ok) {
-					a(r?.error || R("toast.failedAddFolder", "Failed to add browser folder"), "error");
+					a(r?.error || L("toast.failedAddFolder", "Failed to add browser folder"), "error");
 					return;
 				}
 				await h(String(r?.data?.id || "").trim() || null);
@@ -15033,23 +15271,23 @@ function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, co
 				} catch (e) {
 					console.debug?.(e);
 				}
-				await l(), a(R("toast.folderAdded", "Folder added"), "success");
+				await l(), a(L("toast.folderAdded", "Folder added"), "success");
 			}), _(o, "click", async () => {
 				if (!f("customRootId", "")) return;
-				let e = t.options[t.selectedIndex], n = e ? e.text : R("label.thisFolder", "this folder");
-				if (await r(R("dialog.removeFolder", `Remove the browser folder "${n}"?`, { name: n }), R("dialog.customFoldersTitle", "Majoor: Browser Folders"))) {
-					o.disabled = !0, o.textContent = R("btn.removing");
+				let e = t.options[t.selectedIndex], n = e ? e.text : L("label.thisFolder", "this folder");
+				if (await r(L("dialog.removeFolder", `Remove the browser folder "${n}"?`, { name: n }), L("dialog.customFoldersTitle", "Majoor: Browser Folders"))) {
+					o.disabled = !0, o.textContent = L("btn.removing");
 					try {
 						let e = await s(c.CUSTOM_ROOTS_REMOVE, { id: f("customRootId", "") });
 						if (!e?.ok) {
-							a(e?.error || R("toast.failedRemoveFolder", "Failed to remove browser folder"), "error");
+							a(e?.error || L("toast.failedRemoveFolder", "Failed to remove browser folder"), "error");
 							return;
 						}
-						a(R("toast.folderRemoved", "Folder removed"), "success"), p("customRootId", ""), m(""), p("currentFolderRelativePath", ""), await h(), await l();
+						a(L("toast.folderRemoved", "Folder removed"), "success"), p("customRootId", ""), m(""), p("currentFolderRelativePath", ""), await h(), await l();
 					} catch (e) {
-						console.warn("Majoor: remove custom root failed", e), a(R("toast.errorRemovingFolder", "An error occurred while removing the browser folder"), "error");
+						console.warn("Majoor: remove custom root failed", e), a(L("toast.errorRemovingFolder", "An error occurred while removing the browser folder"), "error");
 					} finally {
-						o.disabled = !f("customRootId", ""), o.textContent = R("btn.remove");
+						o.disabled = !f("customRootId", ""), o.textContent = L("btn.remove");
 					}
 				}
 			}), () => {
@@ -15064,35 +15302,35 @@ function bg({ state: e, customSelect: t, customRemoveBtn: n, comfyConfirm: r, co
 }
 //#endregion
 //#region ui/features/panel/controllers/sortController.ts
-function xg({ state: e, sortBtn: t, sortMenu: n, sortPopover: r, popovers: i, reloadGrid: a, onChanged: o = null }) {
-	let { read: s, write: c } = fh(e, ["sort"]), l = () => [
+function Og({ state: e, sortBtn: t, sortMenu: n, sortPopover: r, popovers: i, reloadGrid: a, onChanged: o = null }) {
+	let { read: s, write: c } = yh(e, ["sort"]), l = () => [
 		{
 			key: "mtime_desc",
-			label: R("sort.newest")
+			label: L("sort.newest")
 		},
 		{
 			key: "mtime_asc",
-			label: R("sort.oldest")
+			label: L("sort.oldest")
 		},
 		{
 			key: "name_asc",
-			label: R("sort.nameAZ")
+			label: L("sort.nameAZ")
 		},
 		{
 			key: "name_desc",
-			label: R("sort.nameZA")
+			label: L("sort.nameZA")
 		},
 		{
 			key: "rating_desc",
-			label: R("sort.ratingHigh")
+			label: L("sort.ratingHigh")
 		},
 		{
 			key: "size_desc",
-			label: R("sort.sizeDesc")
+			label: L("sort.sizeDesc")
 		},
 		{
 			key: "size_asc",
-			label: R("sort.sizeAsc")
+			label: L("sort.sizeAsc")
 		}
 	], u = (e) => {
 		let n = t.querySelector("i");
@@ -15151,24 +15389,24 @@ function xg({ state: e, sortBtn: t, sortMenu: n, sortPopover: r, popovers: i, re
 }
 //#endregion
 //#region ui/features/panel/controllers/sidebarController.ts
-var Sg = "_mjrRescanning", Cg = 1500, wg = (e) => /^\d+$/.test(String(e ?? "").trim());
-async function Tg({ card: e, asset: t, sidebar: n, onAssetUpdated: r }) {
+var kg = "_mjrRescanning", Ag = 1500, jg = (e) => /^\d+$/.test(String(e ?? "").trim());
+async function Mg({ card: e, asset: t, sidebar: n, onAssetUpdated: r }) {
 	if (!e || !t || globalThis._mjrMaintenanceActive) return;
 	try {
 		let t = Date.now();
-		if (t - (Number(e[Sg] || 0) || 0) < Cg) return;
-		e[Sg] = t;
+		if (t - (Number(e[kg] || 0) || 0) < Ag) return;
+		e[kg] = t;
 	} catch (e) {
 		console.debug?.(e);
 	}
 	let i = e.querySelector(".mjr-workflow-dot");
 	try {
-		i && (Wt(i, "pending", "Pending: metadata refresh in progress", { asset: t }), i.classList.add("mjr-pulse-animation"), i.style.cursor = "progress", i.title = R("tooltip.pendingRefresh", "Pending: metadata refresh in progress"));
+		i && (Wt(i, "pending", "Pending: metadata refresh in progress", { asset: t }), i.classList.add("mjr-pulse-animation"), i.style.cursor = "progress", i.title = L("tooltip.pendingRefresh", "Pending: metadata refresh in progress"));
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		A(R("toast.rescanUpdatingAiIndex", "Rescanning file + updating AI index..."), "info", 2200);
+		k(L("toast.rescanUpdatingAiIndex", "Rescanning file + updating AI index..."), "info", 2200);
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -15176,22 +15414,22 @@ async function Tg({ card: e, asset: t, sidebar: n, onAssetUpdated: r }) {
 		filename: t.filename,
 		subfolder: t.subfolder || "",
 		type: String(t.type || "output").toLowerCase(),
-		root_id: Ne(t) || void 0
-	}, o = null, s = !1, c = !1, l = !1;
+		root_id: Pe(t) || void 0
+	}, o = null, s = !1, l = !1, u = !1;
 	try {
-		if (s = !!(await ue(lt.INDEX_FILES, {
+		if (s = !!(await ue(B.INDEX_FILES, {
 			files: [a],
 			incremental: !1
-		}))?.ok, !s && i && (Wt(i, "error", "Error: metadata refresh failed", { asset: t }), i.classList.remove("mjr-pulse-animation"), i.style.cursor = ""), wg(t?.id)) {
-			c = !0;
+		}))?.ok, !s && i && (Wt(i, "error", "Error: metadata refresh failed", { asset: t }), i.classList.remove("mjr-pulse-animation"), i.style.cursor = ""), jg(t?.id)) {
+			l = !0;
 			try {
-				l = !!(await k(t.id))?.ok;
+				u = !!(await c(t.id))?.ok;
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
 		if (s && t.id != null) {
-			let e = await oe(t.id);
+			let e = await ie(t.id);
 			e?.ok && e.data && (o = {
 				...t,
 				...e.data
@@ -15231,13 +15469,13 @@ async function Tg({ card: e, asset: t, sidebar: n, onAssetUpdated: r }) {
 		}
 	}
 	try {
-		s && l ? A(R("toast.metadataVectorUpdated", "Metadata + AI vector index updated for this asset."), "success", 2200) : s && c && !l && A(R("toast.metadataUpdatedVectorFailed", "Metadata updated. AI vector index could not be updated."), "warning", 2600);
+		s && u ? k(L("toast.metadataVectorUpdated", "Metadata + AI vector index updated for this asset."), "success", 2200) : s && l && !u && k(L("toast.metadataUpdatedVectorFailed", "Metadata updated. AI vector index could not be updated."), "warning", 2600);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return o;
 }
-function Eg(e, t) {
+function Ng(e, t) {
 	if (e) {
 		try {
 			let n = e.querySelector(".mjr-asset-card.is-selected");
@@ -15273,7 +15511,7 @@ function Eg(e, t) {
 		}
 	}
 }
-var Dg = (e) => {
+var Pg = (e) => {
 	if (e == null) return "";
 	try {
 		if (typeof CSS < "u" && typeof CSS.escape == "function") return CSS.escape(String(e));
@@ -15282,32 +15520,32 @@ var Dg = (e) => {
 	}
 	return String(e).replace(/([!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~])/g, "\\$1");
 };
-function Og(e, t) {
+function Fg(e, t) {
 	if (!e || !t) return null;
 	try {
-		return e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Dg(t)}"]`);
+		return e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Pg(t)}"]`);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	try {
-		return e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Dg(t)}"]`);
+		return e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Pg(t)}"]`);
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return null;
 }
-function kg(e) {
+function Ig(e) {
 	if (!e) return null;
 	let t = e.dataset?.mjrSelectedAssetId;
 	if (t) {
-		let n = Og(e, t);
+		let n = Fg(e, t);
 		if (n) return n;
 	}
 	let n = e.dataset?.mjrSelectedAssetIds;
 	if (n) try {
 		let t = JSON.parse(n);
 		if (Array.isArray(t) && t.length) {
-			let n = Og(e, t[0]);
+			let n = Fg(e, t[0]);
 			if (n) return n;
 		}
 	} catch (e) {
@@ -15315,7 +15553,7 @@ function kg(e) {
 	}
 	return e.querySelector(".mjr-asset-card.is-selected");
 }
-function Ag(e, { preventScroll: t = !0 } = {}) {
+function Lg(e, { preventScroll: t = !0 } = {}) {
 	if (e) try {
 		e.focus?.({ preventScroll: t });
 	} catch {
@@ -15326,14 +15564,14 @@ function Ag(e, { preventScroll: t = !0 } = {}) {
 		}
 	}
 }
-function jg(e, { force: t = !1 } = {}) {
+function Rg(e, { force: t = !1 } = {}) {
 	if (!e || !t && !e._mjrFocusWithin) return;
-	let n = kg(e);
-	n && (Ag(n), e._mjrFocusWithin = !0);
+	let n = Ig(e);
+	n && (Lg(n), e._mjrFocusWithin = !0);
 }
-function Mg(e) {
+function zg(e) {
 	if (e) try {
-		let t = kg(e);
+		let t = Ig(e);
 		if (!t) return;
 		let n = e.parentElement;
 		if (n && typeof n.getBoundingClientRect == "function" && typeof t.getBoundingClientRect == "function") {
@@ -15348,7 +15586,7 @@ function Mg(e) {
 		console.debug?.(e);
 	}
 }
-function Ng(e) {
+function Bg(e) {
 	if (e) try {
 		e._mjrAutoRevealSelectionUntil = Date.now() + 900;
 	} catch (e) {
@@ -15356,12 +15594,12 @@ function Ng(e) {
 	}
 	let t = () => {
 		try {
-			Mg(e);
+			zg(e);
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			jg(e);
+			Rg(e);
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -15376,10 +15614,10 @@ function Ng(e) {
 		t();
 	}
 }
-function Pg(e, t) {
+function Vg(e, t) {
 	e && (t ? (e.classList.add("is-selected"), e.setAttribute?.("aria-selected", "true")) : (e.classList.remove("is-selected"), e.setAttribute?.("aria-selected", "false")));
 }
-function Fg(e) {
+function Hg(e) {
 	try {
 		if (typeof e?._mjrGetRenderedCards == "function") {
 			let t = e._mjrGetRenderedCards();
@@ -15394,15 +15632,15 @@ function Fg(e) {
 		return [];
 	}
 }
-function Ig(e) {
+function Ug(e) {
 	if (e) try {
-		let t = Fg(e).filter((e) => e?.classList?.contains?.("is-selected")).map((e) => e?.dataset?.mjrAssetId).filter(Boolean);
+		let t = Hg(e).filter((e) => e?.classList?.contains?.("is-selected")).map((e) => e?.dataset?.mjrAssetId).filter(Boolean);
 		t.length ? (e.dataset.mjrSelectedAssetIds = JSON.stringify(t), !e.dataset.mjrSelectedAssetId && t[0] && (e.dataset.mjrSelectedAssetId = String(t[0]))) : (delete e.dataset.mjrSelectedAssetIds, delete e.dataset.mjrSelectedAssetId);
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function Lg(e, t, n = "") {
+function Wg(e, t, n = "") {
 	if (!e) return [];
 	let r = Array.from(t || []).map(String).filter(Boolean);
 	try {
@@ -15416,9 +15654,9 @@ function Lg(e, t, n = "") {
 		console.debug?.(e);
 	}
 	try {
-		for (let t of Fg(e)) {
+		for (let t of Hg(e)) {
 			let e = t?.dataset?.mjrAssetId;
-			Pg(t, !!(e && r.includes(String(e))));
+			Vg(t, !!(e && r.includes(String(e))));
 		}
 	} catch (e) {
 		console.debug?.(e);
@@ -15433,7 +15671,7 @@ function Lg(e, t, n = "") {
 	}
 	return r;
 }
-function Rg({ gridContainer: e, state: t, activeId: n, readState: r = null, writeState: i = null } = {}) {
+function Gg({ gridContainer: e, state: t, activeId: n, readState: r = null, writeState: i = null } = {}) {
 	if (!(!t && !i || !e)) try {
 		let a = [];
 		if (e.dataset?.mjrSelectedAssetIds) try {
@@ -15442,7 +15680,7 @@ function Rg({ gridContainer: e, state: t, activeId: n, readState: r = null, writ
 		} catch (e) {
 			console.debug?.(e);
 		}
-		else a = e.dataset?.mjrSelectedAssetId ? [String(e.dataset.mjrSelectedAssetId)].filter(Boolean) : Fg(e).filter((e) => e?.classList?.contains?.("is-selected")).map((e) => e?.dataset?.mjrAssetId).filter(Boolean).map(String);
+		else a = e.dataset?.mjrSelectedAssetId ? [String(e.dataset.mjrSelectedAssetId)].filter(Boolean) : Hg(e).filter((e) => e?.classList?.contains?.("is-selected")).map((e) => e?.dataset?.mjrAssetId).filter(Boolean).map(String);
 		typeof i == "function" ? i("selectedAssetIds", a) : t.selectedAssetIds = a;
 		let o = String(typeof r == "function" ? r("activeAssetId", "") || "" : t?.activeAssetId || "");
 		n == null ? o && a.includes(o) || (typeof i == "function" ? i("activeAssetId", a[0] || "") : t.activeAssetId = a[0] || "") : typeof i == "function" ? i("activeAssetId", String(n)) : t.activeAssetId = String(n);
@@ -15450,8 +15688,8 @@ function Rg({ gridContainer: e, state: t, activeId: n, readState: r = null, writ
 		console.debug?.(e);
 	}
 }
-function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadge: r, showAssetInSidebar: i, closeSidebar: a, state: o }) {
-	let { read: s, write: c } = fh(o, [
+function Kg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadge: r, showAssetInSidebar: i, closeSidebar: a, state: o }) {
+	let { read: s, write: c } = yh(o, [
 		"activeAssetId",
 		"selectedAssetIds",
 		"sidebarOpen"
@@ -15486,9 +15724,9 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				}
 			}, a = () => {
 				n && cancelAnimationFrame(n), r && clearTimeout(r), n = requestAnimationFrame(() => {
-					n = null, i() && Mg(e);
+					n = null, i() && zg(e);
 				}), r = setTimeout(() => {
-					r = null, i() && Mg(e);
+					r = null, i() && zg(e);
 				}, 160);
 			}, o = new ResizeObserver(() => a());
 			t && o.observe(t), o.observe(e), e._mjrSelectionResizeObserver = o;
@@ -15528,14 +15766,14 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 			if (!a) return;
 			n.preventDefault(), n.stopPropagation();
 			let l = r?.dataset?.mjrAssetId || "";
-			Lg(e, l ? [l] : [], l), Rg({
+			Wg(e, l ? [l] : [], l), Gg({
 				gridContainer: e,
 				state: o,
 				activeId: l,
 				readState: s,
 				writeState: c
 			});
-			let u = await Tg({
+			let u = await Mg({
 				card: r,
 				asset: a,
 				sidebar: t,
@@ -15554,7 +15792,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 		let u = r._mjrAsset;
 		if (u) {
 			if (e?._mjrSelectionManagedByVue) {
-				Rg({
+				Gg({
 					gridContainer: e,
 					state: o,
 					activeId: String(r?.dataset?.mjrAssetId || "").trim(),
@@ -15576,7 +15814,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				return;
 			}
 			if (n.preventDefault(), n.stopPropagation(), n.ctrlKey || n.metaKey || n.shiftKey) {
-				let t = Fg(e), i = t.indexOf(r);
+				let t = Hg(e), i = t.indexOf(r);
 				if (n.shiftKey) {
 					let t = [];
 					try {
@@ -15588,7 +15826,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 						let n = r?.dataset?.mjrAssetId || "", i = t.findIndex((e) => String(e?.id || "") === String(n)), a = Number(e._mjrLastSelectedIndex), l = Number.isFinite(a) ? a : i;
 						if (i >= 0 && l >= 0) {
 							let r = Math.min(l, i), a = Math.max(l, i), u = t.slice(r, a + 1).map((e) => String(e?.id || "")).filter(Boolean);
-							Lg(e, u, n || u[0] || ""), e._mjrLastSelectedIndex = i, Rg({
+							Wg(e, u, n || u[0] || ""), e._mjrLastSelectedIndex = i, Gg({
 								gridContainer: e,
 								state: o,
 								activeId: n || "",
@@ -15623,7 +15861,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				}
 				a && (l.has(a) ? l.delete(a) : l.add(a));
 				let u = Array.from(l), d = l.has(a) ? a : u[0] || "";
-				Lg(e, u, d), Rg({
+				Wg(e, u, d), Gg({
 					gridContainer: e,
 					state: o,
 					activeId: d,
@@ -15633,7 +15871,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				return;
 			} else {
 				if (r.classList.contains("is-selected")) {
-					Lg(e, [], ""), Rg({
+					Wg(e, [], ""), Gg({
 						gridContainer: e,
 						state: o,
 						activeId: "",
@@ -15643,7 +15881,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 					return;
 				}
 				let n = r?.dataset?.mjrAssetId;
-				Lg(e, n ? [n] : [], n || ""), Rg({
+				Wg(e, n ? [n] : [], n || ""), Gg({
 					gridContainer: e,
 					state: o,
 					activeId: n || "",
@@ -15657,7 +15895,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				}
 			}
 			try {
-				Mg(e), r?.focus?.({ preventScroll: !0 });
+				zg(e), r?.focus?.({ preventScroll: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -15667,10 +15905,10 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 	let p = async () => {
 		let n = String(s("activeAssetId", "") || ""), r = null;
 		if (n) try {
-			r = e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Dg(n)}"]`);
+			r = e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Pg(n)}"]`);
 		} catch {
 			try {
-				r = e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Dg(n)}"]`);
+				r = e.querySelector(`.mjr-asset-card[data-mjr-asset-id="${Pg(n)}"]`);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -15678,7 +15916,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 		r ||= e.querySelector(".mjr-asset-card.is-selected");
 		let l = r?._mjrAsset;
 		if (l) {
-			Eg(e, r), Ig(e), Rg({
+			Ng(e, r), Ug(e), Gg({
 				gridContainer: e,
 				state: o,
 				activeId: r?.dataset?.mjrAssetId,
@@ -15694,7 +15932,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 					} catch (e) {
 						console.debug?.(e);
 					}
-					jg(e, { force: !0 }), Ng(e);
+					Rg(e, { force: !0 }), Bg(e);
 					return;
 				}
 			} catch (e) {
@@ -15707,7 +15945,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 				} catch (e) {
 					console.debug?.(e);
 				}
-				Ng(e), r?.focus?.({ preventScroll: !0 });
+				Bg(e), r?.focus?.({ preventScroll: !0 });
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -15722,7 +15960,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 		if (!n) return !1;
 		let r = null;
 		try {
-			r = Og(e, n);
+			r = Fg(e, n);
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -15759,7 +15997,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 	let _ = (t) => {
 		if (t.defaultPrevented || (t.key?.toLowerCase?.() || "") !== "d" || t.ctrlKey || t.metaKey || t.altKey || t.target?.isContentEditable || t.target?.closest?.("input, textarea, select, [contenteditable='true']")) return;
 		let n = Pt(t.target, ".mjr-asset-card");
-		n && n._mjrAsset && (t.preventDefault(), t.stopPropagation(), Eg(e, n), Ig(e), Rg({
+		n && n._mjrAsset && (t.preventDefault(), t.stopPropagation(), Ng(e, n), Ug(e), Gg({
 			gridContainer: e,
 			state: o,
 			activeId: n?.dataset?.mjrAssetId,
@@ -15846,7 +16084,7 @@ function zg({ gridContainer: e, sidebar: t, createRatingBadge: n, createTagsBadg
 }
 //#endregion
 //#region ui/features/panel/controllers/panelHotkeysController.ts
-function Bg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleFloatingViewer: r, onFocusSearch: i, onClearSearch: a, allowListKeys: o } = {}) {
+function qg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleFloatingViewer: r, onFocusSearch: i, onClearSearch: a, allowListKeys: o } = {}) {
 	let s = !1, c = !1, l = null, u = o instanceof Set ? o : new Set([
 		" ",
 		"ArrowUp",
@@ -15900,7 +16138,7 @@ function Bg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleF
 			c = !1;
 		},
 		keydown: (o) => {
-			if (Se() || ge().scope === "viewer") return;
+			if (Ce() || _e().scope === "viewer") return;
 			if (o.key?.toLowerCase?.() === "v" && !o.ctrlKey && !o.metaKey && !o.altKey && !o.shiftKey && !(o.target?.isContentEditable || o.target?.closest?.("input, textarea, select, [contenteditable='true']")) && l?.isConnected && f(o)) {
 				let e = !1;
 				try {
@@ -15987,7 +16225,7 @@ function Bg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleF
 			} catch (e) {
 				console.debug?.(e);
 			}
-			ne("panel");
+			ee("panel");
 		}
 	}, g = () => {
 		if (l) {
@@ -16001,7 +16239,7 @@ function Bg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleF
 			} catch (e) {
 				console.debug?.(e);
 			}
-			ge().scope === "panel" && ne(null), l = null;
+			_e().scope === "panel" && ee(null), l = null;
 		}
 	};
 	return {
@@ -16011,17 +16249,17 @@ function Bg({ onTriggerScan: e, getScanContext: t, onToggleDetails: n, onToggleF
 }
 //#endregion
 //#region ui/vue/composables/useGridSelection.ts
-function Vg(e) {
+function Jg(e) {
 	return Array.isArray(e) ? e.map((e) => String(e || "").trim()).filter(Boolean) : [];
 }
-function Hg({ gridContainer: e, readSelectedAssetIds: t = () => [], readActiveAssetId: n = () => "", writeSelectedAssetIds: r = (e) => {}, writeActiveAssetId: i = (e) => {}, onSelectionChanged: a = () => {}, lifecycleSignal: o = null } = {}) {
+function Yg({ gridContainer: e, readSelectedAssetIds: t = () => [], readActiveAssetId: n = () => "", writeSelectedAssetIds: r = (e) => {}, writeActiveAssetId: i = (e) => {}, onSelectionChanged: a = () => {}, lifecycleSignal: o = null } = {}) {
 	if (!e) return {
 		restoreSelectionState() {},
 		dispose() {}
 	};
 	let s = (e) => {
 		try {
-			let t = e?.detail || {}, n = Vg(t.selectedIds);
+			let t = e?.detail || {}, n = Jg(t.selectedIds);
 			r(n), i(String(t.activeId || n[0] || "").trim());
 		} catch (e) {
 			console.debug?.(e);
@@ -16039,7 +16277,7 @@ function Hg({ gridContainer: e, readSelectedAssetIds: t = () => [], readActiveAs
 	}
 	return {
 		restoreSelectionState: ({ scrollTop: r = 0 } = {}) => {
-			let i = Vg(t()), a = String(n() || i[0] || "").trim();
+			let i = Jg(t()), a = String(n() || i[0] || "").trim();
 			if (!(!i.length && !a)) {
 				try {
 					typeof e?._mjrSetSelection == "function" && e._mjrSetSelection(i, a);
@@ -16056,7 +16294,7 @@ function Hg({ gridContainer: e, readSelectedAssetIds: t = () => [], readActiveAs
 						console.debug?.(e);
 					}
 					try {
-						Kl(e, a)?.scrollIntoView?.({
+						Jl(e, a)?.scrollIntoView?.({
 							block: "nearest",
 							behavior: "instant"
 						});
@@ -16077,7 +16315,7 @@ function Hg({ gridContainer: e, readSelectedAssetIds: t = () => [], readActiveAs
 }
 //#endregion
 //#region ui/vue/composables/useAssetsQuery.ts
-function Ug(e) {
+function Xg(e) {
 	try {
 		if (typeof requestAnimationFrame == "function") {
 			requestAnimationFrame(e);
@@ -16088,13 +16326,13 @@ function Ug(e) {
 	}
 	setTimeout(e, 0);
 }
-function Wg(e = {}, t = "*") {
+function Zg(e = {}, t = "*") {
 	return e.scope === "output" && !e.collectionId && t === "*" && !e.kindFilter && !e.workflowOnly && !(Number(e.minRating || 0) > 0) && !(Number(e.minSizeMB || 0) > 0) && !(Number(e.maxSizeMB || 0) > 0) && !(Number(e.minWidth || 0) > 0) && !(Number(e.minHeight || 0) > 0) && !(Number(e.maxWidth || 0) > 0) && !(Number(e.maxHeight || 0) > 0) && !String(e.workflowType || "").trim() && !String(e.workflowId || "").trim() && !e.dateRangeFilter && !e.dateExactFilter;
 }
-function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => null, gridController: r, captureAnchor: i, restoreAnchor: a, restoreGridUiState: o = null, readScrollTop: s = () => 0, restoreSelectionState: c = () => {}, readActiveAssetId: l = () => "", isSidebarOpen: u = () => !1, toggleSidebarDetails: d = () => {}, getQuery: f = () => "*", getScope: p = () => "output", loadAssets: m = null, lifecycleSignal: h = null } = {}) {
+function Qg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => null, gridController: r, captureAnchor: i, restoreAnchor: a, restoreGridUiState: o = null, readScrollTop: s = () => 0, restoreSelectionState: c = () => {}, readActiveAssetId: l = () => "", isSidebarOpen: u = () => !1, toggleSidebarDetails: d = () => {}, getQuery: f = () => "*", getScope: p = () => "output", loadAssets: m = null, lifecycleSignal: h = null } = {}) {
 	let g = 0, _ = !1, v = null, y = null, b = null, x = 0, S = !0, C = "", w = Date.now(), T = () => {
 		try {
-			return wc(e, (typeof n == "function" ? n() : t) || t || null);
+			return Ec(e, (typeof n == "function" ? n() : t) || t || null);
 		} catch (e) {
 			return console.debug?.(e), !1;
 		}
@@ -16106,7 +16344,7 @@ function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => nul
 		}
 		if (b && !v) {
 			let e = b, t = x || 50;
-			b = null, x = 0, te(e, Math.min(t, 50));
+			b = null, x = 0, P(e, Math.min(t, 50));
 		}
 		return t && g > 0 && !_ && k().catch((e) => console.debug?.(e)), S;
 	}, D = () => {
@@ -16183,7 +16421,7 @@ function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => nul
 		} catch (e) {
 			console.debug?.(e);
 		}
-		Ug(() => {
+		Xg(() => {
 			let e = Number(s() || 0) || 0;
 			if (e > 0) try {
 				t.scrollTop = e;
@@ -16213,19 +16451,19 @@ function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => nul
 				return;
 			}
 			if (!D() && !O() && String(p() || "output") === "output" && String(f() || "*") === "*") try {
-				let t = await I(`${lt.HEALTH_COUNTERS}?scope=output`, { signal: h || void 0 });
+				let t = await oe(`${B.HEALTH_COUNTERS}?scope=output`, { signal: h || void 0 });
 				t?.ok && (t.data?.total_assets || 0) > 0 && await m(e);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-	}, te = (e, t = 2e3) => (v && clearTimeout(v), E() ? (b = null, x = 0, v = setTimeout(() => {
+	}, P = (e, t = 2e3) => (v && clearTimeout(v), E() ? (b = null, x = 0, v = setTimeout(() => {
 		v = null, ee(e).catch(() => {});
 	}, t), v) : (b = e, x = t, null));
 	return {
 		queuedReload: k,
 		restoreUiState: N,
-		scheduleAutoLoad: te,
+		scheduleAutoLoad: P,
 		createCountersUpdateHandler: ({ state: t = {}, getStableQuery: n = () => String(e?.dataset?.mjrQuery || "*").trim() || "*", getRecentUserInteractionAt: r = () => 0 } = {}) => {
 			let i = globalThis?.window ?? globalThis, a = null, o = null, s = null, c = !1;
 			return async (e = {}) => {
@@ -16233,7 +16471,7 @@ function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => nul
 					c = !0, a = e.last_scan_end, o = e.last_index_end, s = Number(e.total_assets ?? null);
 					return;
 				}
-				let l = e.last_scan_end && e.last_scan_end !== a, u = e.last_index_end && e.last_index_end !== o, d = Number(e.total_assets ?? null), f = Wg(t, String(n() || "*").trim() || "*"), p = Date.now() - w < 8e3, m = Number.isFinite(d) && Number.isFinite(s) ? d - s : 0, h = Math.max(0, Number(i?.__mjrLastAssetUpsertCount || 0) || 0), g = m >= 20;
+				let l = e.last_scan_end && e.last_scan_end !== a, u = e.last_index_end && e.last_index_end !== o, d = Number(e.total_assets ?? null), f = Zg(t, String(n() || "*").trim() || "*"), p = Date.now() - w < 8e3, m = Number.isFinite(d) && Number.isFinite(s) ? d - s : 0, h = Math.max(0, Number(i?.__mjrLastAssetUpsertCount || 0) || 0), g = m >= 20;
 				if (Number.isFinite(d) && (s = d), !f) {
 					a = e.last_scan_end, o = e.last_index_end;
 					return;
@@ -16352,7 +16590,7 @@ function Gg({ gridContainer: e, gridWrapper: t, readScrollElement: n = () => nul
 }
 //#endregion
 //#region ui/features/panel/panelBootstrap.ts
-function Kg(e, { useComfyThemeUI: t }) {
+function $g(e, { useComfyThemeUI: t }) {
 	t ? e.classList.add("mjr-assets-manager") : e.classList.remove("mjr-assets-manager");
 	let n = e.parentElement || null, r = n ? {
 		height: n.style.height,
@@ -16392,8 +16630,8 @@ function Kg(e, { useComfyThemeUI: t }) {
 }
 //#endregion
 //#region ui/features/panel/panelSettingsSync.ts
-function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper: i, similarBtn: a, setSemanticEnabled: o, similarEnabledTitle: s, similarDisabledTitle: c, refreshGridFn: l, isSidebarOpen: u, readActiveAssetId: d, getSidebarController: f, panelLifecycleAC: p }) {
-	let m = "", g = () => {
+function e_({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper: i, similarBtn: a, setSemanticEnabled: s, similarEnabledTitle: c, similarDisabledTitle: l, refreshGridFn: u, isSidebarOpen: d, readActiveAssetId: f, getSidebarController: p, panelLifecycleAC: m }) {
+	let h = "", g = () => {
 		try {
 			return !!(mn()?.ai?.vectorSearchEnabled ?? !0);
 		} catch {
@@ -16407,19 +16645,19 @@ function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper:
 			console.debug?.(e);
 		}
 		try {
-			a.disabled = !n, a.title = n ? s : c;
+			a.disabled = !n, a.title = n ? c : l;
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			o?.(n);
+			s?.(n);
 		} catch (e) {
 			console.debug?.(e);
 		}
 	}, v = (e) => {
 		let t = String(e || "right").toLowerCase() === "left" ? "left" : "right", a = t === "left" ? n?.nextElementSibling === i : i?.nextElementSibling === n;
-		if (m === t && a) return;
-		m = t;
+		if (h === t && a) return;
+		h = t;
 		let o = 0, s = 0;
 		try {
 			o = Number(i?.scrollTop || 0) || 0, s = Number(i?.scrollLeft || 0) || 0;
@@ -16457,19 +16695,19 @@ function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper:
 		let n = String(e || t.scope || "output").toLowerCase(), r = !!mn()?.watcher?.enabled;
 		if (n === "custom") {
 			try {
-				await h(!1);
+				await S(!1);
 			} catch (e) {
 				console.debug?.(e);
 			}
 			return;
 		}
 		try {
-			await h(r);
+			await S(r);
 		} catch (e) {
 			console.debug?.(e);
 		}
 		if (r) try {
-			await x({
+			await o({
 				scope: n,
 				customRootId: ""
 			});
@@ -16479,17 +16717,17 @@ function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper:
 	}, b = (e) => {
 		let n = String(e?.detail?.key || "").trim(), r = n === "__init__", i = r || n.startsWith("grid.") || n.startsWith("infiniteScroll.") || n.startsWith("siblings.") || n.startsWith("search.") || n.startsWith("rtHydrate.") || n.startsWith("workflowMinimap."), a = r || n.startsWith("sidebar.") || n.startsWith("ai."), o = r || n.startsWith("watcher.");
 		try {
-			let e = mn(), t = !!(e?.ai?.vectorSearchEnabled ?? !0), o = String(e?.ui?.cardHoverColor || "").trim(), s = String(e?.ui?.cardSelectionColor || "").trim(), c = String(e?.ui?.ratingColor || "").trim(), p = String(e?.ui?.tagColor || "").trim();
-			if (/^#[0-9a-fA-F]{3,8}$/.test(o) && document.documentElement.style.setProperty("--mjr-card-hover-color", o), /^#[0-9a-fA-F]{3,8}$/.test(s) && document.documentElement.style.setProperty("--mjr-card-selection-color", s), /^#[0-9a-fA-F]{3,8}$/.test(c) && document.documentElement.style.setProperty("--mjr-rating-color", c), /^#[0-9a-fA-F]{3,8}$/.test(p) && document.documentElement.style.setProperty("--mjr-tag-color", p), v(e.sidebar?.position || "right"), _(t), i) {
+			let e = mn(), t = !!(e?.ai?.vectorSearchEnabled ?? !0), o = String(e?.ui?.cardHoverColor || "").trim(), s = String(e?.ui?.cardSelectionColor || "").trim(), c = String(e?.ui?.ratingColor || "").trim(), l = String(e?.ui?.tagColor || "").trim();
+			if (/^#[0-9a-fA-F]{3,8}$/.test(o) && document.documentElement.style.setProperty("--mjr-card-hover-color", o), /^#[0-9a-fA-F]{3,8}$/.test(s) && document.documentElement.style.setProperty("--mjr-card-selection-color", s), /^#[0-9a-fA-F]{3,8}$/.test(c) && document.documentElement.style.setProperty("--mjr-rating-color", c), /^#[0-9a-fA-F]{3,8}$/.test(l) && document.documentElement.style.setProperty("--mjr-tag-color", l), v(e.sidebar?.position || "right"), _(t), i) {
 				let e = Zn() || null;
 				if (!r && n.startsWith("siblings.")) try {
 					e?.dispatchEvent(new CustomEvent("mjr:reload-grid"));
 				} catch {
-					e && l(e);
+					e && u(e);
 				}
-				else (n.startsWith("grid.") || n.startsWith("workflowMinimap.")) && e && l(e);
+				else (n.startsWith("grid.") || n.startsWith("workflowMinimap.")) && e && u(e);
 			}
-			a && u() && d() && f()?.refreshActiveAsset?.();
+			a && d() && f() && p()?.refreshActiveAsset?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -16506,7 +16744,7 @@ function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper:
 		console.debug?.(e);
 	}
 	try {
-		window.addEventListener?.("mjr-settings-changed", b, { signal: p?.signal });
+		window.addEventListener?.("mjr-settings-changed", b, { signal: m?.signal });
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -16519,7 +16757,7 @@ function qg({ container: e, state: t, sidebar: n, browseSection: r, gridWrapper:
 }
 //#endregion
 //#region ui/features/panel/panelGridEventBindings.ts
-function Jg({ gridContainer: e, panelLifecycleAC: t, requestQueuedReload: n, notifyContextChanged: r, markUserInteraction: i, writePanelValue: a, popovers: o, collectionsPopover: s, gridController: c, registerSummaryDispose: l }) {
+function t_({ gridContainer: e, panelLifecycleAC: t, requestQueuedReload: n, notifyContextChanged: r, markUserInteraction: i, writePanelValue: a, popovers: o, collectionsPopover: s, gridController: c, registerSummaryDispose: l }) {
 	let u = null;
 	try {
 		u = () => n(), e.addEventListener("mjr:reload-grid", u, { signal: t?.signal }), l(() => {
@@ -16547,7 +16785,7 @@ function Jg({ gridContainer: e, panelLifecycleAC: t, requestQueuedReload: n, not
 				}), i(), r();
 				let l = Number(n?.count || s.length || o.length || 0);
 				try {
-					A(R("toast.nameCollisionInView", "Name collision in view: {n} item(s) selected", { n: l }), "info", 1800);
+					k(L("toast.nameCollisionInView", "Name collision in view: {n} item(s) selected", { n: l }), "info", 1800);
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -16630,39 +16868,39 @@ function Jg({ gridContainer: e, panelLifecycleAC: t, requestQueuedReload: n, not
 }
 //#endregion
 //#region ui/features/panel/panelSimilarSearch.ts
-var Yg = 500;
-function Xg(e) {
+var n_ = 500;
+function r_(e) {
 	return Number(e?.status || 0) === 404 && String(e?.error || "").toLowerCase().includes("non-json");
 }
-function Zg(e, t = "") {
+function i_(e, t = "") {
 	let n = Array.isArray(e) ? e : [];
-	return n.length <= Yg ? {
+	return n.length <= n_ ? {
 		list: n,
 		title: t,
 		truncated: !1,
 		total: n.length
 	} : {
-		list: n.slice(0, Yg),
-		title: `${String(t || "").trim() || "Generation group"} - showing first ${Yg}/${n.length}`,
+		list: n.slice(0, n_),
+		title: `${String(t || "").trim() || "Generation group"} - showing first ${n_}/${n.length}`,
 		truncated: !0,
 		total: n.length
 	};
 }
-function Qg(e = {}) {
+function a_(e = {}) {
 	let t = String(e?.stackId || e?.stack_id || "").trim();
 	if (t) return `stack:${t}`;
 	let n = String(e?.asset?.id || "").trim();
 	return e?.isDupGroup ? n ? `duplicates:${n}` : "duplicates" : n ? `group:${n}` : "group";
 }
-function $g(e, t) {
+function o_(e, t) {
 	return String(e?.[t] ?? e?.file_info?.[t] ?? "").trim();
 }
-function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplicatesBtn: r, similarSameNodeBtn: i, similarSameWorkflowBtn: a, gridContainer: o, state: s, panelLifecycleAC: c, isAiEnabled: l, similarDisabledTitle: u, readActiveAssetId: d, readSelectedAssetIds: f, readPanelValue: p, writePanelValue: m, scopeController: h, closePopovers: g, closePeerPopovers: _, popovers: v, workflowIdInput: y, reloadGrid: b, getDuplicatesAlert: x }) {
-	let S = () => String(d() || f()[0] || "").trim(), C = () => {
-		let e = Number(S());
+function s_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplicatesBtn: r, similarSameNodeBtn: i, similarSameWorkflowBtn: a, gridContainer: o, state: s, panelLifecycleAC: c, isAiEnabled: l, similarDisabledTitle: d, readActiveAssetId: f, readSelectedAssetIds: p, readPanelValue: m, writePanelValue: h, scopeController: g, closePopovers: _, closePeerPopovers: v, popovers: y, workflowIdInput: b, reloadGrid: x, getDuplicatesAlert: S }) {
+	let C = () => String(f() || p()[0] || "").trim(), w = () => {
+		let e = Number(C());
 		return Number.isFinite(e) && e > 0 ? e : 0;
-	}, w = () => {
-		let e = S();
+	}, T = () => {
+		let e = C();
 		if (!e) return null;
 		try {
 			let t = o?._mjrGetAssets, n = typeof t == "function" ? t() : [];
@@ -16670,20 +16908,20 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 		} catch (e) {
 			return console.debug?.(e), null;
 		}
-	}, T = async () => {
-		let e = w();
+	}, E = async () => {
+		let e = T();
 		if (e) return e;
-		let t = C();
-		return t ? E(t) : null;
-	}, E = async (e = C()) => {
+		let t = w();
+		return t ? D(t) : null;
+	}, D = async (e = w()) => {
 		if (!e) return null;
 		try {
-			let t = await oe(e, { timeoutMs: 3e4 });
+			let t = await ie(e, { timeoutMs: 3e4 });
 			return t?.ok && t.data || null;
 		} catch (e) {
 			return console.debug?.(e), null;
 		}
-	}, O = async (e, t) => e && t.some((t) => $g(e, t)) ? e : await E() || e, k = (e = {}) => (Array.isArray(e?.files) ? e.files : []).map((e) => ({
+	}, O = async (e, t) => e && t.some((t) => o_(e, t)) ? e : await D() || e, A = (e = {}) => (Array.isArray(e?.files) ? e.files : []).map((e) => ({
 		filename: String(e?.filename || "").trim(),
 		subfolder: String(e?.subfolder || "").trim().replace(/\\/g, "/"),
 		type: String(e?.type || "").trim().toLowerCase()
@@ -16692,7 +16930,7 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 		for (let e of t.slice(0, 4)) {
 			let t = e.type === "input" ? "input" : "output";
 			try {
-				let i = await I(L({
+				let i = await oe(I({
 					q: e.filename,
 					scope: t,
 					limit: 50,
@@ -16713,19 +16951,19 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 			}
 		}
 		if (!n.length) {
-			A(R("nodeContext.fileNotIndexed", "The node file is not indexed yet. Run a scan first."), "info", 3200);
+			k(L("nodeContext.fileNotIndexed", "The node file is not indexed yet. Run a scan first."), "info", 3200);
 			return;
 		}
 		let i = String(e?.title || e?.sourceNodeType || e?.source_node_type || t[0]?.filename || "").trim();
-		m("similarResults", n), m("similarSourceAssetId", `node-file:${t[0]?.filename || ""}`), m("similarTitle", R("nodeContext.fileResultsTitle", "Node {node} file ({n} assets)", {
+		h("similarResults", n), h("similarSourceAssetId", `node-file:${t[0]?.filename || ""}`), h("similarTitle", L("nodeContext.fileResultsTitle", "Node {node} file ({n} assets)", {
 			node: i || t[0]?.filename || "",
 			n: n.length
-		})), await h?.setScope?.("similar");
+		})), await g?.setScope?.("similar");
 	}, M = async (e = {}) => {
-		let t = String(e?.sourceNodeId || e?.source_node_id || "").trim(), n = k(e);
+		let t = String(e?.sourceNodeId || e?.source_node_id || "").trim(), n = A(e);
 		if (!(!t && !n.length)) {
 			try {
-				g?.();
+				_?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -16734,26 +16972,26 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 				return;
 			}
 			try {
-				let r = await I(ut(t, {
+				let r = await oe(ut(t, {
 					jobId: e?.jobId || e?.job_id || "",
 					latest: e?.latest !== !1,
 					limit: 500
 				}), { timeoutMs: 3e4 });
 				if (!r?.ok) {
-					if (Xg(r)) {
+					if (r_(r)) {
 						if (n.length) {
 							await j(e, n);
 							return;
 						}
 						let t = window.MajoorAssetsManager ||= {};
-						t.nodeContextRouteMissingToastShown || (t.nodeContextRouteMissingToastShown = !0, A(R("nodeContext.routeMissing", "Node context backend route is not loaded yet. Restart ComfyUI after updating Majoor Assets Manager."), "warn", 7e3));
+						t.nodeContextRouteMissingToastShown || (t.nodeContextRouteMissingToastShown = !0, k(L("nodeContext.routeMissing", "Node context backend route is not loaded yet. Restart ComfyUI after updating Majoor Assets Manager."), "warn", 7e3));
 						return;
 					}
 					if (n.length) {
 						await j(e, n);
 						return;
 					}
-					A(String(r?.error || R("nodeContext.loadFailed", "Failed to load node assets")), "error", 3e3);
+					k(String(r?.error || L("nodeContext.loadFailed", "Failed to load node assets")), "error", 3e3);
 					return;
 				}
 				let i = Array.isArray(r?.data) ? r.data : [];
@@ -16762,130 +17000,130 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 						await j(e, n);
 						return;
 					}
-					A(R("nodeContext.noAssets", "No indexed assets found for this node yet."), "info", 2600);
+					k(L("nodeContext.noAssets", "No indexed assets found for this node yet."), "info", 2600);
 					return;
 				}
 				let a = String(e?.title || e?.sourceNodeType || e?.source_node_type || t).trim();
-				m("similarResults", i), m("similarSourceAssetId", `node:${t}`), m("similarTitle", R("nodeContext.resultsTitle", "Node {node} outputs ({n} assets)", {
+				h("similarResults", i), h("similarSourceAssetId", `node:${t}`), h("similarTitle", L("nodeContext.resultsTitle", "Node {node} outputs ({n} assets)", {
 					node: a || t,
 					n: i.length
-				})), await h?.setScope?.("similar");
+				})), await g?.setScope?.("similar");
 			} catch (e) {
-				console.debug?.(e), A(R("nodeContext.loadFailed", "Failed to load node assets"), "error", 3e3);
+				console.debug?.(e), k(L("nodeContext.loadFailed", "Failed to load node assets"), "error", 3e3);
 			}
 		}
 	}, N = async () => {
 		if (!l()) {
-			A(u, "info", 2200);
+			k(d, "info", 2200);
 			return;
 		}
 		try {
-			g();
+			_();
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let t = C();
+		let t = w();
 		if (!t) {
-			A(R("search.selectAssetForSimilar", "Select an asset first to find similar images/videos."), "info", 2500);
+			k(L("search.selectAssetForSimilar", "Select an asset first to find similar images/videos."), "info", 2500);
 			return;
 		}
 		let n = e.title;
-		e.disabled = !0, e.title = R("search.findingSimilar", "Finding similar assets...");
+		e.disabled = !0, e.title = L("search.findingSimilar", "Finding similar assets...");
 		try {
-			let e = await D(t, {
+			let e = await u(t, {
 				topK: 100,
 				scope: s.scope || "output",
 				customRootId: s.customRootId || ""
 			});
 			if (!e?.ok) {
-				A(String(e?.error || R("search.findSimilarFailed", "Failed to find similar assets")), "error", 3e3);
+				k(String(e?.error || L("search.findSimilarFailed", "Failed to find similar assets")), "error", 3e3);
 				return;
 			}
 			let n = Array.isArray(e?.data) ? e.data : [];
-			m("similarResults", n), m("similarSourceAssetId", String(t)), m("similarTitle", R("search.similarResults", "Similar to asset #{id} ({n} results)", {
+			h("similarResults", n), h("similarSourceAssetId", String(t)), h("similarTitle", L("search.similarResults", "Similar to asset #{id} ({n} results)", {
 				id: t,
 				n: n.length
-			})), await h?.setScope?.("similar");
+			})), await g?.setScope?.("similar");
 		} catch (e) {
-			console.debug?.(e), A(R("search.findSimilarFailed", "Failed to find similar assets"), "error", 3e3);
+			console.debug?.(e), k(L("search.findSimilarFailed", "Failed to find similar assets"), "error", 3e3);
 		} finally {
 			e.disabled = !1, e.title = n;
 		}
 	}, ee = async () => {
 		try {
-			g?.();
+			_?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
-		let e = await T(), t = String(e?.id || S() || "").trim(), n = Array.isArray(e?._mjrDupMembers) ? e._mjrDupMembers : [];
+		let e = await E(), t = String(e?.id || C() || "").trim(), n = Array.isArray(e?._mjrDupMembers) ? e._mjrDupMembers : [];
 		if (n.length >= 2) {
-			m("similarResults", n), m("similarSourceAssetId", t ? `duplicates:${t}` : "duplicates"), m("similarTitle", R("search.duplicateResults", "Duplicates ({n} assets)", { n: n.length })), await h?.setScope?.("similar");
+			h("similarResults", n), h("similarSourceAssetId", t ? `duplicates:${t}` : "duplicates"), h("similarTitle", L("search.duplicateResults", "Duplicates ({n} assets)", { n: n.length })), await g?.setScope?.("similar");
 			return;
 		}
-		let r = (x?.() || {})?.firstGroup;
+		let r = (S?.() || {})?.firstGroup;
 		if (r && Array.isArray(r.assets) && r.assets.length >= 2) {
-			m("similarResults", r.assets), m("similarSourceAssetId", "duplicates"), m("similarTitle", R("search.duplicateResults", "Duplicates ({n} assets)", { n: r.assets.length })), await h?.setScope?.("similar");
+			h("similarResults", r.assets), h("similarSourceAssetId", "duplicates"), h("similarTitle", L("search.duplicateResults", "Duplicates ({n} assets)", { n: r.assets.length })), await g?.setScope?.("similar");
 			return;
 		}
-		A(R("search.noKnownDuplicates", "No duplicate group is available yet. Run duplicate analysis from the duplicate alert first."), "info", 3200);
-	}, te = async () => {
-		let e = await O(await T(), ["source_node_id", "source_node_type"]), t = $g(e, "source_node_id");
+		k(L("search.noKnownDuplicates", "No duplicate group is available yet. Run duplicate analysis from the duplicate alert first."), "info", 3200);
+	}, P = async () => {
+		let e = await O(await E(), ["source_node_id", "source_node_type"]), t = o_(e, "source_node_id");
 		if (!t) {
-			A(R("search.noSourceNode", "Selected asset has no persisted source node id."), "info", 2600);
+			k(L("search.noSourceNode", "Selected asset has no persisted source node id."), "info", 2600);
 			return;
 		}
 		await M({
 			sourceNodeId: t,
-			sourceNodeType: $g(e, "source_node_type"),
-			jobId: $g(e, "job_id"),
-			title: $g(e, "source_node_type") || t
+			sourceNodeType: o_(e, "source_node_type"),
+			jobId: o_(e, "job_id"),
+			title: o_(e, "source_node_type") || t
 		});
-	}, ne = async () => {
-		try {
-			g?.();
-		} catch (e) {
-			console.debug?.(e);
-		}
-		let e = $g(await O(await T(), ["workflow_id"]), "workflow_id");
-		if (!e) {
-			A(R("search.noWorkflowId", "Selected asset has no persisted workflow id."), "info", 2600);
-			return;
-		}
-		m("workflowId", e);
-		try {
-			y && (y.value = e);
-		} catch (e) {
-			console.debug?.(e);
-		}
-		try {
-			await h?.setScope?.(s.scope || "output");
-		} catch (e) {
-			console.debug?.(e);
-		}
-		await b?.();
-	};
-	e?.addEventListener("click", (n) => {
-		n.stopPropagation();
+	}, te = async () => {
 		try {
 			_?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
-		v?.toggle?.(t, e);
+		let e = o_(await O(await E(), ["workflow_id"]), "workflow_id");
+		if (!e) {
+			k(L("search.noWorkflowId", "Selected asset has no persisted workflow id."), "info", 2600);
+			return;
+		}
+		h("workflowId", e);
+		try {
+			b && (b.value = e);
+		} catch (e) {
+			console.debug?.(e);
+		}
+		try {
+			await g?.setScope?.(s.scope || "output");
+		} catch (e) {
+			console.debug?.(e);
+		}
+		await x?.();
+	};
+	e?.addEventListener("click", (n) => {
+		n.stopPropagation();
+		try {
+			v?.();
+		} catch (e) {
+			console.debug?.(e);
+		}
+		y?.toggle?.(t, e);
 	}, { signal: c?.signal });
-	let P = (e, t) => {
+	let ne = (e, t) => {
 		e?.addEventListener("click", (e) => {
 			e.stopPropagation(), t();
 		}, { signal: c?.signal });
 	};
-	P(n, N), P(r, ee), P(i, te), P(a, ne), o?.addEventListener(B.OPEN_STACK_GROUP, async (e) => {
+	ne(n, N), ne(r, ee), ne(i, P), ne(a, te), o?.addEventListener(z.OPEN_STACK_GROUP, async (e) => {
 		try {
-			let t = e?.detail || {}, n = Array.isArray(t?.members) ? t.members : [], r = `Generation group (${n.length} assets)`, i = Zg(n, String(t?.title || "").trim() || r);
-			i.truncated && A(`Large stack truncated to ${Yg}/${i.total} assets to keep the grid responsive.`, "warn", 5e3), m("similarResults", i.list), m("similarSourceAssetId", Qg(t)), m("similarTitle", i.title || r), await Promise.resolve(), await h?.setScope?.("similar");
+			let t = e?.detail || {}, n = Array.isArray(t?.members) ? t.members : [], r = `Generation group (${n.length} assets)`, i = i_(n, String(t?.title || "").trim() || r);
+			i.truncated && k(`Large stack truncated to ${n_}/${i.total} assets to keep the grid responsive.`, "warn", 5e3), h("similarResults", i.list), h("similarSourceAssetId", a_(t)), h("similarTitle", i.title || r), await Promise.resolve(), await g?.setScope?.("similar");
 		} catch (e) {
 			console.debug?.(e);
 		}
-	}, { signal: c?.signal }), window.addEventListener(B.OPEN_NODE_CONTEXT, (e) => {
+	}, { signal: c?.signal }), window.addEventListener(z.OPEN_NODE_CONTEXT, (e) => {
 		try {
 			let e = window.MajoorAssetsManager;
 			e?.pendingNodeContext && (e.pendingNodeContext = null);
@@ -16905,7 +17143,7 @@ function e_({ similarBtn: e, similarPopover: t, similarFindBtn: n, similarDuplic
 }
 //#endregion
 //#region ui/features/panel/panelPinnedFolders.ts
-function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFoldersMenu: n = null, pinnedFoldersPopover: r, popovers: i, closeOtherPopovers: a, state: o, gridContainer: s, customSelect: c, scopeController: l, customRootsController: u, gridController: d, applyWatcherForScope: f, refreshDuplicateAlerts: p, notifyContextChanged: m, panelLifecycleAC: h }) {
+function c_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFoldersMenu: n = null, pinnedFoldersPopover: r, popovers: i, closeOtherPopovers: a, state: o, gridContainer: s, customSelect: c, scopeController: l, customRootsController: u, gridController: d, applyWatcherForScope: f, refreshDuplicateAlerts: p, notifyContextChanged: m, panelLifecycleAC: h }) {
 	let g = (e) => {
 		let t = String(e?.id || "").trim();
 		if (!t) return null;
@@ -16917,7 +17155,7 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 		};
 	}, _ = async () => {
 		try {
-			let e = await I(lt.CUSTOM_ROOTS, h?.signal ? { signal: h.signal } : void 0);
+			let e = await oe(B.CUSTOM_ROOTS, h?.signal ? { signal: h.signal } : void 0);
 			return e?.ok && Array.isArray(e.data) ? e.data.map(g).filter(Boolean) : [];
 		} catch (e) {
 			return console.debug?.(e), [];
@@ -16962,10 +17200,10 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 	}, y = async (e, t = null) => {
 		t?.preventDefault?.(), t?.stopPropagation?.();
 		let n = String(e?.id || "").trim();
-		if (!n || !await Gt(R("dialog.unpinFolder", "Unpin folder \"{name}\"?", { name: String(e?.label || e?.path || n).trim() }))) return;
-		let r = await ue(lt.CUSTOM_ROOTS_REMOVE, { id: n });
+		if (!n || !await Gt(L("dialog.unpinFolder", "Unpin folder \"{name}\"?", { name: String(e?.label || e?.path || n).trim() }))) return;
+		let r = await ue(B.CUSTOM_ROOTS_REMOVE, { id: n });
 		if (!r?.ok) {
-			A(r?.error || R("toast.unpinFolderFailed", "Failed to unpin folder"), "error");
+			k(r?.error || L("toast.unpinFolderFailed", "Failed to unpin folder"), "error");
 			return;
 		}
 		String(o.customRootId || "") === n && (o.customRootId = "", o.customRootLabel = "", o.currentFolderRelativePath = "");
@@ -16977,9 +17215,9 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 		await S(), await d.reloadGrid();
 	}, b = (e) => typeof t?.setPinnedFolders == "function" ? (t.setPinnedFolders({
 		roots: e,
-		emptyLabel: R("msg.noPinnedFolders", "No pinned folders"),
-		loadingLabel: R("status.loading", "Loading..."),
-		unpinLabel: R("ctx.unpinFolder", "Unpin folder"),
+		emptyLabel: L("msg.noPinnedFolders", "No pinned folders"),
+		loadingLabel: L("status.loading", "Loading..."),
+		unpinLabel: L("ctx.unpinFolder", "Unpin folder"),
 		onOpen: v,
 		onUnpin: y,
 		loading: !1
@@ -16992,7 +17230,7 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 			}
 			if (!e.length) {
 				let e = document.createElement("div");
-				e.className = "mjr-muted", e.style.cssText = "padding:10px 12px; opacity:0.75;", e.textContent = R("msg.noPinnedFolders", "No pinned folders"), n.appendChild(e);
+				e.className = "mjr-muted", e.style.cssText = "padding:10px 12px; opacity:0.75;", e.textContent = L("msg.noPinnedFolders", "No pinned folders"), n.appendChild(e);
 				return;
 			}
 			for (let t of e) {
@@ -17001,13 +17239,13 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 				let r = document.createElement("button");
 				r.type = "button", r.className = "mjr-menu-item mjr-pinned-folder-open", r.textContent = t.label, r.addEventListener("click", () => v(t), { signal: h?.signal });
 				let i = document.createElement("button");
-				i.type = "button", i.className = "mjr-menu-item mjr-pinned-folder-unpin", i.title = R("ctx.unpinFolder", "Unpin folder"), i.textContent = "x", i.addEventListener("click", (e) => y(t, e), { signal: h?.signal }), e.appendChild(r), e.appendChild(i), n.appendChild(e);
+				i.type = "button", i.className = "mjr-menu-item mjr-pinned-folder-unpin", i.title = L("ctx.unpinFolder", "Unpin folder"), i.textContent = "x", i.addEventListener("click", (e) => y(t, e), { signal: h?.signal }), e.appendChild(r), e.appendChild(i), n.appendChild(e);
 			}
 		}
 	};
 	async function S() {
 		try {
-			t?.setPinnedFoldersLoading?.(!0, R("status.loading", "Loading..."));
+			t?.setPinnedFoldersLoading?.(!0, L("status.loading", "Loading..."));
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -17026,8 +17264,8 @@ function t_({ pinnedFoldersBtn: e, pinnedFoldersController: t = null, pinnedFold
 }
 //#endregion
 //#region ui/features/filters/calendar/AgendaCalendar.ts
-var n_ = (e) => String(e).padStart(2, "0");
-function r_(e) {
+var l_ = (e) => String(e).padStart(2, "0");
+function u_(e) {
 	try {
 		let t = String(e || "").trim();
 		if (!/^\d{4}-\d{2}-\d{2}$/.test(t)) return null;
@@ -17039,50 +17277,50 @@ function r_(e) {
 		return null;
 	}
 }
-function i_(e) {
+function d_(e) {
 	try {
 		let t = e.getFullYear(), n = e.getMonth() + 1, r = e.getDate();
-		return `${t}-${n_(n)}-${n_(r)}`;
+		return `${t}-${l_(n)}-${l_(r)}`;
 	} catch {
 		return "";
 	}
 }
-function a_(e) {
+function f_(e) {
 	try {
-		return `${e.getFullYear()}-${n_(e.getMonth() + 1)}`;
+		return `${e.getFullYear()}-${l_(e.getMonth() + 1)}`;
 	} catch {
 		return "";
 	}
 }
-function o_(e) {
+function p_(e) {
 	try {
 		return new Date(e.getFullYear(), e.getMonth(), 1);
 	} catch {
 		return /* @__PURE__ */ new Date();
 	}
 }
-function s_(e, t) {
+function m_(e, t) {
 	try {
 		return new Date(e.getFullYear(), e.getMonth() + t, 1);
 	} catch {
 		return /* @__PURE__ */ new Date();
 	}
 }
-function c_(e) {
+function h_(e) {
 	try {
 		return new Date(e.getFullYear(), e.getMonth() + 1, 0).getDate();
 	} catch {
 		return 31;
 	}
 }
-function l_(e) {
+function g_(e) {
 	try {
 		return (e.getDay() + 6) % 7;
 	} catch {
 		return 0;
 	}
 }
-function u_(e, t) {
+function __(e, t) {
 	if (e) try {
 		let n = String(e.value || "");
 		e.value = t || "", n !== e.value && e.dispatchEvent?.(new Event("change", { bubbles: !0 }));
@@ -17090,14 +17328,14 @@ function u_(e, t) {
 		console.debug?.(e);
 	}
 }
-async function d_({ state: e, monthKey: t }) {
+async function v_({ state: e, monthKey: t }) {
 	try {
 		let n = String(e?.scope || "output");
 		if (n === "collection") return {
 			ok: !0,
 			days: {}
 		};
-		let r = String(e?.currentFolderRelativePath || "").trim(), i = n === "custom" && !e?.customRootId ? null : r || null, a = await I(st({
+		let r = String(e?.currentFolderRelativePath || "").trim(), i = n === "custom" && !e?.customRootId ? null : r || null, a = await oe(ct({
 			scope: n,
 			customRootId: e?.customRootId || null,
 			subfolder: i,
@@ -17129,7 +17367,7 @@ async function d_({ state: e, monthKey: t }) {
 		};
 	}
 }
-function f_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = null } = {}) {
+function y_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = null } = {}) {
 	if (!e || !(e instanceof HTMLElement) || !t) return {
 		dispose() {},
 		refresh() {}
@@ -17149,10 +17387,10 @@ function f_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = n
 	let u = document.createElement("div");
 	u.className = "mjr-agenda-footer";
 	let d = document.createElement("button");
-	d.type = "button", d.className = "mjr-btn mjr-agenda-clear", d.textContent = R("action.clear", "Clear");
+	d.type = "button", d.className = "mjr-btn mjr-agenda-clear", d.textContent = L("action.clear", "Clear");
 	let f = document.createElement("button");
-	f.type = "button", f.className = "mjr-btn mjr-agenda-refresh", f.textContent = R("action.refresh", "Refresh"), u.appendChild(d), u.appendChild(f), i.appendChild(a), i.appendChild(l), i.appendChild(u), e.appendChild(i);
-	let p = o_(r_(t.value) || /* @__PURE__ */ new Date()), m = {}, h = 0, g = !1, _ = () => {
+	f.type = "button", f.className = "mjr-btn mjr-agenda-refresh", f.textContent = L("action.refresh", "Refresh"), u.appendChild(d), u.appendChild(f), i.appendChild(a), i.appendChild(l), i.appendChild(u), e.appendChild(i);
+	let p = p_(u_(t.value) || /* @__PURE__ */ new Date()), m = {}, h = 0, g = !1, _ = () => {
 		if (g) return;
 		let e = p.getFullYear(), n = p.getMonth();
 		s.textContent = p.toLocaleString(void 0, {
@@ -17160,53 +17398,53 @@ function f_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = n
 			year: "numeric"
 		}), l.innerHTML = "";
 		let r = [
-			R("weekday.monShort", "Mon"),
-			R("weekday.tueShort", "Tue"),
-			R("weekday.wedShort", "Wed"),
-			R("weekday.thuShort", "Thu"),
-			R("weekday.friShort", "Fri"),
-			R("weekday.satShort", "Sat"),
-			R("weekday.sunShort", "Sun")
+			L("weekday.monShort", "Mon"),
+			L("weekday.tueShort", "Tue"),
+			L("weekday.wedShort", "Wed"),
+			L("weekday.thuShort", "Thu"),
+			L("weekday.friShort", "Fri"),
+			L("weekday.satShort", "Sat"),
+			L("weekday.sunShort", "Sun")
 		];
 		for (let e of r) {
 			let t = document.createElement("div");
 			t.className = "mjr-agenda-weekday", t.textContent = e, l.appendChild(t);
 		}
-		let i = l_(new Date(e, n, 1)), a = c_(p), o = r_(t.value), c = o ? i_(o) : "";
+		let i = g_(new Date(e, n, 1)), a = h_(p), o = u_(t.value), c = o ? d_(o) : "";
 		for (let e = 0; e < i; e++) {
 			let e = document.createElement("div");
 			e.className = "mjr-agenda-day mjr-agenda-day--blank", l.appendChild(e);
 		}
 		for (let r = 1; r <= a; r++) {
-			let i = i_(new Date(e, n, r)), a = Number(m?.[i] || 0) || 0, o = document.createElement("button");
+			let i = d_(new Date(e, n, r)), a = Number(m?.[i] || 0) || 0, o = document.createElement("button");
 			if (o.type = "button", o.className = "mjr-agenda-day", o.textContent = String(r), o.dataset.date = i, a > 0) {
 				o.classList.add("mjr-agenda-day--has-assets");
-				let e = R(a === 1 ? "tooltip.assetsDaySingular" : "tooltip.assetsDayPlural", a === 1 ? "{count} asset" : "{count} assets", { count: a });
+				let e = L(a === 1 ? "tooltip.assetsDaySingular" : "tooltip.assetsDayPlural", a === 1 ? "{count} asset" : "{count} assets", { count: a });
 				o.title = e;
 				let t = document.createElement("span");
 				t.className = "mjr-agenda-day-badge", t.textContent = a > 99 ? "99+" : String(a), t.setAttribute("aria-label", e), o.appendChild(t);
-			} else o.title = R("tooltip.noAssetsDay", "No assets on this day");
+			} else o.title = L("tooltip.noAssetsDay", "No assets on this day");
 			i === c && o.classList.add("mjr-agenda-day--selected"), o.addEventListener("click", () => {
-				u_(t, String(t.value || "").trim() === i ? "" : i);
+				__(t, String(t.value || "").trim() === i ? "" : i);
 			}), l.appendChild(o);
 		}
 	}, v = async () => {
 		if (g) return;
-		let e = a_(p);
+		let e = f_(p);
 		if (!e) return;
 		h += 1;
-		let t = h, r = await d_({
+		let t = h, r = await v_({
 			state: n,
 			monthKey: e
 		});
 		g || t === h && (m = r.ok && r.days || {}, _());
 	};
 	return o.addEventListener("click", async () => {
-		p = s_(p, -1), await v();
+		p = m_(p, -1), await v();
 	}), c.addEventListener("click", async () => {
-		p = s_(p, 1), await v();
+		p = m_(p, 1), await v();
 	}), d.addEventListener("click", () => {
-		u_(t, "");
+		__(t, "");
 		try {
 			r?.();
 		} catch (e) {
@@ -17215,9 +17453,9 @@ function f_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = n
 	}), f.addEventListener("click", async () => {
 		await v();
 	}), t.addEventListener("change", () => {
-		let e = r_(t.value);
+		let e = u_(t.value);
 		if (e) {
-			let t = o_(e);
+			let t = p_(e);
 			(t.getFullYear() !== p.getFullYear() || t.getMonth() !== p.getMonth()) && (p = t);
 		}
 		_();
@@ -17235,14 +17473,14 @@ function f_({ container: e, hiddenInput: t, state: n, onRequestReloadGrid: r = n
 }
 //#endregion
 //#region ui/features/panel/controllers/filtersController.ts
-var p_ = (e) => {
+var b_ = (e) => {
 	let t = String(e ?? "").trim();
 	if (!t) return 0;
 	let n = t.replace(",", "."), r = Number(n);
 	return Number.isFinite(r) ? r : 0;
 };
-function m_({ state: e, kindSelect: t, wfCheckbox: n, workflowTypeSelect: r, workflowIdInput: i, workflowModelInput: a, workflowRunsOnSelect: o, ratingSelect: s, minSizeInput: c, maxSizeInput: l, resolutionPresetSelect: u, minWidthInput: d, minHeightInput: f, maxWidthInput: p, maxHeightInput: m, dateRangeSelect: h, dateExactInput: g, reloadGrid: _, reconcileSelection: v = null, onFiltersChanged: y = null, lifecycleSignal: b = null }) {
-	let { write: x } = fh(e, [
+function x_({ state: e, kindSelect: t, wfCheckbox: n, workflowTypeSelect: r, workflowIdInput: i, workflowModelInput: a, workflowRunsOnSelect: o, ratingSelect: s, minSizeInput: c, maxSizeInput: l, resolutionPresetSelect: u, minWidthInput: d, minHeightInput: f, maxWidthInput: p, maxHeightInput: m, dateRangeSelect: h, dateExactInput: g, reloadGrid: _, reconcileSelection: v = null, onFiltersChanged: y = null, lifecycleSignal: b = null }) {
+	let { write: x } = yh(e, [
 		"kindFilter",
 		"workflowOnly",
 		"minRating",
@@ -17354,7 +17592,7 @@ function m_({ state: e, kindSelect: t, wfCheckbox: n, workflowTypeSelect: r, wor
 		C();
 	}, b ? { signal: b } : void 0);
 	let E = () => {
-		let e = p_(c?.value || 0), t = p_(l?.value || 0), n = Number.isFinite(e) && e > 0 ? e : 0, r = Number.isFinite(t) && t > 0 ? t : 0;
+		let e = b_(c?.value || 0), t = b_(l?.value || 0), n = Number.isFinite(e) && e > 0 ? e : 0, r = Number.isFinite(t) && t > 0 ? t : 0;
 		r > 0 && n > 0 && r < n && (r = n, l && (l.value = String(r))), x("minSizeMB", n), x("maxSizeMB", r);
 		try {
 			y?.();
@@ -17365,7 +17603,7 @@ function m_({ state: e, kindSelect: t, wfCheckbox: n, workflowTypeSelect: r, wor
 	};
 	T(c, "change", E, b ? { signal: b } : void 0), T(l, "change", E, b ? { signal: b } : void 0);
 	let D = () => {
-		let e = p_(d?.value || 0), t = p_(f?.value || 0), n = p_(p?.value || 0), r = p_(m?.value || 0), i = Number.isFinite(e) && e > 0 ? Math.round(e) : 0, a = Number.isFinite(t) && t > 0 ? Math.round(t) : 0, o = Number.isFinite(n) && n > 0 ? Math.round(n) : 0, s = Number.isFinite(r) && r > 0 ? Math.round(r) : 0;
+		let e = b_(d?.value || 0), t = b_(f?.value || 0), n = b_(p?.value || 0), r = b_(m?.value || 0), i = Number.isFinite(e) && e > 0 ? Math.round(e) : 0, a = Number.isFinite(t) && t > 0 ? Math.round(t) : 0, o = Number.isFinite(n) && n > 0 ? Math.round(n) : 0, s = Number.isFinite(r) && r > 0 ? Math.round(r) : 0;
 		o > 0 && i > 0 && o < i && (o = i, p && (p.value = String(o))), s > 0 && a > 0 && s < a && (s = a, m && (m.value = String(s))), x("minWidth", i), x("minHeight", a), x("maxWidth", o), x("maxHeight", s);
 		try {
 			u && (u.value = {
@@ -17454,7 +17692,7 @@ function m_({ state: e, kindSelect: t, wfCheckbox: n, workflowTypeSelect: r, wor
 }
 //#endregion
 //#region ui/features/panel/panelFiltersInit.ts
-function h_({ state: e, hasVueHeaderSection: t, kindSelect: n, wfCheckbox: r, workflowTypeSelect: i, workflowIdInput: a, workflowModelInput: o, workflowRunsOnSelect: s, ratingSelect: c, minSizeInput: l, maxSizeInput: u, resolutionPresetSelect: d, minWidthInput: f, minHeightInput: p, maxWidthInput: m, maxHeightInput: h, dateRangeSelect: g, dateExactInput: _, agendaContainer: v, gridController: y, reconcileVisibleSelection: b, exitSimilarViewIfActive: x, notifyContextChanged: S, panelLifecycleAC: C, popovers: w = null, filterPopover: T = null }) {
+function S_({ state: e, hasVueHeaderSection: t, kindSelect: n, wfCheckbox: r, workflowTypeSelect: i, workflowIdInput: a, workflowModelInput: o, workflowRunsOnSelect: s, ratingSelect: c, minSizeInput: l, maxSizeInput: u, resolutionPresetSelect: d, minWidthInput: f, minHeightInput: p, maxWidthInput: m, maxHeightInput: h, dateRangeSelect: g, dateExactInput: _, agendaContainer: v, gridController: y, reconcileVisibleSelection: b, exitSimilarViewIfActive: x, notifyContextChanged: S, panelLifecycleAC: C, popovers: w = null, filterPopover: T = null }) {
 	let E = null;
 	try {
 		try {
@@ -17464,7 +17702,7 @@ function h_({ state: e, hasVueHeaderSection: t, kindSelect: n, wfCheckbox: r, wo
 		} catch (e) {
 			console.debug?.(e);
 		}
-		E = f_({
+		E = y_({
 			container: v,
 			hiddenInput: _,
 			state: e,
@@ -17505,7 +17743,7 @@ function h_({ state: e, hasVueHeaderSection: t, kindSelect: n, wfCheckbox: r, wo
 		D = () => {
 			e &&= (clearTimeout(e), null);
 		};
-	} else D = m_({
+	} else D = x_({
 		state: e,
 		kindSelect: n,
 		wfCheckbox: r,
@@ -17543,7 +17781,7 @@ function h_({ state: e, hasVueHeaderSection: t, kindSelect: n, wfCheckbox: r, wo
 }
 //#endregion
 //#region ui/features/panel/panelContextMenuExtraActions.ts
-function g_({ state: e, scopeController: t, browserNav: n, gridController: r, getDuplicatesAlert: i, refreshDuplicateAlerts: a }) {
+function C_({ state: e, scopeController: t, browserNav: n, gridController: r, getDuplicatesAlert: i, refreshDuplicateAlerts: a }) {
 	return {
 		clearSimilarScope: async () => {
 			try {
@@ -17571,38 +17809,38 @@ function g_({ state: e, scopeController: t, browserNav: n, gridController: r, ge
 			if (t && Array.isArray(t.assets) && t.assets.length >= 2) {
 				let e = t.assets[0] || {}, n = t.assets.slice(1).map((e) => Number(e?.id || 0)).filter((e) => e > 0);
 				if (n.length) {
-					if (await Gt(R("dialog.mergeDuplicateTags", "Exact duplicates detected ({count}). Merge tags into \"{target}\"?", {
+					if (await Gt(L("dialog.mergeDuplicateTags", "Exact duplicates detected ({count}). Merge tags into \"{target}\"?", {
 						count: t.assets.length,
 						target: e?.filename || e?.id
 					}))) {
-						let t = await me(Number(e?.id || 0), n);
-						t?.ok ? A(R("toast.tagsMerged", "Tags merged"), "success", 2200) : A(R("toast.tagMergeFailed", "Tag merge failed: {error}", { error: t?.error || "error" }), "warning", 3500);
+						let t = await he(Number(e?.id || 0), n);
+						t?.ok ? k(L("toast.tagsMerged", "Tags merged"), "success", 2200) : k(L("toast.tagMergeFailed", "Tag merge failed: {error}", { error: t?.error || "error" }), "warning", 3500);
 					}
-					if (await Gt(R("dialog.deleteExactDuplicates", "Delete {count} exact duplicate(s)?", { count: n.length }))) {
+					if (await Gt(L("dialog.deleteExactDuplicates", "Delete {count} exact duplicate(s)?", { count: n.length }))) {
 						let e = await T(n);
-						e?.ok ? (A(R("toast.duplicatesDeleted", "Duplicates deleted"), "success", 2200), await r.reloadGrid()) : A(R("toast.deleteFailed", "Delete failed: {error}", { error: e?.error || "error" }), "warning", 3500);
+						e?.ok ? (k(L("toast.duplicatesDeleted", "Duplicates deleted"), "success", 2200), await r.reloadGrid()) : k(L("toast.deleteFailed", "Delete failed: {error}", { error: e?.error || "error" }), "warning", 3500);
 					}
 					await a();
 					return;
 				}
 			}
-			if (!await Gt(R("dialog.startDuplicateAnalysis", "Start duplicate analysis in background?"))) return;
-			let n = await d(500);
-			n?.ok ? A(R("toast.dupAnalysisStarted", "Duplicate analysis started"), "info", 2200) : A(R("toast.analysisNotStarted", "Analysis not started: {error}", { error: n?.error || "error" }), "warning", 3500), await a();
+			if (!await Gt(L("dialog.startDuplicateAnalysis", "Start duplicate analysis in background?"))) return;
+			let n = await g(500);
+			n?.ok ? k(L("toast.dupAnalysisStarted", "Duplicate analysis started"), "info", 2200) : k(L("toast.analysisNotStarted", "Analysis not started: {error}", { error: n?.error || "error" }), "warning", 3500), await a();
 		}
 	};
 }
 //#endregion
 //#region ui/features/panel/panelRuntime.ts
-async function __(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
-	return v_(e, {
+async function w_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
+	return T_(e, {
 		useComfyThemeUI: t,
 		external: n
 	});
 }
-async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
-	zp("panelRender"), Hp("panelRender");
-	let r = typeof AbortController < "u" ? new AbortController() : null, { popovers: i, hostWrapper: a, hostWrapperPrevStyle: o } = Kg(e, { useComfyThemeUI: t }), s = dh();
+async function T_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
+	Kp("panelRender"), Yp("panelRender");
+	let r = typeof AbortController < "u" ? new AbortController() : null, { popovers: i, hostWrapper: a, hostWrapperPrevStyle: o } = $g(e, { useComfyThemeUI: t }), s = vh();
 	if (!s) throw Error("[Majoor] mountAssetsManagerPanelRuntime requires an active Pinia panel store");
 	for (let e of [
 		"statusSection",
@@ -17618,7 +17856,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		"gridContainer",
 		"sidebar"
 	]) if (!n?.[e]) throw Error(`[Majoor] mountAssetsManagerPanelRuntime now requires external.${e}`);
-	let c = fh(null, [
+	let c = yh(null, [
 		"searchQuery",
 		"scrollTop",
 		"scope",
@@ -17642,27 +17880,27 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	let l = (e, t = "") => c.read(e, s?.[e] ?? t), u = (e, t) => c.write(e, t), d = () => {
 		let e = l("selectedAssetIds", []);
 		return Array.isArray(e) ? e.map(String).filter(Boolean) : [];
-	}, p = () => String(l("activeAssetId", "") || "").trim(), m = () => !!l("sidebarOpen", !1), { header: h, tabButtons: g, customMenuBtn: _, filterBtn: v, sortBtn: y, collectionsBtn: b, pinnedFoldersBtn: x, messageBtn: S, settingsBtn: C, customPopover: w, customSelect: T, customAddBtn: E, customRemoveBtn: D, filterPopover: O, kindSelect: k, wfCheckbox: j, workflowTypeSelect: M, workflowIdInput: N, workflowModelInput: ee, workflowRunsOnSelect: te, ratingSelect: P, minSizeInput: F, maxSizeInput: re, resolutionPresetSelect: ie, minWidthInput: ae, minHeightInput: oe, maxWidthInput: se, maxHeightInput: ce, dateRangeSelect: le, dateExactInput: de, agendaContainer: fe, sortPopover: pe, sortMenu: me, collectionsPopover: he, pinnedFoldersPopover: _e, pinnedFoldersController: ve, pinnedFoldersMenu: be, messagePopoverTitle: xe, messagePopover: Se, messageTabBtn: Ce, messageTabBadge: we, historyTabBtn: Te, historyTabBadge: Ee, historyTabCount: De, historyPanel: Oe, shortcutsTabBtn: ke, messageList: Ae, shortcutsPanel: je, markReadBtn: Me, searchSection: Ne, searchInputEl: Pe, similarBtn: Fe, similarPopover: Ie, similarFindBtn: Le, similarDuplicatesBtn: Re, similarSameNodeBtn: ze, similarSameWorkflowBtn: Be, setSemanticEnabled: Ve, _headerDispose: He } = n.headerSection, Ue = !!n?.headerSection?.isVueHeader;
-	c.read("searchQuery", "") && (Pe.value = c.read("searchQuery", "")), Pe.addEventListener("input", (e) => {
+	}, p = () => String(l("activeAssetId", "") || "").trim(), m = () => !!l("sidebarOpen", !1), { header: h, tabButtons: g, customMenuBtn: _, filterBtn: v, sortBtn: y, collectionsBtn: b, pinnedFoldersBtn: x, messageBtn: S, settingsBtn: C, customPopover: w, customSelect: T, customAddBtn: E, customRemoveBtn: D, filterPopover: O, kindSelect: A, wfCheckbox: j, workflowTypeSelect: M, workflowIdInput: N, workflowModelInput: P, workflowRunsOnSelect: te, ratingSelect: ne, minSizeInput: F, maxSizeInput: re, resolutionPresetSelect: ie, minWidthInput: ae, minHeightInput: se, maxWidthInput: ce, maxHeightInput: le, dateRangeSelect: de, dateExactInput: fe, agendaContainer: pe, sortPopover: me, sortMenu: he, collectionsPopover: ge, pinnedFoldersPopover: ve, pinnedFoldersController: ye, pinnedFoldersMenu: xe, messagePopoverTitle: Se, messagePopover: Ce, messageTabBtn: we, messageTabBadge: Te, historyTabBtn: Ee, historyTabBadge: De, historyTabCount: Oe, historyPanel: ke, shortcutsTabBtn: Ae, messageList: je, shortcutsPanel: Me, markReadBtn: Ne, searchSection: Pe, searchInputEl: Fe, similarBtn: Ie, similarPopover: Le, similarFindBtn: Re, similarDuplicatesBtn: ze, similarSameNodeBtn: Be, similarSameWorkflowBtn: Ve, setSemanticEnabled: He, _headerDispose: Ue } = n.headerSection, We = !!n?.headerSection?.isVueHeader;
+	c.read("searchQuery", "") && (Fe.value = c.read("searchQuery", "")), Fe.addEventListener("input", (e) => {
 		c.write("searchQuery", e.target.value);
 	}, { signal: r?.signal });
-	let We = n.summaryBar, Ge = n.updateSummaryBar, Ke = n.folderBreadcrumb, qe = n.folderBreadcrumbController || null, Je = n.statusSection, Ye = n.statusDot, Xe = n.statusText, Ze = n.capabilitiesSection, Qe = n.browseSection, $e = n.gridWrapper, et = n.sidebar;
+	let Ge = n.summaryBar, Ke = n.updateSummaryBar, qe = n.folderBreadcrumb, Je = n.folderBreadcrumbController || null, Ye = n.statusSection, Xe = n.statusDot, Ze = n.statusText, Qe = n.capabilitiesSection, $e = n.browseSection, et = n.gridWrapper, tt = n.sidebar;
 	mn();
-	let tt = document.createElement("div");
-	tt.classList.add("mjr-am-content");
-	let L = null, nt = null;
+	let nt = document.createElement("div");
+	nt.classList.add("mjr-am-content");
+	let I = null, rt = null;
 	e.tabIndex = -1;
-	let z = null, rt = 0, it = () => {
+	let R = null, it = 0, at = () => {
 		try {
-			rt = Date.now();
+			it = Date.now();
 		} catch {
-			rt = 0;
+			it = 0;
 		}
-	}, at = typeof n?.bindGridHostState == "function" && typeof n?.restoreGridUiState == "function", ot = !at;
-	$e.addEventListener("scroll", () => {
-		it(), ot && (z && clearTimeout(z), z = setTimeout(() => {
+	}, ot = typeof n?.bindGridHostState == "function" && typeof n?.restoreGridUiState == "function", st = !ot;
+	et.addEventListener("scroll", () => {
+		at(), st && (R && clearTimeout(R), R = setTimeout(() => {
 			try {
-				c.write("scrollTop", $e.scrollTop);
+				c.write("scrollTop", et.scrollTop);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -17670,17 +17908,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	}, {
 		passive: !0,
 		signal: r?.signal
-	}), L = n.gridContainer, L.parentElement !== $e && $e.appendChild(L), er(L);
+	}), I = n.gridContainer, I.parentElement !== et && et.appendChild(I), er(I);
 	try {
-		L.dataset.mjrScope = String(l("scope", s.scope || "output") || "output");
+		I.dataset.mjrScope = String(l("scope", s.scope || "output") || "output");
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let st = [], ct = (e) => {
-		typeof e == "function" && st.push(e);
+	let ct = [], lt = (e) => {
+		typeof e == "function" && ct.push(e);
 	};
-	L._mjrSummaryBarDispose = () => {
-		for (let e of st.splice(0)) try {
+	I._mjrSummaryBarDispose = () => {
+		for (let e of ct.splice(0)) try {
 			e();
 		} catch (e) {
 			console.debug?.(e);
@@ -17689,17 +17927,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	try {
 		let e = () => {
 			try {
-				Ge?.({
+				Ke?.({
 					state: s,
-					gridContainer: L
+					gridContainer: I
 				});
 			} catch (e) {
 				console.debug?.(e);
 			}
 		};
-		L.addEventListener("mjr:grid-stats", e, { signal: r?.signal }), ct(() => {
+		I.addEventListener("mjr:grid-stats", e, { signal: r?.signal }), lt(() => {
 			try {
-				L.removeEventListener("mjr:grid-stats", e);
+				I.removeEventListener("mjr:grid-stats", e);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -17709,54 +17947,54 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	}
 	let ut = n.loadAssets ?? Ti, dt = n.loadAssetsFromList ?? Ei, ft = n.prepareGridForScopeSwitch ?? Di, pt = n.disposeGrid ?? Oi, mt = n.refreshGrid ?? ki, ht = n.captureAnchor ?? Ai, gt = n.restoreAnchor ?? ji, vt = n.hydrateGridFromSnapshot ?? wi;
 	if (typeof n?.onGridContainerReady == "function") try {
-		n.onGridContainerReady(L, { getState: () => s });
+		n.onGridContainerReady(I, { getState: () => s });
 	} catch (e) {
 		console.debug?.(e);
 	}
-	else e._mjrGridContextMenuUnbind = Wa({
-		gridContainer: L,
+	else e._mjrGridContextMenuUnbind = Ga({
+		gridContainer: I,
 		getState: () => s
 	});
-	let yt = R("search.findSimilar", "Find Similar"), bt = R("search.similarDisabled", "AI features are disabled in settings"), { applyWatcherForScope: xt, isAiEnabled: St } = qg({
+	let yt = L("search.findSimilar", "Find Similar"), bt = L("search.similarDisabled", "AI features are disabled in settings"), { applyWatcherForScope: xt, isAiEnabled: St } = e_({
 		container: e,
 		state: s,
-		sidebar: et,
-		browseSection: Qe,
-		gridWrapper: $e,
-		similarBtn: Fe,
-		setSemanticEnabled: Ve,
+		sidebar: tt,
+		browseSection: $e,
+		gridWrapper: et,
+		similarBtn: Ie,
+		setSemanticEnabled: He,
 		similarEnabledTitle: yt,
 		similarDisabledTitle: bt,
 		refreshGridFn: mt,
 		isSidebarOpen: m,
 		readActiveAssetId: p,
-		getSidebarController: () => nt,
+		getSidebarController: () => rt,
 		panelLifecycleAC: r
 	});
-	tt.appendChild(Je), tt.appendChild(Ne), tt.appendChild(Ke), tt.appendChild(We), tt.appendChild(Qe), e.appendChild(h);
+	nt.appendChild(Ye), nt.appendChild(Pe), nt.appendChild(qe), nt.appendChild(Ge), nt.appendChild($e), e.appendChild(h);
 	try {
 		e._mjrVersionUpdateCleanup?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
-	e._mjrVersionUpdateCleanup = He || h._mjrVersionUpdateCleanup, e.appendChild(tt);
-	let Ct = () => pg(Pe), wt = mg({
-		gridContainer: L,
+	e._mjrVersionUpdateCleanup = Ue || h._mjrVersionUpdateCleanup, e.appendChild(nt);
+	let Ct = () => bg(Fe), wt = xg({
+		gridContainer: I,
 		loadAssets: ut,
 		loadAssetsFromList: dt,
-		getCollectionAssets: ye,
+		getCollectionAssets: be,
 		disposeGrid: pt,
 		getQuery: Ct,
-		searchInputEl: Pe,
+		searchInputEl: Fe,
 		state: s
 	}), Tt = null, Dt = null, Ot = null, kt = null, At = null, jt = null, Mt = null, Nt = null, Pt = null, Ft = !1, It = (e) => !!e && String(e?.style?.display || "").toLowerCase() === "block", Lt = () => {
 		let e = [
 			[v, O],
-			[y, pe],
-			[b, he],
-			[x, _e],
-			[S, Se],
-			[Fe, Ie]
+			[y, me],
+			[b, ge],
+			[x, ve],
+			[S, Ce],
+			[Ie, Le]
 		];
 		for (let [t, n] of e) try {
 			t?.classList?.toggle?.("mjr-popover-open", It(n)), t?.setAttribute?.("aria-expanded", It(n) ? "true" : "false");
@@ -17781,26 +18019,26 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		}
 		Lt();
 	};
-	at || (Nt = Hg({
-		gridContainer: L,
+	ot || (Nt = Yg({
+		gridContainer: I,
 		readSelectedAssetIds: d,
 		readActiveAssetId: () => p(),
 		writeSelectedAssetIds: (e) => u("selectedAssetIds", e),
 		writeActiveAssetId: (e) => u("activeAssetId", e),
 		onSelectionChanged: () => {
-			it(), Rt();
+			at(), Rt();
 		},
 		lifecycleSignal: r?.signal || null
-	})), jt = hg({
+	})), jt = Sg({
 		state: s,
-		gridContainer: L,
-		folderBreadcrumb: Ke,
-		folderBreadcrumbController: qe,
+		gridContainer: I,
+		folderBreadcrumb: qe,
+		folderBreadcrumbController: Je,
 		customSelect: T,
 		reloadGrid: () => wt.reloadGrid(),
 		clearSelection: () => {
 			try {
-				L?._mjrSetSelection?.([], "");
+				I?._mjrSetSelection?.([], "");
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -17844,8 +18082,8 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			console.debug?.(e);
 		}
 	}, Bt = null;
-	Jg({
-		gridContainer: L,
+	t_({
+		gridContainer: I,
 		panelLifecycleAC: r,
 		requestQueuedReload: () => {
 			try {
@@ -17864,23 +18102,23 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			}, 120);
 		},
 		notifyContextChanged: Rt,
-		markUserInteraction: it,
+		markUserInteraction: at,
 		writePanelValue: u,
 		popovers: i,
-		collectionsPopover: he,
+		collectionsPopover: ge,
 		gridController: wt,
-		registerSummaryDispose: ct
+		registerSummaryDispose: lt
 	});
-	let Vt = bg({
+	let Vt = Dg({
 		state: s,
 		customSelect: T,
 		customRemoveBtn: D,
 		comfyConfirm: Gt,
 		comfyPrompt: Et,
-		comfyToast: A,
-		get: I,
+		comfyToast: k,
+		get: oe,
 		post: ue,
-		ENDPOINTS: lt,
+		ENDPOINTS: B,
 		reloadGrid: wt.reloadGrid,
 		onRootChanged: async () => {
 			try {
@@ -17913,17 +18151,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	}
 	let Wt = () => {
 		try {
-			let e = L?._mjrGetAssets, t = L?._mjrSetSelection;
+			let e = I?._mjrGetAssets, t = I?._mjrSetSelection;
 			if (typeof e != "function" || typeof t != "function") return;
 			let n = (Array.isArray(e()) ? e() : []).map((e) => String(e?.id ?? "").trim()).filter(Boolean), r = d(), i = r.filter((e) => n.includes(e)), a = r.length - i.length;
 			if (a <= 0) return;
 			let o = p();
-			t(i, i.includes(o) ? o : i[0] || ""), A(R("toast.selectionPruned", "{count} items deselected - not visible in current view", { count: a }), "info", 2600, { noHistory: !0 });
+			t(i, i.includes(o) ? o : i[0] || ""), k(L("toast.selectionPruned", "{count} items deselected - not visible in current view", { count: a }), "info", 2600, { noHistory: !0 });
 		} catch (e) {
 			console.debug?.(e);
 		}
 	};
-	Tt = gg({
+	Tt = Cg({
 		state: s,
 		tabButtons: g,
 		customMenuBtn: _,
@@ -17934,7 +18172,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		reconcileSelection: Wt,
 		onChanged: () => {
 			try {
-				L && (L.dataset.mjrScope = String(l("scope", s.scope || "output") || "output"));
+				I && (I.dataset.mjrScope = String(l("scope", s.scope || "output") || "output"));
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -17954,17 +18192,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		},
 		onBeforeReload: async () => {
 			try {
-				L.dataset.mjrScope = l("scope", "output"), L.dataset.mjrCustomRootId = l("customRootId", "") || "", L.dataset.mjrSubfolder = l("currentFolderRelativePath", "") || "", L.dataset.mjrCollectionId = l("collectionId", "") || "", L.dataset.mjrViewScope = l("viewScope", "") || "";
+				I.dataset.mjrScope = l("scope", "output"), I.dataset.mjrCustomRootId = l("customRootId", "") || "", I.dataset.mjrSubfolder = l("currentFolderRelativePath", "") || "", I.dataset.mjrCollectionId = l("collectionId", "") || "", I.dataset.mjrViewScope = l("viewScope", "") || "";
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				ft(L);
+				ft(I);
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				await Om(Ye, Xe, Ze, {
+				await Fm(Xe, Ze, Qe, {
 					scope: l("scope", s.scope || "output"),
 					customRootId: l("customRootId", s.customRootId || "")
 				}, null, { signal: r?.signal || null });
@@ -17983,40 +18221,40 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	};
 	Object.values(g).forEach((e) => {
 		e.addEventListener("click", () => Tt.setScope(e.dataset.scope), { signal: r?.signal });
-	}), ug({
+	}), _g({
 		messageBtn: S,
-		messagePopover: Se,
-		title: xe,
-		messageList: Ae,
-		historyTabBtn: Te,
-		historyTabBadge: Ee,
-		historyTabCount: De,
-		historyPanel: Oe,
-		shortcutsPanel: je,
-		messageTabBtn: Ce,
-		messageTabBadge: we,
-		shortcutsTabBtn: ke,
-		markReadBtn: Me,
+		messagePopover: Ce,
+		title: Se,
+		messageList: je,
+		historyTabBtn: Ee,
+		historyTabBadge: De,
+		historyTabCount: Oe,
+		historyPanel: ke,
+		shortcutsPanel: Me,
+		messageTabBtn: we,
+		messageTabBadge: Te,
+		shortcutsTabBtn: Ae,
+		markReadBtn: Ne,
 		popovers: i,
 		signal: r?.signal,
 		onBeforeToggle: () => {
-			i.close(w), i.close(O), i.close(pe), i.close(he), i.close(_e);
+			i.close(w), i.close(O), i.close(me), i.close(ge), i.close(ve);
 		}
 	}), i.setDismissWhitelist([
 		w,
 		O,
-		pe,
-		he,
-		_e,
-		Se,
-		Ie,
+		me,
+		ge,
+		ve,
+		Ce,
+		Le,
 		_,
 		v,
 		y,
 		b,
 		x,
 		S,
-		Fe
+		Ie
 	]), i.setOnVisibilityChanged?.(() => Lt());
 	try {
 		window.addEventListener(Kn, (e) => {
@@ -18026,33 +18264,33 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		console.debug?.(e);
 	}
 	Lt(), _.addEventListener("click", (e) => {
-		e.stopPropagation(), i.close(O), i.close(pe), i.close(he), i.close(Se), i.close(Ie), i.toggle(w, _);
+		e.stopPropagation(), i.close(O), i.close(me), i.close(ge), i.close(Ce), i.close(Le), i.toggle(w, _);
 	}, { signal: r?.signal }), v.addEventListener("click", (e) => {
-		e.stopPropagation(), i.close(w), i.close(pe), i.close(he), i.close(Se), i.close(Ie), i.toggle(O, v);
+		e.stopPropagation(), i.close(w), i.close(me), i.close(ge), i.close(Ce), i.close(Le), i.toggle(O, v);
 	}, { signal: r?.signal }), b.addEventListener("click", (e) => {
-		e.stopPropagation(), i.close(w), i.close(O), i.close(pe), i.close(Se), i.close(Ie), i.toggle(he, b);
+		e.stopPropagation(), i.close(w), i.close(O), i.close(me), i.close(Ce), i.close(Le), i.toggle(ge, b);
 	}, { signal: r?.signal });
-	let qt = Ue ? null : xg({
+	let qt = We ? null : Og({
 		state: s,
 		sortBtn: y,
-		sortMenu: me,
-		sortPopover: pe,
+		sortMenu: he,
+		sortPopover: me,
 		popovers: i,
 		reloadGrid: wt.reloadGrid,
 		onChanged: () => Rt()
 	});
 	qt ? qt.bind({ onBeforeToggle: () => {
-		i.close(w), i.close(O), i.close(he), i.close(Se), i.close(Ie);
+		i.close(w), i.close(O), i.close(ge), i.close(Ce), i.close(Le);
 	} }) : y.addEventListener("click", (e) => {
-		e.stopPropagation(), i.close(w), i.close(O), i.close(he), i.close(Se), i.close(Ie), i.toggle(pe, y);
-	}, { signal: r?.signal }), e_({
-		similarBtn: Fe,
-		similarPopover: Ie,
-		similarFindBtn: Le,
-		similarDuplicatesBtn: Re,
-		similarSameNodeBtn: ze,
-		similarSameWorkflowBtn: Be,
-		gridContainer: L,
+		e.stopPropagation(), i.close(w), i.close(O), i.close(ge), i.close(Ce), i.close(Le), i.toggle(me, y);
+	}, { signal: r?.signal }), s_({
+		similarBtn: Ie,
+		similarPopover: Le,
+		similarFindBtn: Re,
+		similarDuplicatesBtn: ze,
+		similarSameNodeBtn: Be,
+		similarSameWorkflowBtn: Ve,
+		gridContainer: I,
 		state: s,
 		panelLifecycleAC: r,
 		isAiEnabled: St,
@@ -18063,26 +18301,26 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		writePanelValue: u,
 		scopeController: Tt,
 		closePopovers: () => {
-			i.close(w), i.close(O), i.close(pe), i.close(he), i.close(Se), i.close(Ie);
+			i.close(w), i.close(O), i.close(me), i.close(ge), i.close(Ce), i.close(Le);
 		},
 		closePeerPopovers: () => {
-			i.close(w), i.close(O), i.close(pe), i.close(he), i.close(Se), i.close(_e);
+			i.close(w), i.close(O), i.close(me), i.close(ge), i.close(Ce), i.close(ve);
 		},
 		popovers: i,
 		workflowIdInput: N,
 		reloadGrid: () => wt.reloadGrid(),
 		getDuplicatesAlert: () => Ot
-	}), t_({
+	}), c_({
 		pinnedFoldersBtn: x,
-		pinnedFoldersController: ve,
-		pinnedFoldersMenu: be,
-		pinnedFoldersPopover: _e,
+		pinnedFoldersController: ye,
+		pinnedFoldersMenu: xe,
+		pinnedFoldersPopover: ve,
 		popovers: i,
 		closeOtherPopovers: () => {
-			i.close(w), i.close(O), i.close(pe), i.close(he), i.close(Se), i.close(Ie);
+			i.close(w), i.close(O), i.close(me), i.close(ge), i.close(Ce), i.close(Le);
 		},
 		state: s,
-		gridContainer: L,
+		gridContainer: I,
 		customSelect: T,
 		scopeController: Tt,
 		customRootsController: Vt,
@@ -18092,26 +18330,26 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		notifyContextChanged: Rt,
 		panelLifecycleAC: r
 	});
-	let { agendaCalendar: Jt, disposeFilters: Yt } = h_({
+	let { agendaCalendar: Jt, disposeFilters: Yt } = S_({
 		state: s,
-		hasVueHeaderSection: Ue,
-		kindSelect: k,
+		hasVueHeaderSection: We,
+		kindSelect: A,
 		wfCheckbox: j,
 		workflowTypeSelect: M,
 		workflowIdInput: N,
-		workflowModelInput: ee,
+		workflowModelInput: P,
 		workflowRunsOnSelect: te,
-		ratingSelect: P,
+		ratingSelect: ne,
 		minSizeInput: F,
 		maxSizeInput: re,
 		resolutionPresetSelect: ie,
 		minWidthInput: ae,
-		minHeightInput: oe,
-		maxWidthInput: se,
-		maxHeightInput: ce,
-		dateRangeSelect: le,
-		dateExactInput: de,
-		agendaContainer: fe,
+		minHeightInput: se,
+		maxWidthInput: ce,
+		maxHeightInput: le,
+		dateRangeSelect: de,
+		dateExactInput: fe,
+		agendaContainer: pe,
 		gridController: wt,
 		reconcileVisibleSelection: Wt,
 		exitSimilarViewIfActive: Kt,
@@ -18119,7 +18357,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		panelLifecycleAC: r,
 		popovers: i,
 		filterPopover: O
-	}), Xt = g_({
+	}), Xt = C_({
 		state: s,
 		scopeController: Tt,
 		browserNav: jt,
@@ -18128,32 +18366,32 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		refreshDuplicateAlerts: zt
 	});
 	try {
-		Dt = yg({
+		Dt = Eg({
 			state: s,
-			gridContainer: L,
+			gridContainer: I,
 			filterBtn: v,
 			sortBtn: y,
 			collectionsBtn: b,
-			searchInputEl: Pe,
-			kindSelect: k,
+			searchInputEl: Fe,
+			kindSelect: A,
 			wfCheckbox: j,
 			workflowTypeSelect: M,
 			workflowIdInput: N,
-			workflowModelInput: ee,
+			workflowModelInput: P,
 			workflowRunsOnSelect: te,
-			ratingSelect: P,
+			ratingSelect: ne,
 			minSizeInput: F,
 			maxSizeInput: re,
 			minWidthInput: ae,
-			minHeightInput: oe,
-			maxWidthInput: se,
-			maxHeightInput: ce,
+			minHeightInput: se,
+			maxWidthInput: ce,
+			maxHeightInput: le,
 			resolutionPresetSelect: ie,
-			dateRangeSelect: le,
-			dateExactInput: de,
+			dateRangeSelect: de,
+			dateExactInput: fe,
 			scopeController: Tt,
 			sortController: qt,
-			updateSummaryBar: Ge,
+			updateSummaryBar: Ke,
 			reloadGrid: () => wt.reloadGrid(),
 			getExtraContext: () => ({ duplicatesAlert: Ot }),
 			extraActions: Xt
@@ -18162,13 +18400,13 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		console.debug?.(e);
 	}
 	try {
-		if (Rt(), at) ct(n.bindGridHostState({
+		if (Rt(), ot) lt(n.bindGridHostState({
 			onContextChanged: Rt,
-			markUserInteraction: it
+			markUserInteraction: at
 		}));
 		else {
 			let e = () => Rt();
-			L.addEventListener("mjr:grid-stats", e, { signal: r?.signal }), window.addEventListener?.("mjr-settings-changed", e, { signal: r?.signal });
+			I.addEventListener("mjr:grid-stats", e, { signal: r?.signal }), window.addEventListener?.("mjr-settings-changed", e, { signal: r?.signal });
 			let t = null, n = null, i = () => {
 				n && clearTimeout(n), n = setTimeout(() => {
 					n = null, t && cancelAnimationFrame(t), t = requestAnimationFrame(() => {
@@ -18176,9 +18414,9 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 					});
 				}, 250);
 			}, a = new MutationObserver(() => i());
-			a.observe(L, { childList: !0 }), L._mjrSummaryBarObserver = a, ct(() => {
+			a.observe(I, { childList: !0 }), I._mjrSummaryBarObserver = a, lt(() => {
 				try {
-					L.removeEventListener("mjr:grid-stats", e);
+					I.removeEventListener("mjr:grid-stats", e);
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -18202,22 +18440,22 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	nt = zg({
-		gridContainer: L,
-		sidebar: et,
+	rt = Kg({
+		gridContainer: I,
+		sidebar: tt,
 		createRatingBadge: _t,
 		createTagsBadge: Ut,
-		showAssetInSidebar: Qm,
-		closeSidebar: $m,
+		showAssetInSidebar: ah,
+		closeSidebar: oh,
 		state: s
 	});
 	let Zt = {
 		gridController: wt,
 		captureAnchor: ht,
 		restoreAnchor: gt,
-		restoreGridUiState: at ? (e) => n.restoreGridUiState(e, { onRestoreSidebar: () => {
+		restoreGridUiState: ot ? (e) => n.restoreGridUiState(e, { onRestoreSidebar: () => {
 			try {
-				nt?.toggleDetails?.();
+				rt?.toggleDetails?.();
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -18229,45 +18467,45 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		readActiveAssetId: p,
 		isSidebarOpen: m,
 		toggleSidebarDetails: () => {
-			nt?.toggleDetails?.();
+			rt?.toggleDetails?.();
 		},
 		getQuery: Ct,
 		getScope: () => c.read("scope", s.scope),
 		loadAssets: ut,
 		lifecycleSignal: r?.signal || null
 	};
-	Pt = typeof n?.initAssetsQueryController == "function" ? n.initAssetsQueryController(Zt) : Gg({
-		gridContainer: L,
-		gridWrapper: $e,
+	Pt = typeof n?.initAssetsQueryController == "function" ? n.initAssetsQueryController(Zt) : Qg({
+		gridContainer: I,
+		gridWrapper: et,
 		...Zt
 	});
-	let Qt = Bg({
+	let Qt = qg({
 		onTriggerScan: (e) => {
-			bm(Ye, Xe, Ze, e || {});
+			Dm(Xe, Ze, Qe, e || {});
 		},
 		onToggleDetails: () => {
-			nt?.toggleDetails?.();
+			rt?.toggleDetails?.();
 		},
 		onToggleFloatingViewer: () => {
 			try {
-				window.dispatchEvent(new Event(B.MFV_TOGGLE));
+				window.dispatchEvent(new Event(z.MFV_TOGGLE));
 			} catch (e) {
 				console.debug?.(e);
 			}
 		},
 		onFocusSearch: () => {
 			try {
-				Pe?.focus?.();
-				let e = Pe?.value?.length || 0;
-				Pe?.setSelectionRange?.(e, e);
+				Fe?.focus?.();
+				let e = Fe?.value?.length || 0;
+				Fe?.setSelectionRange?.(e, e);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		},
 		onClearSearch: () => {
 			try {
-				if (!Pe) return;
-				u("searchQuery", ""), Pe.value = "", Pe.dispatchEvent?.(new Event("input", { bubbles: !0 }));
+				if (!Fe) return;
+				u("searchQuery", ""), Fe.value = "", Fe.dispatchEvent?.(new Event("input", { bubbles: !0 }));
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -18276,8 +18514,8 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			scope: c.read("scope", s.scope),
 			customRootId: c.read("customRootId", s.customRootId)
 		})
-	}), $t = Za({
-		gridContainer: L,
+	}), $t = Qa({
+		gridContainer: I,
 		createRatingBadge: _t
 	}), en = null;
 	if (e._eventCleanup) try {
@@ -18285,9 +18523,9 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	Qt.bind(tt), $t.bind(), ne("grid");
+	Qt.bind(nt), $t.bind(), ee("grid");
 	try {
-		e._mjrHotkeys = Qt, e._mjrRatingHotkeys = $t, e._mjrSidebarController = nt;
+		e._mjrHotkeys = Qt, e._mjrRatingHotkeys = $t, e._mjrSidebarController = rt;
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -18298,7 +18536,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			console.debug?.(e);
 		}
 		try {
-			Je?._mjrStatusPollDispose?.();
+			Ye?._mjrStatusPollDispose?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -18309,7 +18547,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		}
 		e._mjrVersionUpdateCleanup = null;
 		try {
-			z && clearTimeout(z), z = null;
+			R && clearTimeout(R), R = null;
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -18323,7 +18561,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		ge().scope === "grid" && ne(null);
+		_e().scope === "grid" && ee(null);
 		try {
 			Jt?.dispose?.();
 		} catch (e) {
@@ -18341,12 +18579,12 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		}
 		en = null;
 		try {
-			et?.dispose?.();
+			tt?.dispose?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			nt?.dispose?.();
+			rt?.dispose?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -18373,17 +18611,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 		}
 		Nt = null;
 		try {
-			L?._mjrSummaryBarDispose?.();
+			I?._mjrSummaryBarDispose?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			L?._mjrSummaryBarObserver?.disconnect?.();
+			I?._mjrSummaryBarObserver?.disconnect?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
 		try {
-			L?._mjrGridContextMenuUnbind?.();
+			I?._mjrGridContextMenuUnbind?.();
 		} catch (e) {
 			console.debug?.(e);
 		}
@@ -18398,11 +18636,11 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			console.debug?.(e);
 		}
 		try {
-			L && pt(L);
+			I && pt(I);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		Xn(L), L = null;
+		Xn(I), I = null;
 		try {
 			i.dispose();
 		} catch (e) {
@@ -18422,17 +18660,17 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	let tn = async () => {
 		await Pt?.queuedReload?.();
 	};
-	Rm(Ye, Xe, Je, Ze, Pt?.createCountersUpdateHandler?.({
+	Gm(Xe, Ze, Ye, Qe, Pt?.createCountersUpdateHandler?.({
 		state: s,
-		getStableQuery: () => String(L?.dataset?.mjrQuery || "*").trim() || "*",
-		getRecentUserInteractionAt: () => Number(rt || 0)
+		getStableQuery: () => String(I?.dataset?.mjrQuery || "*").trim() || "*",
+		getRecentUserInteractionAt: () => Number(it || 0)
 	}) ?? (async () => {
 		await tn();
 	}), () => ({
 		scope: c.read("scope", s.scope),
 		customRootId: c.read("customRootId", s.customRootId)
 	})), Tt.setActiveTabStyles(), jt?.renderBreadcrumb?.(), Vt.refreshCustomRoots().catch(() => {}), en = Pt?.bindSearchInput?.({
-		searchInputEl: Pe,
+		searchInputEl: Fe,
 		lifecycleSignal: r?.signal || null,
 		debounceMs: 120,
 		onQueryChanged: () => {
@@ -18442,7 +18680,7 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 			Kt({ reload: !1 }), Rt();
 		},
 		startSearchTimer: () => {
-			zp("searchQuery");
+			Kp("searchQuery");
 		},
 		reloadGrid: () => {
 			wt.reloadGrid();
@@ -18450,9 +18688,9 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	});
 	let nn = !1;
 	try {
-		nn = await vt(L, {
+		nn = await vt(I, {
 			scope: l("scope", s.scope || "output") || "output",
-			query: String(pg(c.read("searchQuery", s.searchQuery || "*") || "*") || "*"),
+			query: String(bg(c.read("searchQuery", s.searchQuery || "*") || "*") || "*"),
 			customRootId: l("customRootId", s.customRootId || "") || "",
 			subfolder: l("currentFolderRelativePath", s.currentFolderRelativePath || "") || "",
 			collectionId: l("collectionId", s.collectionId || "") || "",
@@ -18480,11 +18718,11 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	}
 	let rn = !1;
 	try {
-		rn = !!L?.querySelector?.(".mjr-asset-card");
+		rn = !!I?.querySelector?.(".mjr-asset-card");
 	} catch (e) {
 		console.debug?.(e);
 	}
-	let an = Hf(), on = !an && (nn || rn) ? Promise.resolve({
+	let an = Yf(), on = !an && (nn || rn) ? Promise.resolve({
 		ok: !0,
 		hydrated: !!nn,
 		cached: !!rn
@@ -18523,14 +18761,14 @@ async function v_(e, { useComfyThemeUI: t = !0, external: n = {} } = {}) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return Gp(Bp("panelRender", "gridRender") ?? 0), { gridContainer: L };
+	return Qp(qp("panelRender", "gridRender") ?? 0), { gridContainer: I };
 }
 //#endregion
 //#region ui/vue/components/status/StatusSection.vue
-var y_ = {
+var E_ = {
 	__name: "StatusSection",
 	setup(e, { expose: t }) {
-		let n = ym({ getScanContext: null }), r = n.querySelector("#mjr-status-dot"), i = n.querySelector("#mjr-status-text"), a = n.querySelector("#mjr-status-capabilities");
+		let n = Em({ getScanContext: null }), r = n.querySelector("#mjr-status-dot"), i = n.querySelector("#mjr-status-text"), a = n.querySelector("#mjr-status-capabilities");
 		return Or(() => {
 			try {
 				n?._mjrStatusPollDispose?.();
@@ -18542,26 +18780,26 @@ var y_ = {
 			capabilitiesSection: a
 		}), (e, t) => null;
 	}
-}, b_ = Sr({
+}, D_ = Sr({
 	open: !1,
 	initial: null,
 	resolve: null
 });
-function x_(e = {}) {
-	return b_.open = !0, b_.initial = e || {}, new Promise((e) => {
-		b_.resolve = e;
+function O_(e = {}) {
+	return D_.open = !0, D_.initial = e || {}, new Promise((e) => {
+		D_.resolve = e;
 	});
 }
-function S_(e = null) {
-	let t = b_.resolve;
-	b_.open = !1, b_.initial = null, b_.resolve = null, t && t(e);
+function k_(e = null) {
+	let t = D_.resolve;
+	D_.open = !1, D_.initial = null, D_.resolve = null, t && t(e);
 }
 //#endregion
 //#region ui/vue/components/panel/SimilarSearchPopover.vue
-var C_ = {
+var A_ = {
 	class: "mjr-popover mjr-similar-popover",
 	style: { display: "none" }
-}, w_ = { class: "mjr-menu mjr-similar-menu" }, T_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, E_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, D_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, O_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, k_ = {
+}, j_ = { class: "mjr-menu mjr-similar-menu" }, M_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, N_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, P_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, F_ = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, I_ = {
 	__name: "SimilarSearchPopover",
 	setup(e, { expose: t }) {
 		let n = Z(null), r = Z(null), i = Z(null), a = Z(null), o = (e) => e?.$el || e || null;
@@ -18580,7 +18818,7 @@ var C_ = {
 			}
 		}), (e, t) => {
 			let o = gr("MButton");
-			return V(), Y("div", C_, [U("div", w_, [
+			return V(), Y("div", A_, [U("div", j_, [
 				J(o, {
 					ref_key: "findSimilarBtnRef",
 					ref: n,
@@ -18588,12 +18826,12 @@ var C_ = {
 					class: "mjr-menu-item",
 					severity: "secondary",
 					text: "",
-					title: K(R)("search.findSimilarWarning", "Find similar assets. This may be heavy on very large libraries.")
+					title: K(L)("search.findSimilarWarning", "Find similar assets. This may be heavy on very large libraries.")
 				}, {
-					default: Q(() => [U("span", T_, [t[0] ||= U("i", {
+					default: Q(() => [U("span", M_, [t[0] ||= U("i", {
 						class: "pi pi-sparkles",
 						"aria-hidden": "true"
-					}, null, -1), U("span", null, q(K(R)("search.findSimilar", "Find Similar")), 1)])]),
+					}, null, -1), U("span", null, q(K(L)("search.findSimilar", "Find Similar")), 1)])]),
 					_: 1
 				}, 8, ["title"]),
 				J(o, {
@@ -18604,10 +18842,10 @@ var C_ = {
 					severity: "secondary",
 					text: ""
 				}, {
-					default: Q(() => [U("span", E_, [t[1] ||= U("i", {
+					default: Q(() => [U("span", N_, [t[1] ||= U("i", {
 						class: "pi pi-clone",
 						"aria-hidden": "true"
-					}, null, -1), U("span", null, q(K(R)("search.findDuplicates", "Find Duplicate")), 1)])]),
+					}, null, -1), U("span", null, q(K(L)("search.findDuplicates", "Find Duplicate")), 1)])]),
 					_: 1
 				}, 512),
 				t[4] ||= U("div", { class: "mjr-menu-divider" }, null, -1),
@@ -18619,10 +18857,10 @@ var C_ = {
 					severity: "secondary",
 					text: ""
 				}, {
-					default: Q(() => [U("span", D_, [t[2] ||= U("i", {
+					default: Q(() => [U("span", P_, [t[2] ||= U("i", {
 						class: "pi pi-share-alt",
 						"aria-hidden": "true"
-					}, null, -1), U("span", null, q(K(R)("search.generatedWithSameSaveNode", "Generated with same save node")), 1)])]),
+					}, null, -1), U("span", null, q(K(L)("search.generatedWithSameSaveNode", "Generated with same save node")), 1)])]),
 					_: 1
 				}, 512),
 				J(o, {
@@ -18633,20 +18871,20 @@ var C_ = {
 					severity: "secondary",
 					text: ""
 				}, {
-					default: Q(() => [U("span", O_, [t[3] ||= U("i", {
+					default: Q(() => [U("span", F_, [t[3] ||= U("i", {
 						class: "pi pi-sitemap",
 						"aria-hidden": "true"
-					}, null, -1), U("span", null, q(K(R)("search.generatedFromSameWorkflow", "Generated from same workflow")), 1)])]),
+					}, null, -1), U("span", null, q(K(L)("search.generatedFromSameWorkflow", "Generated from same workflow")), 1)])]),
 					_: 1
 				}, 512)
 			])]);
 		};
 	}
-}, A_ = { class: "mjr-am-search-pill" }, j_ = ["id"], M_ = { class: "mjr-am-search-tools" }, N_ = { class: "mjr-popover-anchor" }, P_ = { class: "mjr-popover-anchor" }, F_ = "Ctrl/Cmd+F, Ctrl/Cmd+K, Ctrl/Cmd+H", I_ = "AND", L_ = {
+}, L_ = { class: "mjr-am-search-pill" }, R_ = ["id"], z_ = { class: "mjr-am-search-tools" }, B_ = { class: "mjr-popover-anchor" }, V_ = { class: "mjr-popover-anchor" }, H_ = "Ctrl/Cmd+F, Ctrl/Cmd+K, Ctrl/Cmd+H", U_ = "AND", W_ = {
 	__name: "SearchBar",
 	emits: ["search-change"],
 	setup(e, { expose: t, emit: n }) {
-		let r = n, i = uh(), a = Z(null), o = Z(null), s = Z(null), c = Z(null), l = Z(null), u = Z(null), d = dt("mjr-search-autocomplete-", 8), f = (e) => e?.$el || e || null, p = () => f(o.value), m = Z(!1), h = Z(!0), g = Z(I_), _ = null, v = null, y = G(() => m.value ? R("search.semanticPlaceholder", "Describe what you're looking for...") : R("search.placeholder", "Search assets...")), b = G(() => m.value ? Ht(R("search.semanticTitle", "AI semantic search — describe your image in natural language"), F_) : Ht(R("search.title", "Search by filename, tags, or attributes (e.g. rating:5, ext:png)"), F_)), x = G(() => m.value ? {
+		let r = n, i = _h(), a = Z(null), o = Z(null), s = Z(null), c = Z(null), l = Z(null), u = Z(null), d = dt("mjr-search-autocomplete-", 8), f = (e) => e?.$el || e || null, p = () => f(o.value), m = Z(!1), h = Z(!0), g = Z(U_), _ = null, v = null, y = G(() => m.value ? L("search.semanticPlaceholder", "Describe what you're looking for...") : L("search.placeholder", "Search assets...")), b = G(() => m.value ? Ht(L("search.semanticTitle", "AI semantic search — describe your image in natural language"), H_) : Ht(L("search.title", "Search by filename, tags, or attributes (e.g. rating:5, ext:png)"), H_)), x = G(() => m.value ? {
 			background: "rgba(0, 188, 212, 0.2)",
 			borderColor: "rgba(0, 188, 212, 0.6)",
 			color: "#00BCD4",
@@ -18683,13 +18921,13 @@ var C_ = {
 			}
 		}, T = async (e) => {
 			let t = e.target.value || "";
-			i.searchQuery = t, i.metadataSearchMode = I_, S(), C({ query: t }), await A();
+			i.searchQuery = t, i.metadataSearchMode = U_, S(), C({ query: t }), await A();
 		}, E = (e) => {
 			let t = String(e || "").split(/\s+/);
 			return t[t.length - 1] || "";
 		};
 		async function D() {
-			return _ || (v ||= I(lt.METADATA_KEYS, { limit: 600 }).then((e) => {
+			return _ || (v ||= oe(B.METADATA_KEYS, { limit: 600 }).then((e) => {
 				let t = e?.data || {};
 				return _ = t, t;
 			}), v);
@@ -18714,7 +18952,7 @@ var C_ = {
 			if (!(m.value || e.length < 1)) try {
 				let t = [], n = await D();
 				if (t.push(...k(e, n)), !e.includes(":") && e.length >= 2) {
-					let n = await I("/mjr/am/autocomplete", {
+					let n = await oe("/mjr/am/autocomplete", {
 						q: e,
 						limit: 10
 					});
@@ -18734,11 +18972,11 @@ var C_ = {
 		}), ir(m, () => {
 			S();
 		}), ir(() => i.metadataSearchMode, (e) => {
-			String(e || "").toUpperCase() !== I_ && (i.metadataSearchMode = I_), g.value !== I_ && (g.value = I_), S();
+			String(e || "").toUpperCase() !== U_ && (i.metadataSearchMode = U_), g.value !== U_ && (g.value = U_), S();
 		}), fr(() => {
 			try {
 				let e = p();
-				e && (e.value = i.searchQuery || ""), i.metadataSearchMode = I_;
+				e && (e.value = i.searchQuery || ""), i.metadataSearchMode = U_;
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -18780,7 +19018,7 @@ var C_ = {
 				ref_key: "searchSectionRef",
 				ref: a,
 				class: "mjr-am-search"
-			}, [U("div", A_, [
+			}, [U("div", L_, [
 				t[0] ||= U("span", { class: "mjr-am-search-icon" }, [U("i", { class: "pi pi-search" })], -1),
 				J(n, {
 					ref_key: "searchInputRef",
@@ -18801,9 +19039,9 @@ var C_ = {
 					ref_key: "dataListRef",
 					ref: s,
 					id: K(d)
-				}, null, 8, j_)
-			]), U("div", M_, [
-				U("div", N_, [J(r, {
+				}, null, 8, R_)
+			]), U("div", z_, [
+				U("div", B_, [J(r, {
 					ref_key: "semanticBtnRef",
 					ref: u,
 					type: "button",
@@ -18813,7 +19051,7 @@ var C_ = {
 					rounded: "",
 					disabled: !h.value,
 					"aria-disabled": !h.value,
-					title: h.value ? K(R)("search.semanticToggle", "Toggle AI semantic search (CLIP-based)") : K(R)("search.semanticDisabled", "AI semantic search is disabled in settings"),
+					title: h.value ? K(L)("search.semanticToggle", "Toggle AI semantic search (CLIP-based)") : K(L)("search.semanticDisabled", "AI semantic search is disabled in settings"),
 					style: Cr(x.value),
 					onClick: w
 				}, {
@@ -18825,7 +19063,7 @@ var C_ = {
 					"title",
 					"style"
 				])]),
-				U("div", P_, [J(r, {
+				U("div", V_, [J(r, {
 					ref_key: "similarBtnRef",
 					ref: c,
 					type: "button",
@@ -18833,11 +19071,11 @@ var C_ = {
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("search.findSimilar", "Find Similar")
+					title: K(L)("search.findSimilar", "Find Similar")
 				}, {
 					default: Q(() => [...t[2] ||= [U("i", { class: "pi pi-search" }, null, -1)]]),
 					_: 1
-				}, 8, ["title"]), J(k_, {
+				}, 8, ["title"]), J(I_, {
 					ref_key: "similarPopoverRef",
 					ref: l
 				}, null, 512)]),
@@ -18848,13 +19086,13 @@ var C_ = {
 			])], 512);
 		};
 	}
-}, R_ = {
+}, G_ = {
 	class: "mjr-popover mjr-sort-popover",
 	style: { display: "none" }
-}, z_ = { class: "mjr-menu-item-label" }, B_ = {
+}, K_ = { class: "mjr-menu-item-label" }, q_ = {
 	__name: "SortPopover",
 	setup(e) {
-		let t = uh(), n = G(() => t.sort || "mtime_desc"), r = (e) => {
+		let t = _h(), n = G(() => t.sort || "mtime_desc"), r = (e) => {
 			t.sort = e;
 			try {
 				window.dispatchEvent(new CustomEvent("mjr:sort-changed", { detail: { sort: e } }));
@@ -18864,37 +19102,37 @@ var C_ = {
 		}, i = G(() => [
 			{
 				key: "mtime_desc",
-				label: R("sort.newest"),
+				label: L("sort.newest"),
 				icon: "pi pi-sort-amount-down"
 			},
 			{
 				key: "mtime_asc",
-				label: R("sort.oldest"),
+				label: L("sort.oldest"),
 				icon: "pi pi-sort-amount-up-alt"
 			},
 			{
 				key: "name_asc",
-				label: R("sort.nameAZ"),
+				label: L("sort.nameAZ"),
 				icon: "pi pi-sort-alpha-down"
 			},
 			{
 				key: "name_desc",
-				label: R("sort.nameZA"),
+				label: L("sort.nameZA"),
 				icon: "pi pi-sort-alpha-up"
 			},
 			{
 				key: "rating_desc",
-				label: R("sort.ratingHigh"),
+				label: L("sort.ratingHigh"),
 				icon: "pi pi-star-fill"
 			},
 			{
 				key: "size_desc",
-				label: R("sort.sizeDesc"),
+				label: L("sort.sizeDesc"),
 				icon: "pi pi-sort-numeric-down-alt"
 			},
 			{
 				key: "size_asc",
-				label: R("sort.sizeAsc"),
+				label: L("sort.sizeAsc"),
 				icon: "pi pi-sort-numeric-up-alt"
 			}
 		].map((e) => ({
@@ -18904,12 +19142,12 @@ var C_ = {
 		})));
 		return (e, t) => {
 			let r = gr("MMenu");
-			return V(), Y("div", R_, [J(r, {
+			return V(), Y("div", G_, [J(r, {
 				model: i.value,
 				class: "mjr-menu mjr-prime-menu mjr-sort-menu",
 				pt: { list: { class: "mjr-menu mjr-prime-menu-list" } }
 			}, {
-				item: Q(({ item: e }) => [U("div", { class: X(["mjr-menu-item", { "is-active": n.value === e.key }]) }, [U("span", z_, q(e.label), 1), U("i", {
+				item: Q(({ item: e }) => [U("div", { class: X(["mjr-menu-item", { "is-active": n.value === e.key }]) }, [U("span", K_, q(e.label), 1), U("i", {
 					class: X([e.icon, "mjr-menu-item-check"]),
 					style: Cr({ opacity: +(n.value === e.key) })
 				}, null, 6)], 2)]),
@@ -18917,20 +19155,20 @@ var C_ = {
 			}, 8, ["model"])]);
 		};
 	}
-}, V_ = { class: "mjr-popover mjr-filter-popover mjr-popover--hidden" }, H_ = { class: "mjr-filter-head" }, U_ = { class: "mjr-filter-head-left" }, W_ = { class: "mjr-filter-kicker" }, G_ = { class: "mjr-filter-subtitle" }, K_ = { class: "mjr-filter-head-actions" }, q_ = { class: "mjr-filter-active-count" }, J_ = { class: "mjr-filter-group-title" }, Y_ = {
+}, J_ = { class: "mjr-popover mjr-filter-popover mjr-popover--hidden" }, Y_ = { class: "mjr-filter-head" }, X_ = { class: "mjr-filter-head-left" }, Z_ = { class: "mjr-filter-kicker" }, Q_ = { class: "mjr-filter-subtitle" }, $_ = { class: "mjr-filter-head-actions" }, ev = { class: "mjr-filter-active-count" }, tv = { class: "mjr-filter-group-title" }, nv = {
 	class: "mjr-filter-group-chevron",
 	"aria-hidden": "true"
-}, X_ = { class: "mjr-filter-group-body" }, Z_ = { class: "mjr-filter-card" }, Q_ = { class: "mjr-popover-row" }, $_ = { class: "mjr-popover-label" }, ev = { class: "mjr-popover-row" }, tv = { class: "mjr-popover-label" }, nv = ["title"], rv = { class: "mjr-filter-card" }, iv = { class: "mjr-popover-row" }, av = { class: "mjr-popover-label" }, ov = { class: "mjr-popover-row" }, sv = { class: "mjr-popover-label" }, cv = { class: "mjr-popover-row" }, lv = { class: "mjr-popover-label" }, uv = { class: "mjr-filter-stack" }, dv = { class: "mjr-popover-row" }, fv = { class: "mjr-popover-label" }, pv = { class: "mjr-popover-row" }, mv = { class: "mjr-popover-label" }, hv = { class: "mjr-filter-group-title" }, gv = {
+}, rv = { class: "mjr-filter-group-body" }, iv = { class: "mjr-filter-card" }, av = { class: "mjr-popover-row" }, ov = { class: "mjr-popover-label" }, sv = { class: "mjr-popover-row" }, cv = { class: "mjr-popover-label" }, lv = ["title"], uv = { class: "mjr-filter-card" }, dv = { class: "mjr-popover-row" }, fv = { class: "mjr-popover-label" }, pv = { class: "mjr-popover-row" }, mv = { class: "mjr-popover-label" }, hv = { class: "mjr-popover-row" }, gv = { class: "mjr-popover-label" }, _v = { class: "mjr-filter-stack" }, vv = { class: "mjr-popover-row" }, yv = { class: "mjr-popover-label" }, bv = { class: "mjr-popover-row" }, xv = { class: "mjr-popover-label" }, Sv = { class: "mjr-filter-group-title" }, Cv = {
 	class: "mjr-filter-group-chevron",
 	"aria-hidden": "true"
-}, _v = { class: "mjr-filter-group-body" }, vv = { class: "mjr-filter-card" }, yv = { class: "mjr-popover-row mjr-popover-row--3col" }, bv = { class: "mjr-popover-label" }, xv = { class: "mjr-popover-row" }, Sv = { class: "mjr-popover-label" }, Cv = { class: "mjr-popover-row mjr-popover-row--3col" }, wv = { class: "mjr-popover-label" }, Tv = { class: "mjr-popover-row mjr-popover-row--3col" }, Ev = { class: "mjr-popover-label" }, Dv = { class: "mjr-filter-group-title" }, Ov = {
+}, wv = { class: "mjr-filter-group-body" }, Tv = { class: "mjr-filter-card" }, Ev = { class: "mjr-popover-row mjr-popover-row--3col" }, Dv = { class: "mjr-popover-label" }, Ov = { class: "mjr-popover-row" }, kv = { class: "mjr-popover-label" }, Av = { class: "mjr-popover-row mjr-popover-row--3col" }, jv = { class: "mjr-popover-label" }, Mv = { class: "mjr-popover-row mjr-popover-row--3col" }, Nv = { class: "mjr-popover-label" }, Pv = { class: "mjr-filter-group-title" }, Fv = {
 	class: "mjr-filter-group-chevron",
 	"aria-hidden": "true"
-}, kv = { class: "mjr-filter-group-body" }, Av = { class: "mjr-filter-card mjr-filter-card--agenda" }, jv = { class: "mjr-popover-row" }, Mv = { class: "mjr-popover-label" }, Nv = { class: "mjr-popover-row" }, Pv = { class: "mjr-popover-label" }, Fv = {
+}, Iv = { class: "mjr-filter-group-body" }, Lv = { class: "mjr-filter-card mjr-filter-card--agenda" }, Rv = { class: "mjr-popover-row" }, zv = { class: "mjr-popover-label" }, Bv = { class: "mjr-popover-row" }, Vv = { class: "mjr-popover-label" }, Hv = {
 	__name: "FilterPopover",
 	setup(e, { expose: t }) {
-		let n = uh(), r = Z(null), a = Z(null), o = Z(null), s = Z(null), c = Z(null), l = Z(null), u = Z(null), d = Z(null), f = Z(null), p = Z(null), m = Z([{
-			label: R("filter.any", "Any"),
+		let n = _h(), i = Z(null), a = Z(null), o = Z(null), s = Z(null), c = Z(null), l = Z(null), u = Z(null), d = Z(null), f = Z(null), p = Z(null), m = Z([{
+			label: L("filter.any", "Any"),
 			value: ""
 		}]), h = (e) => e?.$el || e || null, g = (e) => h(e.value)?.value || "", _ = (e, t) => {
 			let n = h(e.value);
@@ -18941,19 +19179,19 @@ var C_ = {
 			time: !0
 		}), y = G(() => [
 			{
-				label: R("filter.all"),
+				label: L("filter.all"),
 				value: ""
 			},
 			{
-				label: R("filter.images", "Images"),
+				label: L("filter.images", "Images"),
 				value: "image"
 			},
 			{
-				label: R("filter.videos", "Videos"),
+				label: L("filter.videos", "Videos"),
 				value: "video"
 			},
 			{
-				label: R("filter.audio", "Audio"),
+				label: L("filter.audio", "Audio"),
 				value: "audio"
 			},
 			{
@@ -18962,7 +19200,7 @@ var C_ = {
 			}
 		]), b = G(() => [
 			{
-				label: R("filter.any", "Any"),
+				label: L("filter.any", "Any"),
 				value: ""
 			},
 			{
@@ -19007,7 +19245,7 @@ var C_ = {
 			}
 		]), x = G(() => [
 			{
-				label: R("filter.any", "Any"),
+				label: L("filter.any", "Any"),
 				value: ""
 			},
 			{
@@ -19028,11 +19266,11 @@ var C_ = {
 			}
 		]), S = G(() => {
 			let e = Array.isArray(m.value) ? m.value.slice() : [{
-				label: R("filter.any", "Any"),
+				label: L("filter.any", "Any"),
 				value: ""
 			}];
 			(!e.length || String(e[0]?.value || "") !== "") && e.unshift({
-				label: R("filter.any", "Any"),
+				label: L("filter.any", "Any"),
 				value: ""
 			});
 			let t = String(n.workflowModelFilter || "").trim();
@@ -19042,7 +19280,7 @@ var C_ = {
 			}), e;
 		}), C = G(() => [
 			{
-				label: R("filter.anyRating"),
+				label: L("filter.anyRating"),
 				value: "0"
 			},
 			{
@@ -19067,7 +19305,7 @@ var C_ = {
 			}
 		]), w = G(() => [
 			{
-				label: R("filter.any", "Any"),
+				label: L("filter.any", "Any"),
 				value: ""
 			},
 			{
@@ -19088,19 +19326,19 @@ var C_ = {
 			}
 		]), T = G(() => [
 			{
-				label: R("filter.anytime"),
+				label: L("filter.anytime"),
 				value: ""
 			},
 			{
-				label: R("filter.today"),
+				label: L("filter.today"),
 				value: "today"
 			},
 			{
-				label: R("filter.thisWeek"),
+				label: L("filter.thisWeek"),
 				value: "this_week"
 			},
 			{
-				label: R("filter.thisMonth"),
+				label: L("filter.thisMonth"),
 				value: "this_month"
 			}
 		]), E = G(() => {
@@ -19125,14 +19363,14 @@ var C_ = {
 			}
 		}, A = async () => {
 			try {
-				let e = await i();
+				let e = await r();
 				if (!e?.ok) return;
 				let t = (Array.isArray(e.data?.model_families) ? e.data.model_families : []).map((e) => ({
 					label: String(e?.label || e?.value || "").trim(),
 					value: String(e?.value || e?.label || "").trim()
 				})).filter((e) => e.value).slice(0, 200);
 				m.value = [{
-					label: R("filter.any", "Any"),
+					label: L("filter.any", "Any"),
 					value: ""
 				}, ...t];
 			} catch (e) {
@@ -19150,14 +19388,14 @@ var C_ = {
 			n.workflowType = String(e || "").trim().toUpperCase(), t && k();
 		}, ee = (e, { emit: t = !0 } = {}) => {
 			n.workflowId = String(e || "").trim(), t && k();
-		}, te = (e, { emit: t = !0 } = {}) => {
-			n.workflowModelFilter = String(e || "").trim(), t && k();
-		}, ne = (e, { emit: t = !0 } = {}) => {
-			n.workflowRunsOnFilter = String(e || "").trim().toLowerCase(), t && k();
 		}, P = (e, { emit: t = !0 } = {}) => {
+			n.workflowModelFilter = String(e || "").trim(), t && k();
+		}, te = (e, { emit: t = !0 } = {}) => {
+			n.workflowRunsOnFilter = String(e || "").trim().toLowerCase(), t && k();
+		}, ne = (e, { emit: t = !0 } = {}) => {
 			n.minRating = Number(e || 0) || 0, t && k();
 		}, F = () => {
-			let e = O(g(r) || 0), t = O(g(a) || 0);
+			let e = O(g(i) || 0), t = O(g(a) || 0);
 			t > 0 && e > 0 && t < e && (t = e, _(a, t)), n.minSizeMB = e > 0 ? e : 0, n.maxSizeMB = t > 0 ? t : 0, k();
 		}, re = () => {
 			let e = Math.max(0, Math.round(O(g(o) || 0))), t = Math.max(0, Math.round(O(g(s) || 0))), r = Math.max(0, Math.round(O(g(c) || 0))), i = Math.max(0, Math.round(O(g(l) || 0)));
@@ -19180,7 +19418,7 @@ var C_ = {
 				...v.value,
 				[t]: !v.value[t]
 			});
-		}, I = (e) => !!v.value[String(e || "").trim().toLowerCase()], ce = ({ getValue: e, setValue: t }) => ({
+		}, ce = (e) => !!v.value[String(e || "").trim().toLowerCase()], le = ({ getValue: e, setValue: t }) => ({
 			get value() {
 				return e();
 			},
@@ -19192,7 +19430,7 @@ var C_ = {
 			dispatchEvent() {
 				return !0;
 			}
-		}), le = ({ getChecked: e, setChecked: t }) => ({
+		}), ue = ({ getChecked: e, setChecked: t }) => ({
 			get checked() {
 				return e();
 			},
@@ -19204,72 +19442,72 @@ var C_ = {
 			dispatchEvent() {
 				return !0;
 			}
-		}), ue = ce({
+		}), de = le({
 			getValue: () => String(n.kindFilter || ""),
 			setValue: j
-		}), de = le({
+		}), fe = ue({
 			getChecked: () => !!n.workflowOnly,
 			setChecked: M
-		}), fe = ce({
+		}), pe = le({
 			getValue: () => String(n.workflowType || "").trim().toUpperCase(),
 			setValue: N
-		}), pe = ce({
+		}), me = le({
 			getValue: () => String(n.workflowId || "").trim(),
 			setValue: ee
-		}), me = ce({
+		}), he = le({
 			getValue: () => String(n.workflowModelFilter || "").trim(),
-			setValue: te
-		}), he = ce({
-			getValue: () => String(n.workflowRunsOnFilter || "").trim().toLowerCase(),
-			setValue: ne
-		}), ge = ce({
-			getValue: () => String(Number(n.minRating || 0) || 0),
 			setValue: P
-		}), _e = ce({
+		}), ge = le({
+			getValue: () => String(n.workflowRunsOnFilter || "").trim().toLowerCase(),
+			setValue: te
+		}), _e = le({
+			getValue: () => String(Number(n.minRating || 0) || 0),
+			setValue: ne
+		}), ve = le({
 			getValue: () => E.value,
 			setValue: ie
-		}), ve = ce({
+		}), ye = le({
 			getValue: () => String(n.dateRangeFilter || ""),
 			setValue: ae
-		}), ye = G(() => {
+		}), be = G(() => {
 			let e = 0;
 			return String(n.kindFilter || "").trim() && (e += 1), n.workflowOnly && (e += 1), String(n.workflowType || "").trim() && (e += 1), String(n.workflowId || "").trim() && (e += 1), String(n.workflowModelFilter || "").trim() && (e += 1), String(n.workflowRunsOnFilter || "").trim() && (e += 1), (Number(n.minRating || 0) || 0) > 0 && (e += 1), ((Number(n.minSizeMB || 0) || 0) > 0 || (Number(n.maxSizeMB || 0) || 0) > 0) && (e += 1), ((Number(n.minWidth || 0) || 0) > 0 || (Number(n.minHeight || 0) || 0) > 0 || (Number(n.maxWidth || 0) || 0) > 0 || (Number(n.maxHeight || 0) || 0) > 0) && (e += 1), String(n.dateRangeFilter || "").trim() && (e += 1), String(n.dateExactFilter || "").trim() && (e += 1), e;
-		}), be = () => {
-			n.kindFilter = "", n.workflowOnly = !1, n.workflowType = "", n.workflowId = "", n.workflowModelFilter = "", n.workflowRunsOnFilter = "", n.minRating = 0, n.minSizeMB = 0, n.maxSizeMB = 0, n.minWidth = 0, n.minHeight = 0, n.maxWidth = 0, n.maxHeight = 0, n.dateRangeFilter = "", n.dateExactFilter = "", _(r, ""), _(a, ""), _(o, ""), _(s, ""), _(c, ""), _(l, ""), _(d, ""), _(f, ""), _(p, ""), k();
+		}), xe = () => {
+			n.kindFilter = "", n.workflowOnly = !1, n.workflowType = "", n.workflowId = "", n.workflowModelFilter = "", n.workflowRunsOnFilter = "", n.minRating = 0, n.minSizeMB = 0, n.maxSizeMB = 0, n.minWidth = 0, n.minHeight = 0, n.maxWidth = 0, n.maxHeight = 0, n.dateRangeFilter = "", n.dateExactFilter = "", _(i, ""), _(a, ""), _(o, ""), _(s, ""), _(c, ""), _(l, ""), _(d, ""), _(f, ""), _(p, ""), k();
 		};
 		return t({
 			get kindSelect() {
-				return ue;
-			},
-			get wfCheckbox() {
 				return de;
 			},
-			get workflowTypeSelect() {
+			get wfCheckbox() {
 				return fe;
 			},
-			get workflowIdInput() {
+			get workflowTypeSelect() {
 				return pe;
 			},
-			get workflowModelInput() {
+			get workflowIdInput() {
 				return me;
+			},
+			get workflowModelInput() {
+				return he;
 			},
 			get workflowModelFamilyOptions() {
 				return S.value;
 			},
 			get workflowRunsOnSelect() {
-				return he;
-			},
-			get ratingSelect() {
 				return ge;
 			},
+			get ratingSelect() {
+				return _e;
+			},
 			get minSizeInput() {
-				return h(r.value);
+				return h(i.value);
 			},
 			get maxSizeInput() {
 				return h(a.value);
 			},
 			get resolutionPresetSelect() {
-				return _e;
+				return ve;
 			},
 			get minWidthInput() {
 				return h(o.value);
@@ -19284,7 +19522,7 @@ var C_ = {
 				return h(l.value);
 			},
 			get dateRangeSelect() {
-				return ve;
+				return ye;
 			},
 			get dateExactInput() {
 				return h(d.value);
@@ -19293,33 +19531,33 @@ var C_ = {
 				return u.value;
 			}
 		}), (e, t) => {
-			let i = gr("MButton"), m = gr("MSelect"), h = gr("MCheckbox"), g = gr("MInputText");
-			return V(), Y("div", V_, [
-				U("div", H_, [U("div", U_, [U("div", W_, q(K(R)("label.filters", "Filters")), 1), U("div", G_, q(K(R)("label.refineResults", "Refine your results")), 1)]), U("div", K_, [U("span", q_, q(ye.value), 1), J(i, {
+			let r = gr("MButton"), m = gr("MSelect"), h = gr("MCheckbox"), g = gr("MInputText");
+			return V(), Y("div", J_, [
+				U("div", Y_, [U("div", X_, [U("div", Z_, q(K(L)("label.filters", "Filters")), 1), U("div", Q_, q(K(L)("label.refineResults", "Refine your results")), 1)]), U("div", $_, [U("span", ev, q(be.value), 1), J(r, {
 					type: "button",
 					class: "mjr-filter-clear-all",
 					severity: "secondary",
 					text: "",
-					disabled: ye.value === 0,
-					onClick: be
+					disabled: be.value === 0,
+					onClick: xe
 				}, {
-					default: Q(() => [tr(q(K(R)("action.clearAll", "Clear all")), 1)]),
+					default: Q(() => [tr(q(K(L)("action.clearAll", "Clear all")), 1)]),
 					_: 1
 				}, 8, ["disabled"])])]),
-				U("div", { class: X(["mjr-filter-group mjr-filter-group--core", { "is-open": I("core") }]) }, [J(i, {
+				U("div", { class: X(["mjr-filter-group mjr-filter-group--core", { "is-open": ce("core") }]) }, [J(r, {
 					type: "button",
 					class: "mjr-filter-group-toggle",
 					severity: "secondary",
 					text: "",
-					"aria-expanded": String(I("core")),
+					"aria-expanded": String(ce("core")),
 					onClick: t[0] ||= (e) => se("core")
 				}, {
-					default: Q(() => [U("span", J_, q(K(R)("group.core", "Core")), 1), U("span", Y_, q(I("core") ? "▾" : "▸"), 1)]),
+					default: Q(() => [U("span", tv, q(K(L)("group.core", "Core")), 1), U("span", nv, q(ce("core") ? "▾" : "▸"), 1)]),
 					_: 1
-				}, 8, ["aria-expanded"]), sr(U("div", X_, [U("div", Z_, [U("div", Q_, [U("div", $_, q(K(R)("label.type")), 1), J(m, {
+				}, 8, ["aria-expanded"]), sr(U("div", rv, [U("div", iv, [U("div", av, [U("div", ov, q(K(L)("label.type")), 1), J(m, {
 					class: "mjr-select mjr-filter-select",
 					"panel-class": "mjr-filter-select-panel",
-					title: K(R)("tooltip.filterByFileType", "Filter by file type"),
+					title: K(L)("tooltip.filterByFileType", "Filter by file type"),
 					"model-value": String(K(n).kindFilter || ""),
 					options: y.value,
 					"option-label": "label",
@@ -19329,16 +19567,16 @@ var C_ = {
 					"title",
 					"model-value",
 					"options"
-				])]), U("div", ev, [U("div", tv, q(K(R)("label.workflow")), 1), U("label", {
+				])]), U("div", sv, [U("div", cv, q(K(L)("label.workflow")), 1), U("label", {
 					class: "mjr-popover-toggle",
-					title: K(R)("tooltip.filterWorkflowOnly", "Show only assets with embedded workflow data")
+					title: K(L)("tooltip.filterWorkflowOnly", "Show only assets with embedded workflow data")
 				}, [J(h, {
 					class: "mjr-checkbox",
 					"model-value": !!K(n).workflowOnly,
 					binary: "",
 					"onUpdate:modelValue": M
-				}, null, 8, ["model-value"]), U("span", null, q(K(R)("filter.onlyWithWorkflow")), 1)], 8, nv)])]), U("div", rv, [
-					U("div", iv, [U("div", av, q(K(R)("label.workflowType", "Workflow type")), 1), J(m, {
+				}, null, 8, ["model-value"]), U("span", null, q(K(L)("filter.onlyWithWorkflow")), 1)], 8, lv)])]), U("div", uv, [
+					U("div", dv, [U("div", fv, q(K(L)("label.workflowType", "Workflow type")), 1), J(m, {
 						class: "mjr-select mjr-filter-select",
 						"panel-class": "mjr-filter-select-panel",
 						"model-value": String(K(n).workflowType || "").trim().toUpperCase(),
@@ -19347,12 +19585,12 @@ var C_ = {
 						"option-value": "value",
 						"onUpdate:modelValue": N
 					}, null, 8, ["model-value", "options"])]),
-					U("div", ov, [U("div", sv, q(K(R)("label.sameWorkflow", "Generated with Same Workflow")), 1), J(g, {
+					U("div", pv, [U("div", mv, q(K(L)("label.sameWorkflow", "Generated with Same Workflow")), 1), J(g, {
 						ref_key: "workflowIdInputRef",
 						ref: f,
 						class: "mjr-input",
-						title: K(R)("tooltip.filterWorkflowId", "Filter assets generated from the same embedded workflow id"),
-						placeholder: K(R)("placeholder.workflowId", "Workflow ID"),
+						title: K(L)("tooltip.filterWorkflowId", "Filter assets generated from the same embedded workflow id"),
+						placeholder: K(L)("placeholder.workflowId", "Workflow ID"),
 						"model-value": String(K(n).workflowId || ""),
 						"onUpdate:modelValue": ee,
 						onChange: t[1] ||= (e) => ee(e?.target?.value)
@@ -19361,68 +19599,68 @@ var C_ = {
 						"placeholder",
 						"model-value"
 					])]),
-					U("div", cv, [U("div", lv, q(K(R)("label.workflowModelFamily", "Model family")), 1), U("div", uv, [J(m, {
+					U("div", hv, [U("div", gv, q(K(L)("label.workflowModelFamily", "Model family")), 1), U("div", _v, [J(m, {
 						class: "mjr-select mjr-filter-select",
 						"panel-class": "mjr-filter-select-panel",
 						"model-value": String(K(n).workflowModelFilter || ""),
 						options: S.value,
 						"option-label": "label",
 						"option-value": "value",
-						"onUpdate:modelValue": te
+						"onUpdate:modelValue": P
 					}, null, 8, ["model-value", "options"]), J(g, {
 						ref_key: "workflowModelInputRef",
 						ref: p,
 						class: "mjr-input",
-						placeholder: K(R)("placeholder.workflowModelFamily", "Flux, Wan, SDXL..."),
+						placeholder: K(L)("placeholder.workflowModelFamily", "Flux, Wan, SDXL..."),
 						"model-value": String(K(n).workflowModelFilter || ""),
-						"onUpdate:modelValue": te,
-						onChange: t[2] ||= (e) => te(e?.target?.value)
+						"onUpdate:modelValue": P,
+						onChange: t[2] ||= (e) => P(e?.target?.value)
 					}, null, 8, ["placeholder", "model-value"])])]),
-					U("div", dv, [U("div", fv, q(K(R)("label.workflowRunsOn", "Runs on")), 1), J(m, {
+					U("div", vv, [U("div", yv, q(K(L)("label.workflowRunsOn", "Runs on")), 1), J(m, {
 						class: "mjr-select mjr-filter-select",
 						"panel-class": "mjr-filter-select-panel",
 						"model-value": String(K(n).workflowRunsOnFilter || "").trim().toLowerCase(),
 						options: x.value,
 						"option-label": "label",
 						"option-value": "value",
-						"onUpdate:modelValue": ne
+						"onUpdate:modelValue": te
 					}, null, 8, ["model-value", "options"])]),
-					U("div", pv, [U("div", mv, q(K(R)("label.rating")), 1), J(m, {
+					U("div", bv, [U("div", xv, q(K(L)("label.rating")), 1), J(m, {
 						class: "mjr-select mjr-filter-select",
 						"panel-class": "mjr-filter-select-panel",
-						title: K(R)("tooltip.filterMinRating", "Filter by minimum rating"),
+						title: K(L)("tooltip.filterMinRating", "Filter by minimum rating"),
 						"model-value": String(Number(K(n).minRating || 0) || 0),
 						options: C.value,
 						"option-label": "label",
 						"option-value": "value",
-						"onUpdate:modelValue": P
+						"onUpdate:modelValue": ne
 					}, null, 8, [
 						"title",
 						"model-value",
 						"options"
 					])])
-				])], 512), [[_r, I("core")]])], 2),
-				U("div", { class: X(["mjr-filter-group mjr-filter-group--media", { "is-open": I("media") }]) }, [J(i, {
+				])], 512), [[_r, ce("core")]])], 2),
+				U("div", { class: X(["mjr-filter-group mjr-filter-group--media", { "is-open": ce("media") }]) }, [J(r, {
 					type: "button",
 					class: "mjr-filter-group-toggle",
 					severity: "secondary",
 					text: "",
-					"aria-expanded": String(I("media")),
+					"aria-expanded": String(ce("media")),
 					onClick: t[3] ||= (e) => se("media")
 				}, {
-					default: Q(() => [U("span", hv, q(K(R)("group.media", "Media")), 1), U("span", gv, q(I("media") ? "▾" : "▸"), 1)]),
+					default: Q(() => [U("span", Sv, q(K(L)("group.media", "Media")), 1), U("span", Cv, q(ce("media") ? "▾" : "▸"), 1)]),
 					_: 1
-				}, 8, ["aria-expanded"]), sr(U("div", _v, [U("div", vv, [
-					U("div", yv, [
-						U("div", bv, q(K(R)("label.fileSizeMB", "File size (MB)")), 1),
+				}, 8, ["aria-expanded"]), sr(U("div", wv, [U("div", Tv, [
+					U("div", Ev, [
+						U("div", Dv, q(K(L)("label.fileSizeMB", "File size (MB)")), 1),
 						J(g, {
 							ref_key: "minSizeInputRef",
-							ref: r,
+							ref: i,
 							type: "number",
 							min: "0",
 							step: "0.1",
 							class: "mjr-input",
-							placeholder: K(R)("label.min", "Min"),
+							placeholder: K(L)("label.min", "Min"),
 							value: K(n).minSizeMB || "",
 							onChange: F
 						}, null, 8, ["placeholder", "value"]),
@@ -19433,12 +19671,12 @@ var C_ = {
 							min: "0",
 							step: "0.1",
 							class: "mjr-input",
-							placeholder: K(R)("label.max", "Max"),
+							placeholder: K(L)("label.max", "Max"),
 							value: K(n).maxSizeMB || "",
 							onChange: F
 						}, null, 8, ["placeholder", "value"])
 					]),
-					U("div", xv, [U("div", Sv, q(K(R)("label.resolutionPx", "Resolution (px)")), 1), J(m, {
+					U("div", Ov, [U("div", kv, q(K(L)("label.resolutionPx", "Resolution (px)")), 1), J(m, {
 						class: "mjr-select mjr-filter-select",
 						"panel-class": "mjr-filter-select-panel",
 						"model-value": E.value,
@@ -19447,8 +19685,8 @@ var C_ = {
 						"option-value": "value",
 						"onUpdate:modelValue": ie
 					}, null, 8, ["model-value", "options"])]),
-					U("div", Cv, [
-						U("div", wv, q(K(R)("label.resolutionMinWxH", "Min WxH (px)")), 1),
+					U("div", Av, [
+						U("div", jv, q(K(L)("label.resolutionMinWxH", "Min WxH (px)")), 1),
 						J(g, {
 							ref_key: "minWidthInputRef",
 							ref: o,
@@ -19456,8 +19694,8 @@ var C_ = {
 							min: "0",
 							step: "1",
 							class: "mjr-input",
-							placeholder: K(R)("label.widthPx", "W (px)"),
-							title: K(R)("tooltip.widthPx", "Minimum width in pixels"),
+							placeholder: K(L)("label.widthPx", "W (px)"),
+							title: K(L)("tooltip.widthPx", "Minimum width in pixels"),
 							value: K(n).minWidth || "",
 							onChange: re
 						}, null, 8, [
@@ -19472,8 +19710,8 @@ var C_ = {
 							min: "0",
 							step: "1",
 							class: "mjr-input",
-							placeholder: K(R)("label.heightPx", "H (px)"),
-							title: K(R)("tooltip.heightPx", "Minimum height in pixels"),
+							placeholder: K(L)("label.heightPx", "H (px)"),
+							title: K(L)("tooltip.heightPx", "Minimum height in pixels"),
 							value: K(n).minHeight || "",
 							onChange: re
 						}, null, 8, [
@@ -19482,8 +19720,8 @@ var C_ = {
 							"value"
 						])
 					]),
-					U("div", Tv, [
-						U("div", Ev, q(K(R)("label.resolutionMaxWxH", "Max WxH (px)")), 1),
+					U("div", Mv, [
+						U("div", Nv, q(K(L)("label.resolutionMaxWxH", "Max WxH (px)")), 1),
 						J(g, {
 							ref_key: "maxWidthInputRef",
 							ref: c,
@@ -19491,8 +19729,8 @@ var C_ = {
 							min: "0",
 							step: "1",
 							class: "mjr-input",
-							placeholder: K(R)("label.widthPx", "W (px)"),
-							title: K(R)("tooltip.widthPx", "Maximum width in pixels"),
+							placeholder: K(L)("label.widthPx", "W (px)"),
+							title: K(L)("tooltip.widthPx", "Maximum width in pixels"),
 							value: K(n).maxWidth || "",
 							onChange: re
 						}, null, 8, [
@@ -19507,8 +19745,8 @@ var C_ = {
 							min: "0",
 							step: "1",
 							class: "mjr-input",
-							placeholder: K(R)("label.heightPx", "H (px)"),
-							title: K(R)("tooltip.heightPx", "Maximum height in pixels"),
+							placeholder: K(L)("label.heightPx", "H (px)"),
+							title: K(L)("tooltip.heightPx", "Maximum height in pixels"),
 							value: K(n).maxHeight || "",
 							onChange: re
 						}, null, 8, [
@@ -19517,21 +19755,21 @@ var C_ = {
 							"value"
 						])
 					])
-				])], 512), [[_r, I("media")]])], 2),
-				U("div", { class: X(["mjr-filter-group mjr-filter-group--time", { "is-open": I("time") }]) }, [J(i, {
+				])], 512), [[_r, ce("media")]])], 2),
+				U("div", { class: X(["mjr-filter-group mjr-filter-group--time", { "is-open": ce("time") }]) }, [J(r, {
 					type: "button",
 					class: "mjr-filter-group-toggle",
 					severity: "secondary",
 					text: "",
-					"aria-expanded": String(I("time")),
+					"aria-expanded": String(ce("time")),
 					onClick: t[4] ||= (e) => se("time")
 				}, {
-					default: Q(() => [U("span", Dv, q(K(R)("group.time", "Time")), 1), U("span", Ov, q(I("time") ? "▾" : "▸"), 1)]),
+					default: Q(() => [U("span", Pv, q(K(L)("group.time", "Time")), 1), U("span", Fv, q(ce("time") ? "▾" : "▸"), 1)]),
 					_: 1
-				}, 8, ["aria-expanded"]), sr(U("div", kv, [U("div", Av, [U("div", jv, [U("div", Mv, q(K(R)("label.dateRange")), 1), J(m, {
+				}, 8, ["aria-expanded"]), sr(U("div", Iv, [U("div", Lv, [U("div", Rv, [U("div", zv, q(K(L)("label.dateRange")), 1), J(m, {
 					class: "mjr-select mjr-filter-select",
 					"panel-class": "mjr-filter-select-panel",
-					title: K(R)("tooltip.filterByDateRange", "Filter by date range"),
+					title: K(L)("tooltip.filterByDateRange", "Filter by date range"),
 					"model-value": String(K(n).dateRangeFilter || ""),
 					options: T.value,
 					"option-label": "label",
@@ -19541,7 +19779,7 @@ var C_ = {
 					"title",
 					"model-value",
 					"options"
-				])]), U("div", Nv, [U("div", Pv, q(K(R)("label.agenda")), 1), U("div", {
+				])]), U("div", Bv, [U("div", Vv, q(K(L)("label.agenda")), 1), U("div", {
 					ref_key: "agendaContainerRef",
 					ref: u,
 					class: "mjr-agenda-container"
@@ -19552,11 +19790,11 @@ var C_ = {
 					class: X(["mjr-input mjr-agenda-input", D.value]),
 					value: K(n).dateExactFilter,
 					onChange: oe
-				}, null, 8, ["class", "value"])], 512)])])], 512), [[_r, I("time")]])], 2)
+				}, null, 8, ["class", "value"])], 512)])])], 512), [[_r, ce("time")]])], 2)
 			]);
 		};
 	}
-}, Iv = 128, Lv = Object.freeze([
+}, Uv = 128, Wv = Object.freeze([
 	{
 		key: "portraits",
 		label: "Portraits",
@@ -19594,10 +19832,10 @@ var C_ = {
 		iconClass: "pi pi-circle"
 	}
 ]);
-function Rv(e) {
+function Gv(e) {
 	try {
 		let t = String(e ?? "").trim();
-		if (!t || t.length > Iv || t.includes("\0")) return "";
+		if (!t || t.length > Uv || t.includes("\0")) return "";
 		for (let e = 0; e < t.length; e += 1) {
 			let n = t.charCodeAt(e);
 			if (n <= 31 || n === 127) return "";
@@ -19607,7 +19845,7 @@ function Rv(e) {
 		return "";
 	}
 }
-function zv(e) {
+function Kv(e) {
 	if (!e || typeof e != "object") return null;
 	let t = String(e.filepath || "").trim();
 	return t ? {
@@ -19619,10 +19857,10 @@ function zv(e) {
 		root_id: String(e.root_id || e.rootId || e.custom_root_id || "").trim() || void 0
 	} : null;
 }
-function Bv(e) {
+function qv(e) {
 	let t = [], n = [], r = /* @__PURE__ */ new Set();
 	for (let i of Array.isArray(e) ? e : []) {
-		let e = zv(i);
+		let e = Kv(i);
 		if (e?.filepath) {
 			let n = e.filepath.toLowerCase();
 			if (r.has(n)) continue;
@@ -19637,24 +19875,24 @@ function Bv(e) {
 		missingIds: n
 	};
 }
-async function Vv(e) {
+async function Jv(e) {
 	let t = Array.from(new Set((Array.isArray(e) ? e : []).map((e) => Number(e)).filter((e) => Number.isFinite(e) && e > 0)));
 	if (!t.length) return {
 		ok: !0,
 		data: []
 	};
-	let n = await M(t);
+	let n = await A(t);
 	if (!n?.ok) return {
 		ok: !1,
 		error: String(n?.error || "Failed to fetch assets")
 	};
-	let { assets: r } = Bv(Array.isArray(n?.data) ? n.data : Array.isArray(n?.data?.assets) ? n.data.assets : []);
+	let { assets: r } = qv(Array.isArray(n?.data) ? n.data : Array.isArray(n?.data?.assets) ? n.data.assets : []);
 	return {
 		ok: !0,
 		data: r
 	};
 }
-function Hv(e) {
+function Yv(e) {
 	let t = String(e?.label || "").trim();
 	if (!(!t || /^group\b/i.test(t))) return t;
 	let n = (Array.isArray(e?.dominant_tags) ? e.dominant_tags : []).map((e) => String(e || "").trim()).filter(Boolean);
@@ -19672,7 +19910,7 @@ function Hv(e) {
 	let s = Object.entries(o).sort((e, t) => t[1] - e[1])[0]?.[0] || "other", c = s === "image" ? "Images" : s === "video" ? "Videos" : s === "audio" ? "Audio" : "Media", l = Number(e?.cluster_id), u = Number.isFinite(l) ? ` ${l + 1}` : "";
 	return a ? `${a} - ${c}` : `${c} Cluster${u}`;
 }
-function Uv() {
+function Xv() {
 	try {
 		return !!(mn()?.ai?.vectorSearchEnabled ?? !0);
 	} catch {
@@ -19681,35 +19919,35 @@ function Uv() {
 }
 //#endregion
 //#region ui/vue/components/panel/CollectionsPopover.vue
-var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-item-label" }, Kv = { class: "mjr-menu-item-label" }, qv = { class: "mjr-menu-item-right" }, Jv = {
+var Zv = { class: "mjr-menu mjr-collections-menu" }, Qv = { class: "mjr-menu-item-label" }, $v = { class: "mjr-menu-item-label" }, ey = { class: "mjr-menu-item-right" }, ty = {
 	key: 0,
 	class: "mjr-menu-item-hint"
-}, Yv = {
+}, ny = {
 	key: 1,
 	class: "mjr-muted"
-}, Xv = {
+}, ry = {
 	key: 2,
 	class: "mjr-state-block is-error"
-}, Zv = {
+}, iy = {
 	key: 3,
 	class: "mjr-muted"
-}, Qv = { class: "mjr-collection-row" }, $v = { class: "mjr-menu-item-label" }, ey = { class: "mjr-menu-item-right" }, ty = {
+}, ay = { class: "mjr-collection-row" }, oy = { class: "mjr-menu-item-label" }, sy = { class: "mjr-menu-item-right" }, cy = {
 	key: 0,
 	class: "mjr-menu-item-hint"
-}, ny = { class: "mjr-state-block" }, ry = { class: "mjr-section-title mjr-section-title--cyan" }, iy = { class: "mjr-section-hint" }, ay = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, oy = { class: "mjr-section-title mjr-section-title--violet" }, sy = { class: "mjr-section-hint" }, cy = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, ly = {
+}, ly = { class: "mjr-state-block" }, uy = { class: "mjr-section-title mjr-section-title--cyan" }, dy = { class: "mjr-section-hint" }, fy = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, py = { class: "mjr-section-title mjr-section-title--violet" }, my = { class: "mjr-section-hint" }, hy = { class: "mjr-menu-item-label mjr-menu-item-label--icon" }, gy = {
 	key: 0,
 	class: "mjr-state-block is-error"
-}, uy = { class: "mjr-cluster-thumbs" }, dy = ["src", "alt"], fy = { class: "mjr-cluster-info" }, py = ["title"], my = { class: "mjr-cluster-count" }, hy = "mjr:collections-changed", gy = {
+}, _y = { class: "mjr-cluster-thumbs" }, vy = ["src", "alt"], yy = { class: "mjr-cluster-info" }, by = ["title"], xy = { class: "mjr-cluster-count" }, Sy = "mjr:collections-changed", Cy = {
 	__name: "CollectionsPopover",
 	setup(e, { expose: t }) {
-		let n = uh(), r = Z(null), i = Z([]), a = Z(!1), o = Z(""), s = Z(!1), c = Z(!0), u = Z(!1), d = Z(!1), f = Z(!1), h = Z([]), g = Z(""), _ = Z(""), v = 0, y = null, b = !1, x = G(() => String(n.collectionId || "").trim()), S = G(() => String(n.collectionName || "").trim()), C = G(() => !!x.value), w = G(() => !c.value || d.value), T = G(() => c.value && u.value), D = G(() => `${Math.max(1, Math.min(i.value.length, 6)) * 48}px`);
-		function k() {
+		let n = _h(), r = Z(null), i = Z([]), a = Z(!1), o = Z(""), s = Z(!1), c = Z(!0), l = Z(!1), u = Z(!1), d = Z(!1), f = Z([]), g = Z(""), _ = Z(""), v = 0, y = null, b = !1, x = G(() => String(n.collectionId || "").trim()), S = G(() => String(n.collectionName || "").trim()), C = G(() => !!x.value), w = G(() => !c.value || u.value), T = G(() => c.value && l.value), D = G(() => `${Math.max(1, Math.min(i.value.length, 6)) * 48}px`);
+		function A() {
 			let e = r.value;
 			return !!e && String(e.style.display || "").toLowerCase() !== "none";
 		}
 		function j({ collectionId: e = x.value, collectionName: t = S.value, close: n = !0, reload: r = !0 } = {}) {
 			try {
-				window.dispatchEvent(new CustomEvent(hy, { detail: {
+				window.dispatchEvent(new CustomEvent(Sy, { detail: {
 					collectionId: String(e || ""),
 					collectionName: String(t || ""),
 					close: n !== !1,
@@ -19721,19 +19959,19 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 		}
 		function M(e) {
 			try {
-				return ot(e) || "";
+				return st(e) || "";
 			} catch (e) {
 				return console.debug?.(e), "";
 			}
 		}
 		async function N() {
-			if (!Uv()) return {
+			if (!Xv()) return {
 				enabled: !1,
 				vectorAvailable: !1,
 				vectorDisabled: !1
 			};
 			try {
-				let e = await p(), t = !e?.ok && (String(e?.code || "").toUpperCase() === "SERVICE_UNAVAILABLE" || /vector search is not enabled/i.test(String(e?.error || "")));
+				let e = await xe(), t = !e?.ok && (String(e?.code || "").toUpperCase() === "SERVICE_UNAVAILABLE" || /vector search is not enabled/i.test(String(e?.error || "")));
 				return {
 					enabled: !0,
 					vectorAvailable: !!(e?.ok && e?.data?.total > 0),
@@ -19755,21 +19993,21 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			}
 			return t;
 		}
-		async function te() {
+		async function P() {
 			let e = ++v;
 			a.value = !0, s.value = !0, o.value = "", g.value = "";
 			try {
-				let [t, n] = await Promise.all([ae(), N()]);
+				let [t, n] = await Promise.all([re(), N()]);
 				if (e !== v) return;
-				t?.ok ? i.value = Array.isArray(t?.data) ? t.data : [] : (o.value = String(t?.error || R("msg.failedLoadCollections", "Failed to load collections")), i.value = []), c.value = !!n.enabled, u.value = !!n.vectorAvailable, d.value = !!n.vectorDisabled, u.value || (h.value = [], f.value = !1);
+				t?.ok ? i.value = Array.isArray(t?.data) ? t.data : [] : (o.value = String(t?.error || L("msg.failedLoadCollections", "Failed to load collections")), i.value = []), c.value = !!n.enabled, l.value = !!n.vectorAvailable, u.value = !!n.vectorDisabled, l.value || (f.value = [], d.value = !1);
 			} catch (t) {
 				if (e !== v) return;
-				console.debug?.(t), o.value = R("msg.failedLoadCollections", "Failed to load collections"), i.value = [];
+				console.debug?.(t), o.value = L("msg.failedLoadCollections", "Failed to load collections"), i.value = [];
 			} finally {
 				e === v && (a.value = !1, s.value = !1);
 			}
 		}
-		function ne(e, t) {
+		function te(e, t) {
 			return async (...n) => {
 				if (!_.value) {
 					_.value = e;
@@ -19781,29 +20019,29 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				}
 			};
 		}
-		let P = ne("create", async () => {
-			let e = await Et(R("dialog.createCollection", "Create collection"), R("dialog.collectionPlaceholder", "Collection name"));
+		let ne = te("create", async () => {
+			let e = await Et(L("dialog.createCollection", "Create collection"), L("dialog.collectionPlaceholder", "Collection name"));
 			if (!e) return;
-			let t = Rv(e);
+			let t = Gv(e);
 			if (!t) {
-				A(R("toast.invalidCollectionName", "Invalid collection name"), "error");
+				k(L("toast.invalidCollectionName", "Invalid collection name"), "error");
 				return;
 			}
 			let n = await E(t);
 			if (!n?.ok) {
-				A(n?.error || R("toast.failedCreateCollection", "Failed to create collection"), "error");
+				k(n?.error || L("toast.failedCreateCollection", "Failed to create collection"), "error");
 				return;
 			}
 			j({
 				collectionId: String(n?.data?.id || ""),
 				collectionName: String(n?.data?.name || t)
 			});
-		}), F = ne("exit", async () => {
+		}), F = te("exit", async () => {
 			j({
 				collectionId: "",
 				collectionName: ""
 			});
-		}), re = ne("open", async (e) => {
+		}), ie = te("open", async (e) => {
 			let t = String(e?.id || ""), n = String(e?.name || t);
 			if (t) {
 				if (t === x.value) {
@@ -19819,12 +20057,12 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					collectionName: n
 				});
 			}
-		}), ie = ne("delete", async (e) => {
+		}), ae = te("delete", async (e) => {
 			let t = String(e?.id || ""), n = String(e?.name || t);
-			if (!t || !await Gt(R("dialog.deleteCollection", "Delete collection \"{name}\"?", { name: n }))) return;
+			if (!t || !await Gt(L("dialog.deleteCollection", "Delete collection \"{name}\"?", { name: n }))) return;
 			let r = await O(t);
 			if (!r?.ok) {
-				A(r?.error || R("toast.failedDeleteCollection", "Failed to delete collection"), "error");
+				k(r?.error || L("toast.failedDeleteCollection", "Failed to delete collection"), "error");
 				return;
 			}
 			if (t === x.value) {
@@ -19834,37 +20072,37 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				});
 				return;
 			}
-			await te();
+			await P();
 		});
 		async function oe(e) {
 			let t = String(e?.label || "").trim();
 			if (!t) return;
 			let n = await E(t);
 			if (!n?.ok) {
-				A(n?.error || R("toast.failedCreateSmartCollection", "Failed to create smart collection"), "error");
+				k(n?.error || L("toast.failedCreateSmartCollection", "Failed to create smart collection"), "error");
 				return;
 			}
 			let r = String(n?.data?.id || "");
 			if (!r) return;
-			let i = await l(String(e?.query || ""), 50);
+			let i = await m(String(e?.query || ""), 50);
 			if (i?.ok && Array.isArray(i?.data) && i.data.length > 0) {
-				let e = Bv(i.data), n = e.assets;
+				let e = qv(i.data), n = e.assets;
 				if (e.missingIds.length) {
-					let t = await Vv(e.missingIds);
+					let t = await Jv(e.missingIds);
 					t.ok && Array.isArray(t.data) && (n = ee(n, t.data));
 				}
 				if (n.length) {
-					let e = await m(r, n);
+					let e = await h(r, n);
 					if (!e?.ok) {
-						A(e?.error || R("toast.failedAddAssetsToSmartCollection", "Failed to add assets to smart collection"), "error");
+						k(e?.error || L("toast.failedAddAssetsToSmartCollection", "Failed to add assets to smart collection"), "error");
 						return;
 					}
-					A(R("toast.smartCollectionCreated", "Smart collection \"{name}\" created with {count} assets!", {
+					k(L("toast.smartCollectionCreated", "Smart collection \"{name}\" created with {count} assets!", {
 						name: t,
 						count: Number(e?.data?.added || n.length || 0)
 					}), "success", 3e3);
-				} else A(R("toast.smartCollectionEmpty", "Collection \"{name}\" created but no matching assets found. Index more assets first.", { name: t }), "info", 3e3);
-			} else A(R("toast.smartCollectionEmpty", "Collection \"{name}\" created but no matching assets found. Index more assets first.", { name: t }), "info", 3e3);
+				} else k(L("toast.smartCollectionEmpty", "Collection \"{name}\" created but no matching assets found. Index more assets first.", { name: t }), "info", 3e3);
+			} else k(L("toast.smartCollectionEmpty", "Collection \"{name}\" created but no matching assets found. Index more assets first.", { name: t }), "info", 3e3);
 			j({
 				collectionId: r,
 				collectionName: t
@@ -19878,78 +20116,78 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				try {
 					await oe(e);
 				} catch (e) {
-					console.error("[Majoor] Smart collection creation failed:", e), A(R("toast.failedCreateSmartCollection", "Failed to create smart collection"), "error");
+					console.error("[Majoor] Smart collection creation failed:", e), k(L("toast.failedCreateSmartCollection", "Failed to create smart collection"), "error");
 				} finally {
 					_.value === t && (_.value = "");
 				}
 			}
 		}
-		async function I() {
-			if (!(f.value || _.value)) {
-				f.value = !0, g.value = "", h.value = [];
+		async function ce() {
+			if (!(d.value || _.value)) {
+				d.value = !0, g.value = "", f.value = [];
 				try {
-					let e = await be(8);
+					let e = await p(8);
 					if (!e?.ok || !Array.isArray(e?.data) || !e.data.length) {
-						A(R("toast.noGroupsFoundIndexFirst", "No groups found. Index more assets first."), "info", 3e3);
+						k(L("toast.noGroupsFoundIndexFirst", "No groups found. Index more assets first."), "info", 3e3);
 						return;
 					}
-					h.value = e.data.map((e) => ({
+					f.value = e.data.map((e) => ({
 						...e,
-						_label: Hv(e)
+						_label: Yv(e)
 					}));
 				} catch (e) {
-					console.error("[Majoor] Discover groups failed:", e), g.value = R("toast.clusterAnalysisFailed", "Cluster analysis failed"), A(R("toast.clusterAnalysisFailed", "Cluster analysis failed"), "error");
+					console.error("[Majoor] Discover groups failed:", e), g.value = L("toast.clusterAnalysisFailed", "Cluster analysis failed"), k(L("toast.clusterAnalysisFailed", "Cluster analysis failed"), "error");
 				} finally {
-					f.value = !1;
+					d.value = !1;
 				}
 			}
 		}
-		async function ce(e) {
+		async function le(e) {
 			let t = `cluster:${String(e?.cluster_id ?? "")}`;
 			if (!_.value) {
 				_.value = t;
 				try {
-					let t = String(e?._label || Hv(e) || "").trim();
+					let t = String(e?._label || Yv(e) || "").trim();
 					if (!t) return;
 					let n = await E(t);
 					if (!n?.ok) {
-						A(n?.error || R("toast.failedCreateCollection", "Failed to create collection"), "error");
+						k(n?.error || L("toast.failedCreateCollection", "Failed to create collection"), "error");
 						return;
 					}
 					let r = String(n?.data?.id || ""), i = Array.isArray(e?.all_asset_ids) ? e.all_asset_ids : [];
 					if (r && i.length) {
-						let e = await Vv(i);
+						let e = await Jv(i);
 						if (!e.ok) {
-							A(e.error || R("toast.failedLoadClusterAssets", "Failed to load cluster assets"), "error");
+							k(e.error || L("toast.failedLoadClusterAssets", "Failed to load cluster assets"), "error");
 							return;
 						}
-						let n = await m(r, e.data || []);
+						let n = await h(r, e.data || []);
 						if (!n?.ok) {
-							A(n?.error || R("toast.failedAddAssetsToCollection", "Failed to add assets to collection"), "error");
+							k(n?.error || L("toast.failedAddAssetsToCollection", "Failed to add assets to collection"), "error");
 							return;
 						}
-						A(R("toast.collectionCreatedWithAssets", "Collection \"{name}\" created with {count} assets!", {
+						k(L("toast.collectionCreatedWithAssets", "Collection \"{name}\" created with {count} assets!", {
 							name: t,
 							count: Number(n?.data?.added || e.data?.length || 0)
 						}), "success", 3e3);
-					} else A(R("toast.collectionCreatedNamed", "Collection \"{name}\" created.", { name: t }), "success", 2200);
+					} else k(L("toast.collectionCreatedNamed", "Collection \"{name}\" created.", { name: t }), "success", 2200);
 					j({
 						collectionId: r,
 						collectionName: t
 					});
 				} catch (e) {
-					console.error("[Majoor] Cluster collection creation failed:", e), A(R("toast.failedCreateCollection", "Failed to create collection"), "error");
+					console.error("[Majoor] Cluster collection creation failed:", e), k(L("toast.failedCreateCollection", "Failed to create collection"), "error");
 				} finally {
 					_.value === t && (_.value = "");
 				}
 			}
 		}
-		function le() {
-			let e = k();
-			e && !b && te().catch(() => {}), b = e;
+		function ue() {
+			let e = A();
+			e && !b && P().catch(() => {}), b = e;
 		}
 		return fr(() => {
-			le(), !(typeof MutationObserver > "u" || !r.value) && (y = new MutationObserver(() => le()), y.observe(r.value, {
+			ue(), !(typeof MutationObserver > "u" || !r.value) && (y = new MutationObserver(() => ue()), y.observe(r.value, {
 				attributes: !0,
 				attributeFilter: ["style"]
 			}));
@@ -19960,23 +20198,23 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				console.debug?.(e);
 			}
 			y = null;
-		}), t({ refresh: te }), (e, t) => {
+		}), t({ refresh: P }), (e, t) => {
 			let n = gr("MButton"), l = gr("MVirtualScroller");
 			return V(), Y("div", {
 				ref_key: "rootRef",
 				ref: r,
 				class: "mjr-popover mjr-collections-popover",
 				style: { display: "none" }
-			}, [U("div", Wv, [
+			}, [U("div", Zv, [
 				J(n, {
 					type: "button",
 					class: "mjr-menu-item",
 					severity: "secondary",
 					text: "",
 					disabled: _.value !== "",
-					onClick: K(P)
+					onClick: K(ne)
 				}, {
-					default: Q(() => [U("span", Gv, q(K(R)("ctx.createCollection", "Create collection")), 1), t[0] ||= U("i", { class: "pi pi-plus mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)]),
+					default: Q(() => [U("span", Qv, q(K(L)("ctx.createCollection", "Create collection")), 1), t[0] ||= U("i", { class: "pi pi-plus mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)]),
 					_: 1
 				}, 8, ["disabled", "onClick"]),
 				C.value ? (V(), nr(n, {
@@ -19988,11 +20226,11 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					disabled: _.value !== "",
 					onClick: K(F)
 				}, {
-					default: Q(() => [U("span", Kv, q(K(R)("ctx.exitCollection", "Exit collection")), 1), U("span", qv, [S.value ? (V(), Y("span", Jv, q(S.value), 1)) : W("", !0), t[1] ||= U("i", { class: "pi pi-times mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)])]),
+					default: Q(() => [U("span", $v, q(K(L)("ctx.exitCollection", "Exit collection")), 1), U("span", ey, [S.value ? (V(), Y("span", ty, q(S.value), 1)) : W("", !0), t[1] ||= U("i", { class: "pi pi-times mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)])]),
 					_: 1
 				}, 8, ["disabled", "onClick"])) : W("", !0),
 				t[9] ||= U("div", { class: "mjr-menu-divider" }, null, -1),
-				a.value ? (V(), Y("div", Yv, q(K(R)("label.loading", "Loading...")), 1)) : o.value ? (V(), Y("div", Xv, q(o.value), 1)) : i.value.length ? (V(), nr(l, {
+				a.value ? (V(), Y("div", ny, q(K(L)("label.loading", "Loading...")), 1)) : o.value ? (V(), Y("div", ry, q(o.value), 1)) : i.value.length ? (V(), nr(l, {
 					key: 4,
 					items: i.value,
 					"item-size": 48,
@@ -20000,15 +20238,15 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					"num-tolerated-items": 4,
 					class: "mjr-collections-virtual-list"
 				}, {
-					item: Q(({ item: e }) => [U("div", Qv, [J(n, {
+					item: Q(({ item: e }) => [U("div", ay, [J(n, {
 						type: "button",
 						class: X(["mjr-menu-item", { "is-active": x.value === String(e.id || "") }]),
 						severity: "secondary",
 						text: "",
 						disabled: _.value !== "",
-						onClick: (t) => K(re)(e)
+						onClick: (t) => K(ie)(e)
 					}, {
-						default: Q(() => [U("span", $v, q(e.name || e.id), 1), U("span", ey, [Number(e.count || 0) ? (V(), Y("span", ty, q(Number(e.count || 0)), 1)) : W("", !0), t[2] ||= U("i", { class: "pi pi-check mjr-menu-item-check" }, null, -1)])]),
+						default: Q(() => [U("span", oy, q(e.name || e.id), 1), U("span", sy, [Number(e.count || 0) ? (V(), Y("span", cy, q(Number(e.count || 0)), 1)) : W("", !0), t[2] ||= U("i", { class: "pi pi-check mjr-menu-item-check" }, null, -1)])]),
 						_: 2
 					}, 1032, [
 						"class",
@@ -20020,8 +20258,8 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 						severity: "secondary",
 						text: "",
 						disabled: _.value !== "",
-						title: K(R)("tooltip.deleteCollection", "Delete collection"),
-						onClick: pr((t) => K(ie)(e), ["stop", "prevent"])
+						title: K(L)("tooltip.deleteCollection", "Delete collection"),
+						onClick: pr((t) => K(ae)(e), ["stop", "prevent"])
 					}, {
 						default: Q(() => [...t[3] ||= [U("i", { class: "pi pi-trash" }, null, -1)]]),
 						_: 1
@@ -20031,13 +20269,13 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 						"onClick"
 					])])]),
 					_: 1
-				}, 8, ["items", "scroll-height"])) : (V(), Y("div", Zv, q(K(R)("msg.noCollections", "No collections yet")), 1)),
-				!s.value && w.value ? (V(), Y(H, { key: 5 }, [t[4] ||= U("div", { class: "mjr-menu-divider" }, null, -1), U("div", ny, q(c.value ? "AI Smart Collections are disabled (enable vector search env var)." : "AI Smart Collections are disabled in settings."), 1)], 64)) : W("", !0),
+				}, 8, ["items", "scroll-height"])) : (V(), Y("div", iy, q(K(L)("msg.noCollections", "No collections yet")), 1)),
+				!s.value && w.value ? (V(), Y(H, { key: 5 }, [t[4] ||= U("div", { class: "mjr-menu-divider" }, null, -1), U("div", ly, q(c.value ? "AI Smart Collections are disabled (enable vector search env var)." : "AI Smart Collections are disabled in settings."), 1)], 64)) : W("", !0),
 				!s.value && T.value ? (V(), Y(H, { key: 6 }, [
 					t[7] ||= U("div", { class: "mjr-menu-divider" }, null, -1),
-					U("div", ry, q(K(R)("label.smartSuggestions", "Smart Suggestions")), 1),
-					U("div", iy, q(K(R)("label.smartCollectionsHint", "Create collections from AI-detected themes")), 1),
-					(V(!0), Y(H, null, ar(K(Lv), (e) => (V(), nr(n, {
+					U("div", uy, q(K(L)("label.smartSuggestions", "Smart Suggestions")), 1),
+					U("div", dy, q(K(L)("label.smartCollectionsHint", "Create collections from AI-detected themes")), 1),
+					(V(!0), Y(H, null, ar(K(Wv), (e) => (V(), nr(n, {
 						key: e.key,
 						type: "button",
 						class: "mjr-menu-item mjr-menu-item--smart",
@@ -20046,48 +20284,48 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 						disabled: _.value !== "",
 						onClick: (t) => se(e)
 					}, {
-						default: Q(() => [U("span", ay, [U("i", { class: X(e.iconClass) }, null, 2), U("span", null, q(e.label), 1)]), t[5] ||= U("i", { class: "pi pi-plus mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)]),
+						default: Q(() => [U("span", fy, [U("i", { class: X(e.iconClass) }, null, 2), U("span", null, q(e.label), 1)]), t[5] ||= U("i", { class: "pi pi-plus mjr-menu-item-check mjr-menu-item-check--visible" }, null, -1)]),
 						_: 2
 					}, 1032, ["disabled", "onClick"]))), 128)),
 					t[8] ||= U("div", { class: "mjr-menu-divider" }, null, -1),
-					U("div", oy, q(K(R)("label.discoverGroups", "Discover Groups")), 1),
-					U("div", sy, q(K(R)("label.discoverGroupsHint", "AI clusters assets by visual similarity")), 1),
+					U("div", py, q(K(L)("label.discoverGroups", "Discover Groups")), 1),
+					U("div", my, q(K(L)("label.discoverGroupsHint", "AI clusters assets by visual similarity")), 1),
 					J(n, {
 						type: "button",
 						class: "mjr-menu-item mjr-menu-item--cluster",
 						severity: "secondary",
 						text: "",
-						disabled: f.value || _.value !== "",
-						onClick: I
+						disabled: d.value || _.value !== "",
+						onClick: ce
 					}, {
-						default: Q(() => [U("span", cy, [t[6] ||= U("i", { class: "pi pi-search" }, null, -1), U("span", null, q(f.value ? K(R)("label.analyzing", "Analyzing...") : K(R)("label.analyzeLibrary", "Analyze library")), 1)])]),
+						default: Q(() => [U("span", hy, [t[6] ||= U("i", { class: "pi pi-search" }, null, -1), U("span", null, q(d.value ? K(L)("label.analyzing", "Analyzing...") : K(L)("label.analyzeLibrary", "Analyze library")), 1)])]),
 						_: 1
 					}, 8, ["disabled"]),
-					g.value ? (V(), Y("div", ly, q(g.value), 1)) : W("", !0),
-					(V(!0), Y(H, null, ar(h.value, (e) => (V(), Y("div", {
+					g.value ? (V(), Y("div", gy, q(g.value), 1)) : W("", !0),
+					(V(!0), Y(H, null, ar(f.value, (e) => (V(), Y("div", {
 						key: e.cluster_id,
 						class: "mjr-cluster-row"
 					}, [
-						U("div", uy, [(V(!0), Y(H, null, ar(Array.isArray(e.sample_assets) ? e.sample_assets.slice(0, 3) : [], (t, n) => (V(), Y("img", {
+						U("div", _y, [(V(!0), Y(H, null, ar(Array.isArray(e.sample_assets) ? e.sample_assets.slice(0, 3) : [], (t, n) => (V(), Y("img", {
 							key: `${e.cluster_id}-${n}`,
 							class: "mjr-cluster-thumb",
 							src: M(t),
 							alt: String(t?.filename || e._label || ""),
 							loading: "lazy"
-						}, null, 8, dy))), 128))]),
-						U("div", fy, [U("div", {
+						}, null, 8, vy))), 128))]),
+						U("div", yy, [U("div", {
 							class: "mjr-cluster-name",
 							title: e._label
-						}, q(e._label), 9, py), U("div", my, q(Number(e.size || 0)) + " " + q(K(R)("label.assets", "assets")), 1)]),
+						}, q(e._label), 9, by), U("div", xy, q(Number(e.size || 0)) + " " + q(K(L)("label.assets", "assets")), 1)]),
 						J(n, {
 							type: "button",
 							class: "mjr-cluster-create-btn",
 							severity: "secondary",
 							disabled: _.value !== "",
-							title: K(R)("ctx.createCollection", "Create collection"),
-							onClick: (t) => ce(e)
+							title: K(L)("ctx.createCollection", "Create collection"),
+							onClick: (t) => le(e)
 						}, {
-							default: Q(() => [tr(q(_.value === `cluster:${String(e.cluster_id ?? "")}` ? K(R)("label.loading", "Loading...") : K(R)("label.create", "Create")), 1)]),
+							default: Q(() => [tr(q(_.value === `cluster:${String(e.cluster_id ?? "")}` ? K(L)("label.loading", "Loading...") : K(L)("label.create", "Create")), 1)]),
 							_: 2
 						}, 1032, [
 							"disabled",
@@ -20099,16 +20337,16 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			])], 512);
 		};
 	}
-}, _y = { class: "mjr-popover mjr-pinned-folders-popover mjr-popover--hidden" }, vy = {
+}, wy = { class: "mjr-popover mjr-pinned-folders-popover mjr-popover--hidden" }, Ty = {
 	key: 0,
 	class: "mjr-muted mjr-pinned-folders-empty"
-}, yy = {
+}, Ey = {
 	key: 1,
 	class: "mjr-muted mjr-pinned-folders-empty"
-}, by = { class: "mjr-pinned-folder-label" }, xy = {
+}, Dy = { class: "mjr-pinned-folder-label" }, Oy = {
 	key: 0,
 	class: "mjr-menu-item-hint mjr-pinned-folder-path"
-}, Sy = {
+}, ky = {
 	__name: "PinnedFoldersPopover",
 	setup(e, { expose: t }) {
 		let n = Z(null), r = Z([]), i = Z(!1), a = Z("No pinned folders"), o = Z("Loading..."), s = Z("Unpin folder"), c = Z(null), l = Z(null);
@@ -20140,12 +20378,12 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			setPinnedFoldersLoading: f
 		}), (e, t) => {
 			let c = gr("MButton");
-			return V(), Y("div", _y, [U("div", {
+			return V(), Y("div", wy, [U("div", {
 				ref_key: "menuRef",
 				ref: n,
 				class: "mjr-menu mjr-pinned-folders-menu",
 				role: "menu"
-			}, [i.value ? (V(), Y("div", vy, q(o.value), 1)) : r.value.length ? (V(!0), Y(H, { key: 2 }, ar(r.value, (e) => (V(), Y("div", {
+			}, [i.value ? (V(), Y("div", Ty, q(o.value), 1)) : r.value.length ? (V(!0), Y(H, { key: 2 }, ar(r.value, (e) => (V(), Y("div", {
 				key: e.id,
 				class: "mjr-pinned-folder-row"
 			}, [J(c, {
@@ -20155,7 +20393,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				severity: "secondary",
 				onClick: (t) => p(e)
 			}, {
-				default: Q(() => [U("span", by, q(e.label), 1), e.path ? (V(), Y("span", xy, q(e.path), 1)) : W("", !0)]),
+				default: Q(() => [U("span", Dy, q(e.label), 1), e.path ? (V(), Y("span", Oy, q(e.path), 1)) : W("", !0)]),
 				_: 2
 			}, 1032, ["onClick"]), J(c, {
 				type: "button",
@@ -20175,17 +20413,17 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				"title",
 				"aria-label",
 				"onClick"
-			])]))), 128)) : (V(), Y("div", yy, q(a.value), 1))], 512)]);
+			])]))), 128)) : (V(), Y("div", Ey, q(a.value), 1))], 512)]);
 		};
 	}
-}, Cy = {
+}, Ay = {
 	class: "mjr-popover mjr-custom-popover",
 	style: { display: "none" }
-}, wy = { class: "mjr-popover-row" }, Ty = { class: "mjr-popover-label" }, Ey = { class: "mjr-popover-row mjr-popover-row--actions" }, Dy = {
+}, jy = { class: "mjr-popover-row" }, My = { class: "mjr-popover-label" }, Ny = { class: "mjr-popover-row mjr-popover-row--actions" }, Py = {
 	__name: "CustomRootsPopover",
 	setup(e, { expose: t }) {
 		let n = Z([{
-			label: R("label.selectFolder", "Select folder..."),
+			label: L("label.selectFolder", "Select folder..."),
 			value: "",
 			disabled: !1
 		}]), r = Z(""), i = Z(!1), a = Z(null), o = Z(null), s = (e) => e?.$el || e || null, c = new EventTarget(), l = (e) => ({
@@ -20265,7 +20503,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			}
 		}), (e, t) => {
 			let s = gr("MSelect"), c = gr("MButton");
-			return V(), Y("div", Cy, [U("div", wy, [U("div", Ty, q(K(R)("label.folder")), 1), J(s, {
+			return V(), Y("div", Ay, [U("div", jy, [U("div", My, q(K(L)("label.folder")), 1), J(s, {
 				class: "mjr-select",
 				"model-value": r.value,
 				options: n.value,
@@ -20277,14 +20515,14 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				"model-value",
 				"options",
 				"disabled"
-			])]), U("div", Ey, [J(c, {
+			])]), U("div", Ny, [J(c, {
 				ref_key: "customAddBtnRef",
 				ref: a,
 				type: "button",
 				class: "mjr-btn",
 				severity: "secondary"
 			}, {
-				default: Q(() => [tr(q(K(R)("btn.add")), 1)]),
+				default: Q(() => [tr(q(K(L)("btn.add")), 1)]),
 				_: 1
 			}, 512), J(c, {
 				ref_key: "customRemoveBtnRef",
@@ -20294,15 +20532,15 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				severity: "secondary",
 				disabled: ""
 			}, {
-				default: Q(() => [tr(q(K(R)("btn.remove")), 1)]),
+				default: Q(() => [tr(q(K(L)("btn.remove")), 1)]),
 				_: 1
 			}, 512)])]);
 		};
 	}
-}, Oy = ["aria-label"], ky = { class: "mjr-messages-head" }, Ay = { class: "mjr-messages-actions" }, jy = ["title"], My = { class: "mjr-messages-star-label" }, Ny = {
+}, Fy = ["aria-label"], Iy = { class: "mjr-messages-head" }, Ly = { class: "mjr-messages-actions" }, Ry = ["title"], zy = { class: "mjr-messages-star-label" }, By = {
 	class: "mjr-messages-tabs",
 	role: "tablist"
-}, Py = { class: "mjr-messages-panels" }, Fy = { class: "mjr-messages-empty" }, Iy = "https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager", Ly = {
+}, Vy = { class: "mjr-messages-panels" }, Hy = { class: "mjr-messages-empty" }, Uy = "https://github.com/MajoorWaldi/ComfyUI-Majoor-AssetsManager", Wy = {
 	__name: "MessagePopover",
 	setup(e, { expose: t }) {
 		let n = Z(null), r = Z(null), i = Z(null), a = Z(null), o = Z(null), s = Z(null), c = Z(null), l = Z(null), u = Z(null), d = Z(null), f = Z(null), p = (e) => e?.$el || e || null;
@@ -20346,7 +20584,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				class: "mjr-popover mjr-messages-popover",
 				id: "mjr-messages-popover",
 				role: "dialog",
-				"aria-label": K(R)("label.messages", "Messages"),
+				"aria-label": K(L)("label.messages", "Messages"),
 				"aria-hidden": "true",
 				tabindex: "-1",
 				style: { display: "none" }
@@ -20367,31 +20605,31 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				}
 			}, {
 				default: Q(() => [
-					U("div", ky, [U("div", {
+					U("div", Iy, [U("div", {
 						ref_key: "titleRef",
 						ref: n,
 						class: "mjr-messages-title"
-					}, q(K(R)("label.messages", "Messages")), 513), U("div", Ay, [U("a", {
-						href: Iy,
+					}, q(K(L)("label.messages", "Messages")), 513), U("div", Ly, [U("a", {
+						href: Uy,
 						target: "_blank",
 						rel: "noopener noreferrer",
 						class: "mjr-btn mjr-messages-star-link",
-						title: K(R)("tooltip.starGithub", "Open GitHub and give a star")
+						title: K(L)("tooltip.starGithub", "Open GitHub and give a star")
 					}, [t[0] ||= U("span", {
 						class: "mjr-messages-star-icon",
 						"aria-hidden": "true"
-					}, "★", -1), U("span", My, q(K(R)("btn.giveStar", "Give a star")), 1)], 8, jy), J(p, {
+					}, "★", -1), U("span", zy, q(K(L)("btn.giveStar", "Give a star")), 1)], 8, Ry), J(p, {
 						ref_key: "markReadBtnRef",
 						ref: r,
 						type: "button",
 						class: "mjr-btn mjr-messages-mark-read-btn",
 						severity: "secondary",
-						title: K(R)("tooltip.markMessagesRead", "Mark all messages as read")
+						title: K(L)("tooltip.markMessagesRead", "Mark all messages as read")
 					}, {
-						default: Q(() => [tr(q(K(R)("btn.markAllRead", "Mark all read")), 1)]),
+						default: Q(() => [tr(q(K(L)("btn.markAllRead", "Mark all read")), 1)]),
 						_: 1
 					}, 8, ["title"])])]),
-					U("div", Ny, [
+					U("div", By, [
 						J(p, {
 							ref_key: "messageTabBtnRef",
 							ref: i,
@@ -20404,7 +20642,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 							"aria-controls": "mjr-messages-panel",
 							id: "mjr-messages-tab"
 						}, {
-							default: Q(() => [U("span", null, q(K(R)("label.messages", "Messages")), 1), U("span", {
+							default: Q(() => [U("span", null, q(K(L)("label.messages", "Messages")), 1), U("span", {
 								ref_key: "messageTabBadgeRef",
 								ref: a,
 								class: "mjr-tab-count-badge",
@@ -20426,7 +20664,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 							id: "mjr-history-tab"
 						}, {
 							default: Q(() => [
-								U("span", null, q(K(R)("label.toastHistory", "History")), 1),
+								U("span", null, q(K(L)("label.toastHistory", "History")), 1),
 								U("span", {
 									ref_key: "historyTabCountRef",
 									ref: c,
@@ -20456,11 +20694,11 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 							"aria-controls": "mjr-shortcuts-panel",
 							id: "mjr-shortcuts-tab"
 						}, {
-							default: Q(() => [tr(q(K(R)("msg.shortcuts.title", "Shortcut Guide")), 1)]),
+							default: Q(() => [tr(q(K(L)("msg.shortcuts.title", "Shortcut Guide")), 1)]),
 							_: 1
 						}, 512)
 					]),
-					U("div", Py, [
+					U("div", Vy, [
 						U("div", {
 							ref_key: "messageListRef",
 							ref: u,
@@ -20468,7 +20706,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 							id: "mjr-messages-panel",
 							role: "tabpanel",
 							"aria-labelledby": "mjr-messages-tab"
-						}, [U("div", Fy, q(K(R)("msg.noMessages", "No messages for now.")), 1)], 512),
+						}, [U("div", Hy, q(K(L)("msg.noMessages", "No messages for now.")), 1)], 512),
 						U("div", {
 							ref_key: "historyPanelRef",
 							ref: d,
@@ -20490,13 +20728,13 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					])
 				]),
 				_: 1
-			})], 8, Oy);
+			})], 8, Fy);
 		};
 	}
-}, Ry = { class: "mjr-am-header-row" }, zy = { class: "mjr-am-header-left" }, By = { class: "mjr-am-header-title" }, Vy = ["data-mjr-version-channel", "title"], Hy = { class: "mjr-tabs" }, Uy = { class: "mjr-am-header-tools" }, Wy = {
+}, Gy = { class: "mjr-am-header-row" }, Ky = { class: "mjr-am-header-left" }, qy = { class: "mjr-am-header-title" }, Jy = ["data-mjr-version-channel", "title"], Yy = { class: "mjr-tabs" }, Xy = { class: "mjr-am-header-tools" }, Zy = {
 	class: "mjr-popover-anchor",
 	style: { display: "none" }
-}, Gy = { class: "mjr-popover-anchor" }, Ky = { class: "mjr-popover-anchor" }, qy = { class: "mjr-popover-anchor" }, Jy = { class: "mjr-popover-anchor" }, Yy = { class: "mjr-popover-anchor" }, Xy = "mjr-am-version-badge-label", Zy = "V", Qy = {
+}, Qy = { class: "mjr-popover-anchor" }, $y = { class: "mjr-popover-anchor" }, eb = { class: "mjr-popover-anchor" }, tb = { class: "mjr-popover-anchor" }, nb = { class: "mjr-popover-anchor" }, rb = "mjr-am-version-badge-label", ib = "V", ab = {
 	__name: "HeaderSection",
 	setup(e, { expose: n }) {
 		let r = null;
@@ -20527,17 +20765,17 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			}
 			return "";
 		}
-		let c = {
+		let s = {
 			name_asc: "pi pi-sort-alpha-down",
 			name_desc: "pi pi-sort-alpha-up",
 			mtime_asc: "pi pi-sort-amount-up-alt",
 			rating_desc: "pi pi-star-fill",
 			size_desc: "pi pi-sort-numeric-down-alt",
 			size_asc: "pi pi-sort-numeric-up-alt"
-		}, l = uh(), u = o() === "nightly", d = Z(null), f = Z(null), p = Z(null), m = Z(null), h = Z(null), g = Z(null), _ = Z(null), v = Z(null), y = Z(null), b = Z(null), x = Z(null), S = Z(null), C = Z(null), w = Z(null), T = Z(null), E = Z(null), D = Z(null), O = Z(null), k = Z(null), j = Z(null), M = Z(null), N = Z(null), ee = Z(null), te = Z(null), ne = Z(null), P = Z(null), F = (e) => e?.$el || e || null, re = Z(u ? "nightly" : "v?"), ie = Z(u ? "nightly" : "stable"), ae = Z(!1), oe = Z(!1), se = Z(!1), ce = G(() => c[l.sort] ?? "pi pi-sort-amount-down"), le = G(() => String(l.viewScope || l.scope || "output").toLowerCase()), de = G(() => le.value === "similar" || Array.isArray(l.similarResults) && l.similarResults.length > 0 || !!l.similarTitle), fe = G(() => {
-			let e = String(l.similarSourceAssetId || "");
+		}, c = _h(), l = o() === "nightly", u = Z(null), f = Z(null), p = Z(null), m = Z(null), h = Z(null), g = Z(null), _ = Z(null), v = Z(null), y = Z(null), b = Z(null), x = Z(null), S = Z(null), C = Z(null), w = Z(null), T = Z(null), E = Z(null), D = Z(null), O = Z(null), A = Z(null), j = Z(null), M = Z(null), N = Z(null), ee = Z(null), P = Z(null), te = Z(null), ne = Z(null), F = (e) => e?.$el || e || null, re = Z(l ? "nightly" : "v?"), ie = Z(l ? "nightly" : "stable"), ae = Z(!1), se = Z(!1), ce = Z(!1), le = G(() => s[c.sort] ?? "pi pi-sort-amount-down"), de = G(() => String(c.viewScope || c.scope || "output").toLowerCase()), fe = G(() => de.value === "similar" || Array.isArray(c.similarResults) && c.similarResults.length > 0 || !!c.similarTitle), pe = G(() => {
+			let e = String(c.similarSourceAssetId || "");
 			return e.startsWith("stack:") || e.startsWith("duplicates:") || e.startsWith("group:") || e.startsWith("node:") ? "group" : "similar";
-		}), pe = G(() => fe.value === "group" ? R("tab.group", "Group") : R("tab.similar", "Similar")), me = G(() => fe.value === "group" ? R("tooltip.tab.group", "Browse current grouped assets") : R("tooltip.tab.similar", "Browse current similar findings")), he = {
+		}), me = G(() => pe.value === "group" ? L("tab.group", "Group") : L("tab.similar", "Similar")), he = G(() => pe.value === "group" ? L("tooltip.tab.group", "Browse current grouped assets") : L("tooltip.tab.similar", "Browse current similar findings")), ge = {
 			get tabAll() {
 				return F(M.value);
 			},
@@ -20548,35 +20786,35 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				return F(ee.value);
 			},
 			get tabCustom() {
-				return F(te.value);
+				return F(P.value);
 			},
 			get tabWorkflow() {
-				return F(ne.value);
+				return F(te.value);
 			},
 			get tabSimilar() {
-				return F(P.value);
+				return F(ne.value);
 			}
-		}, ge = G(() => ({
+		}, _e = G(() => ({
 			position: "relative",
 			fontSize: "10px",
-			opacity: oe.value ? "1" : "0.6",
+			opacity: se.value ? "1" : "0.6",
 			marginLeft: "6px",
 			padding: "2px 5px",
 			borderRadius: "4px",
-			background: oe.value ? "rgba(255,255,255,0.15)" : "rgba(255,255,255,0.08)",
+			background: se.value ? "rgba(255,255,255,0.15)" : "rgba(255,255,255,0.08)",
 			color: "inherit",
 			textDecoration: "none",
 			cursor: "pointer",
 			transition: "opacity 0.2s, background 0.2s",
 			verticalAlign: "middle"
-		})), _e = G(() => se.value ? R("tooltip.closeMFV", "Close Majoor Floating Viewer") : R("tooltip.openMFV", "Open Majoor Floating Viewer")), ve = G(() => "pi pi-eye"), ye = G(() => R("tooltip.openMajoorSettings", "Open Majoor Assets Manager settings"));
-		async function be() {
-			let e = Fe();
+		})), ve = G(() => ce.value ? L("tooltip.closeMFV", "Close Majoor Floating Viewer") : L("tooltip.openMFV", "Open Majoor Floating Viewer")), ye = G(() => "pi pi-eye"), be = G(() => L("tooltip.openMajoorSettings", "Open Majoor Assets Manager settings"));
+		async function xe() {
+			let e = Ie();
 			if (!e || typeof e != "object") {
-				A(R("toast.workflowSerializeFailed", "Could not read the current ComfyUI workflow."), "error");
+				k(L("toast.workflowSerializeFailed", "Could not read the current ComfyUI workflow."), "error");
 				return;
 			}
-			let n = await x_({
+			let n = await O_({
 				workflow: e,
 				name: String(e?.name || e?.title || "workflow").trim()
 			}), r = String(n?.name || "").trim();
@@ -20591,32 +20829,32 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				notes: n?.notes || ""
 			}, { timeoutMs: 3e4 });
 			if (!i?.ok) {
-				A(i?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+				k(i?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 				return;
 			}
-			A(R("toast.workflowSaved", "Workflow saved"), "success", 1800);
+			k(L("toast.workflowSaved", "Workflow saved"), "success", 1800);
 			try {
 				window.dispatchEvent(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-save" } }));
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		async function xe() {
+		async function Se() {
 			let e = "";
 			try {
-				let t = await ue(lt.BROWSE_FOLDER, {});
+				let t = await ue(B.BROWSE_FOLDER, {});
 				t?.ok && (e = String(t?.data?.path || "").trim());
 			} catch (e) {
 				console.debug?.(e);
 			}
 			if (!e) {
-				let t = await Et(R("dialog.enterWorkflowRootPath", "Workflow root folder"), "", R("tab.workflow", "Workflow"));
+				let t = await Et(L("dialog.enterWorkflowRootPath", "Workflow root folder"), "", L("tab.workflow", "Workflow"));
 				e = String(t || "").trim();
 			}
 			if (!e) return;
-			let t = await s(e, { timeoutMs: 3e4 });
+			let t = await d(e, { timeoutMs: 3e4 });
 			if (!t?.ok) {
-				A(t?.error || R("toast.failedSetWorkflowRoots", "Failed to set workflow roots"), "error");
+				k(t?.error || L("toast.failedSetWorkflowRoots", "Failed to set workflow roots"), "error");
 				return;
 			}
 			try {
@@ -20628,9 +20866,9 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			} catch (e) {
 				console.debug?.(e);
 			}
-			A(R("toast.workflowRootsSaved", "Workflow roots saved"), "success", 1800);
+			k(L("toast.workflowRootsSaved", "Workflow roots saved"), "success", 1800);
 		}
-		function Se() {
+		function Ce() {
 			let e = C.value;
 			if (e) try {
 				e.value = "", e.click();
@@ -20638,7 +20876,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				console.debug?.(e);
 			}
 		}
-		function Ce(e) {
+		function we(e) {
 			return new Promise((t, n) => {
 				let r = new FileReader();
 				r.onload = () => {
@@ -20650,14 +20888,14 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				}, r.onerror = () => n(r.error || /* @__PURE__ */ Error("Failed to read workflow file")), r.readAsText(e, "utf-8");
 			});
 		}
-		async function we(e) {
+		async function Te(e) {
 			let n = Array.from(e?.target?.files || []).filter((e) => String(e?.name || "").toLowerCase().endsWith(".json"));
 			if (!n.length) return;
 			let r = 0;
 			for (let e of n) try {
-				let n = await Ce(e);
+				let n = await we(e);
 				if (!n || typeof n != "object") {
-					A(R("toast.workflowImportInvalid", "Invalid workflow JSON."), "error");
+					k(L("toast.workflowImportInvalid", "Invalid workflow JSON."), "error");
 					continue;
 				}
 				let i = await t({
@@ -20665,15 +20903,15 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					name: String(e.name || "workflow.json").replace(/\.json$/i, "").trim() || "workflow"
 				}, { timeoutMs: 3e4 });
 				if (!i?.ok) {
-					A(i?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+					k(i?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 					continue;
 				}
 				r += 1;
 			} catch (e) {
-				console.debug?.(e), A(R("toast.workflowImportInvalid", "Invalid workflow JSON."), "error");
+				console.debug?.(e), k(L("toast.workflowImportInvalid", "Invalid workflow JSON."), "error");
 			}
 			if (r > 0) {
-				A(r === 1 ? R("toast.workflowImported", "Workflow imported") : R("toast.workflowsImported", "{count} workflows imported", { count: r }), "success", 1800);
+				k(r === 1 ? L("toast.workflowImported", "Workflow imported") : L("toast.workflowsImported", "{count} workflows imported", { count: r }), "success", 1800);
 				try {
 					window.dispatchEvent(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-import" } }));
 				} catch (e) {
@@ -20681,106 +20919,106 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				}
 			}
 		}
-		function Te(e, { channel: t = "" } = {}) {
+		function Ee(e, { channel: t = "" } = {}) {
 			re.value = String(e || ""), t && (ie.value = t);
 		}
-		function Ee(e) {
+		function De(e) {
 			i().then((t) => {
 				let n = ie.value.toLowerCase() === "nightly" || re.value.toLowerCase() === "nightly";
 				if (!e && !n) {
 					let e = (typeof t?.version == "string" ? t.version.trim() : "") || "";
-					e && Te(`v${e}`, { channel: "stable" });
+					e && Ee(`v${e}`, { channel: "stable" });
 				}
 			}).catch(() => {
 				r = null;
 			});
 		}
-		async function De(e) {
+		async function Oe(e) {
 			try {
-				let t = await I(lt.VERSION, { cache: "no-cache" });
+				let t = await oe(B.VERSION, { cache: "no-cache" });
 				if (!t?.ok) return;
 				let n = String(t.data?.version || "").trim();
 				if (a(n, String(t.data?.branch || "").trim().toLowerCase()) || e) {
-					Te("nightly", { channel: "nightly" });
+					Ee("nightly", { channel: "nightly" });
 					return;
 				}
-				n && Te(n.startsWith("v") ? n : `v${n}`, { channel: "stable" });
+				n && Ee(n.startsWith("v") ? n : `v${n}`, { channel: "stable" });
 			} catch {}
 		}
-		function Oe(e) {
+		function ke(e) {
 			let t = String(e?.channel || "").trim().toLowerCase(), n = String(e?.current || "").trim().toLowerCase(), r = String(e?.latest || "").trim().toLowerCase();
-			(t === "nightly" || n === "nightly" || r === "nightly") && Te("nightly", { channel: "nightly" }), ae.value = !!e?.available;
-		}
-		function ke() {
-			try {
-				zt(F(v.value), _e.value, Zy);
-			} catch (e) {
-				console.debug?.(e);
-			}
+			(t === "nightly" || n === "nightly" || r === "nightly") && Ee("nightly", { channel: "nightly" }), ae.value = !!e?.available;
 		}
 		function Ae() {
 			try {
-				if (typeof document > "u") return;
-				se.value = !!document.querySelector(".mjr-mfv.is-visible");
+				zt(F(v.value), ve.value, ib);
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		function je(e) {
-			se.value = !!e?.detail?.visible;
+		function je() {
+			try {
+				if (typeof document > "u") return;
+				ce.value = !!document.querySelector(".mjr-mfv.is-visible");
+			} catch (e) {
+				console.debug?.(e);
+			}
 		}
 		function Me(e) {
+			ce.value = !!e?.detail?.visible;
+		}
+		function Ne(e) {
 			try {
-				Oe(e?.detail);
+				ke(e?.detail);
 			} catch (e) {
 				console.debug?.(e);
 			}
-		}
-		function Ne() {
-			window.dispatchEvent(new CustomEvent(B.MFV_TOGGLE));
 		}
 		function Pe() {
+			window.dispatchEvent(new CustomEvent(z.MFV_TOGGLE));
+		}
+		function Fe() {
 			Jn();
 		}
-		function Ie() {
+		function Le() {
 			try {
-				typeof window < "u" && (window.removeEventListener(Qr, Me), window.removeEventListener(B.MFV_VISIBILITY_CHANGED, je));
+				typeof window < "u" && (window.removeEventListener(Qr, Ne), window.removeEventListener(z.MFV_VISIBILITY_CHANGED, Me));
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}
-		return ir(se, () => {
-			ke();
+		return ir(ce, () => {
+			Ae();
 		}), fr(async () => {
 			await or();
 			try {
-				Oe(gi());
+				ke(gi());
 			} catch (e) {
 				console.debug?.(e);
 			}
-			Ae(), ke(), Ee(u), De(u);
+			je(), Ae(), De(l), Oe(l);
 			try {
-				typeof window < "u" && (window.addEventListener(Qr, Me), window.addEventListener(B.MFV_VISIBILITY_CHANGED, je));
+				typeof window < "u" && (window.addEventListener(Qr, Ne), window.addEventListener(z.MFV_VISIBILITY_CHANGED, Me));
 			} catch (e) {
 				console.debug?.(e);
 			}
 			try {
-				d.value._mjrVersionUpdateCleanup = Ie;
+				u.value._mjrVersionUpdateCleanup = Le;
 			} catch (e) {
 				console.debug?.(e);
 			}
 		}), Or(() => {
-			Ie();
+			Le();
 		}), n({
 			isVueHeader: !0,
 			get header() {
-				return d.value;
+				return u.value;
 			},
 			get headerActions() {
 				return f.value;
 			},
 			get tabButtons() {
-				return he;
+				return ge;
 			},
 			get customMenuBtn() {
 				return F(p.value);
@@ -20804,16 +21042,16 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 				return F(b.value);
 			},
 			get customPopover() {
-				return k.value?.$el ?? null;
+				return A.value?.$el ?? null;
 			},
 			get customSelect() {
-				return k.value?.customSelect ?? null;
+				return A.value?.customSelect ?? null;
 			},
 			get customAddBtn() {
-				return k.value?.customAddBtn ?? null;
+				return A.value?.customAddBtn ?? null;
 			},
 			get customRemoveBtn() {
-				return k.value?.customRemoveBtn ?? null;
+				return A.value?.customRemoveBtn ?? null;
 			},
 			get filterPopover() {
 				return E.value?.$el ?? null;
@@ -20951,30 +21189,30 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			setSemanticEnabled(e) {
 				w.value?.setSemanticEnabled?.(e);
 			},
-			_headerDispose: Ie
+			_headerDispose: Le
 		}), (e, t) => {
 			let n = gr("MButton");
 			return V(), Y(H, null, [U("div", {
 				ref_key: "headerRef",
-				ref: d,
+				ref: u,
 				class: "mjr-am-header"
-			}, [U("div", Ry, [U("div", zy, [
+			}, [U("div", Gy, [U("div", Ky, [
 				t[2] ||= U("i", {
 					class: "mjr-am-header-icon pi pi-folder",
 					"aria-hidden": "true"
 				}, null, -1),
-				U("div", By, q(K(R)("manager.title")), 1),
+				U("div", qy, q(K(L)("manager.title")), 1),
 				U("a", {
 					href: "https://ko-fi.com/majoorwaldi",
 					target: "_blank",
 					rel: "noopener noreferrer",
 					class: "mjr-am-version-badge",
 					"data-mjr-version-channel": ie.value,
-					title: K(R)("tooltip.supportKofi"),
-					style: Cr(ge.value),
-					onMouseenter: t[0] ||= (e) => oe.value = !0,
-					onMouseleave: t[1] ||= (e) => oe.value = !1
-				}, [U("span", { class: X(Xy) }, q(re.value), 1), U("span", {
+					title: K(L)("tooltip.supportKofi"),
+					style: Cr(_e.value),
+					onMouseenter: t[0] ||= (e) => se.value = !0,
+					onMouseleave: t[1] ||= (e) => se.value = !1
+				}, [U("span", { class: X(rb) }, q(re.value), 1), U("span", {
 					"aria-hidden": "true",
 					style: Cr({
 						position: "absolute",
@@ -20988,97 +21226,97 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 						display: ae.value ? "block" : "none",
 						pointerEvents: "none"
 					})
-				}, null, 4)], 44, Vy)
+				}, null, 4)], 44, Jy)
 			]), U("div", {
 				ref_key: "headerActionsRef",
 				ref: f,
 				class: "mjr-am-header-actions"
-			}, [U("div", Hy, [
+			}, [U("div", Yy, [
 				J(n, {
 					ref_key: "tabAllRef",
 					ref: M,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "all" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "all" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "all",
-					title: K(R)("tooltip.tab.all")
+					title: K(L)("tooltip.tab.all")
 				}, {
-					default: Q(() => [tr(q(K(R)("tab.all")), 1)]),
+					default: Q(() => [tr(q(K(L)("tab.all")), 1)]),
 					_: 1
 				}, 8, ["class", "title"]),
 				J(n, {
 					ref_key: "tabInputsRef",
 					ref: N,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "input" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "input" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "input",
-					title: K(R)("tooltip.tab.input")
+					title: K(L)("tooltip.tab.input")
 				}, {
-					default: Q(() => [tr(q(K(R)("tab.input")), 1)]),
+					default: Q(() => [tr(q(K(L)("tab.input")), 1)]),
 					_: 1
 				}, 8, ["class", "title"]),
 				J(n, {
 					ref_key: "tabOutputsRef",
 					ref: ee,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "output" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "output" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "output",
-					title: K(R)("tooltip.tab.output")
+					title: K(L)("tooltip.tab.output")
 				}, {
-					default: Q(() => [tr(q(K(R)("tab.output")), 1)]),
+					default: Q(() => [tr(q(K(L)("tab.output")), 1)]),
 					_: 1
 				}, 8, ["class", "title"]),
 				J(n, {
 					ref_key: "tabCustomRef",
-					ref: te,
+					ref: P,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "custom" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "custom" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "custom",
-					title: K(R)("tooltip.tab.custom")
+					title: K(L)("tooltip.tab.custom")
 				}, {
-					default: Q(() => [tr(q(K(R)("tab.custom")), 1)]),
+					default: Q(() => [tr(q(K(L)("tab.custom")), 1)]),
 					_: 1
 				}, 8, ["class", "title"]),
 				J(n, {
 					ref_key: "tabWorkflowRef",
-					ref: ne,
+					ref: te,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "workflow" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "workflow" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "workflow",
-					title: K(R)("tooltip.tab.workflow", "Browse saved workflows")
+					title: K(L)("tooltip.tab.workflow", "Browse saved workflows")
 				}, {
-					default: Q(() => [tr(q(K(R)("tab.workflow", "Workflow")), 1)]),
+					default: Q(() => [tr(q(K(L)("tab.workflow", "Workflow")), 1)]),
 					_: 1
 				}, 8, ["class", "title"]),
 				J(n, {
 					ref_key: "tabSimilarRef",
-					ref: P,
+					ref: ne,
 					type: "button",
-					class: X(["mjr-tab", { "is-active": le.value === "similar" }]),
+					class: X(["mjr-tab", { "is-active": de.value === "similar" }]),
 					severity: "secondary",
 					text: "",
 					"data-scope": "similar",
-					style: Cr({ display: de.value ? "" : "none" }),
-					title: me.value
+					style: Cr({ display: fe.value ? "" : "none" }),
+					title: he.value
 				}, {
-					default: Q(() => [tr(q(pe.value), 1)]),
+					default: Q(() => [tr(q(me.value), 1)]),
 					_: 1
 				}, 8, [
 					"class",
 					"style",
 					"title"
 				])
-			]), U("div", Uy, [
-				le.value === "workflow" ? (V(), nr(n, {
+			]), U("div", Xy, [
+				de.value === "workflow" ? (V(), nr(n, {
 					key: 0,
 					ref_key: "saveWorkflowBtnRef",
 					ref: x,
@@ -21087,9 +21325,9 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.saveCurrentWorkflow", "Save current workflow"),
-					"aria-label": K(R)("tooltip.saveCurrentWorkflow", "Save current workflow"),
-					onClick: be
+					title: K(L)("tooltip.saveCurrentWorkflow", "Save current workflow"),
+					"aria-label": K(L)("tooltip.saveCurrentWorkflow", "Save current workflow"),
+					onClick: xe
 				}, {
 					default: Q(() => [...t[3] ||= [U("i", {
 						class: "pi pi-save",
@@ -21097,7 +21335,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					}, null, -1)]]),
 					_: 1
 				}, 8, ["title", "aria-label"])) : W("", !0),
-				le.value === "workflow" ? (V(), nr(n, {
+				de.value === "workflow" ? (V(), nr(n, {
 					key: 1,
 					ref_key: "pickWorkflowRootBtnRef",
 					ref: S,
@@ -21106,9 +21344,9 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.pickWorkflowRoot", "Pick saved workflow root"),
-					"aria-label": K(R)("tooltip.pickWorkflowRoot", "Pick saved workflow root"),
-					onClick: xe
+					title: K(L)("tooltip.pickWorkflowRoot", "Pick saved workflow root"),
+					"aria-label": K(L)("tooltip.pickWorkflowRoot", "Pick saved workflow root"),
+					onClick: Se
 				}, {
 					default: Q(() => [...t[4] ||= [U("i", {
 						class: "pi pi-folder-plus",
@@ -21116,16 +21354,16 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					}, null, -1)]]),
 					_: 1
 				}, 8, ["title", "aria-label"])) : W("", !0),
-				le.value === "workflow" ? (V(), nr(n, {
+				de.value === "workflow" ? (V(), nr(n, {
 					key: 2,
 					type: "button",
 					class: "mjr-icon-btn mjr-import-workflow-btn",
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.importWorkflow", "Import workflow"),
-					"aria-label": K(R)("tooltip.importWorkflow", "Import workflow"),
-					onClick: Se
+					title: K(L)("tooltip.importWorkflow", "Import workflow"),
+					"aria-label": K(L)("tooltip.importWorkflow", "Import workflow"),
+					onClick: Ce
 				}, {
 					default: Q(() => [...t[5] ||= [U("i", {
 						class: "pi pi-upload",
@@ -21140,9 +21378,9 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					accept: ".json,application/json",
 					multiple: "",
 					style: { display: "none" },
-					onChange: we
+					onChange: Te
 				}, null, 544),
-				U("div", Wy, [J(n, {
+				U("div", Zy, [J(n, {
 					ref_key: "customMenuBtnRef",
 					ref: p,
 					type: "button",
@@ -21150,32 +21388,32 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.browserFolders"),
-					"aria-label": K(R)("tooltip.browserFolders")
+					title: K(L)("tooltip.browserFolders"),
+					"aria-label": K(L)("tooltip.browserFolders")
 				}, {
 					default: Q(() => [...t[6] ||= [U("i", {
 						class: "pi pi-folder-open",
 						"aria-hidden": "true"
 					}, null, -1)]]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(Dy, {
+				}, 8, ["title", "aria-label"]), J(Py, {
 					ref_key: "customPopoverRef",
-					ref: k
+					ref: A
 				}, null, 512)]),
 				J(n, {
 					ref_key: "mfvBtnRef",
 					ref: v,
 					type: "button",
-					class: X(["mjr-icon-btn", { "mjr-mfv-btn-active": se.value }]),
+					class: X(["mjr-icon-btn", { "mjr-mfv-btn-active": ce.value }]),
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: _e.value,
-					"aria-label": _e.value,
-					onClick: Ne
+					title: ve.value,
+					"aria-label": ve.value,
+					onClick: Pe
 				}, {
 					default: Q(() => [U("i", {
-						class: X(ve.value),
+						class: X(ye.value),
 						"aria-hidden": "true"
 					}, null, 2)]),
 					_: 1
@@ -21184,7 +21422,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					"title",
 					"aria-label"
 				]),
-				U("div", Gy, [J(n, {
+				U("div", Qy, [J(n, {
 					ref_key: "messageBtnRef",
 					ref: y,
 					type: "button",
@@ -21192,8 +21430,8 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.openMessages", "Messages and updates"),
-					"aria-label": K(R)("tooltip.openMessages", "Messages and updates")
+					title: K(L)("tooltip.openMessages", "Messages and updates"),
+					"aria-label": K(L)("tooltip.openMessages", "Messages and updates")
 				}, {
 					default: Q(() => [...t[7] ||= [U("i", {
 						class: "pi pi-info-circle",
@@ -21204,7 +21442,7 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 						"aria-hidden": "true"
 					}, null, -1)]]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(Ly, {
+				}, 8, ["title", "aria-label"]), J(Wy, {
 					ref_key: "messagePopoverRef",
 					ref: j
 				}, null, 512)]),
@@ -21216,9 +21454,9 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: ye.value,
-					"aria-label": ye.value,
-					onClick: Pe
+					title: be.value,
+					"aria-label": be.value,
+					onClick: Fe
 				}, {
 					default: Q(() => [...t[8] ||= [U("i", {
 						class: "pi pi-cog",
@@ -21226,11 +21464,11 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					}, null, -1)]]),
 					_: 1
 				}, 8, ["title", "aria-label"])
-			])], 512)])], 512), J(L_, {
+			])], 512)])], 512), J(W_, {
 				ref_key: "searchBarRef",
 				ref: w
 			}, {
-				"filter-anchor": Q(() => [U("div", Ky, [J(n, {
+				"filter-anchor": Q(() => [U("div", $y, [J(n, {
 					ref_key: "filterBtnRef",
 					ref: m,
 					type: "button",
@@ -21238,19 +21476,19 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("label.filters"),
-					"aria-label": K(R)("label.filters")
+					title: K(L)("label.filters"),
+					"aria-label": K(L)("label.filters")
 				}, {
 					default: Q(() => [...t[9] ||= [U("i", {
 						class: "pi pi-filter",
 						"aria-hidden": "true"
 					}, null, -1)]]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(Fv, {
+				}, 8, ["title", "aria-label"]), J(Hv, {
 					ref_key: "filterPopoverRef",
 					ref: E
 				}, null, 512)])]),
-				"sort-anchor": Q(() => [U("div", qy, [J(n, {
+				"sort-anchor": Q(() => [U("div", eb, [J(n, {
 					ref_key: "sortBtnRef",
 					ref: h,
 					type: "button",
@@ -21258,19 +21496,19 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("label.sort"),
-					"aria-label": K(R)("label.sort")
+					title: K(L)("label.sort"),
+					"aria-label": K(L)("label.sort")
 				}, {
 					default: Q(() => [U("i", {
-						class: X(ce.value),
+						class: X(le.value),
 						"aria-hidden": "true"
 					}, null, 2)]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(B_, {
+				}, 8, ["title", "aria-label"]), J(q_, {
 					ref_key: "sortPopoverRef",
 					ref: T
 				}, null, 512)])]),
-				"collections-anchor": Q(() => [U("div", Jy, [J(n, {
+				"collections-anchor": Q(() => [U("div", tb, [J(n, {
 					ref_key: "collectionsBtnRef",
 					ref: g,
 					type: "button",
@@ -21278,19 +21516,19 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("label.collections"),
-					"aria-label": K(R)("label.collections")
+					title: K(L)("label.collections"),
+					"aria-label": K(L)("label.collections")
 				}, {
 					default: Q(() => [...t[10] ||= [U("i", {
 						class: "pi pi-bookmark",
 						"aria-hidden": "true"
 					}, null, -1)]]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(gy, {
+				}, 8, ["title", "aria-label"]), J(Cy, {
 					ref_key: "collectionsPopoverRef",
 					ref: D
 				}, null, 512)])]),
-				"pinned-folders-anchor": Q(() => [U("div", Yy, [J(n, {
+				"pinned-folders-anchor": Q(() => [U("div", nb, [J(n, {
 					ref_key: "pinnedFoldersBtnRef",
 					ref: _,
 					type: "button",
@@ -21298,15 +21536,15 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 					severity: "secondary",
 					text: "",
 					rounded: "",
-					title: K(R)("tooltip.pinnedFolders"),
-					"aria-label": K(R)("tooltip.pinnedFolders")
+					title: K(L)("tooltip.pinnedFolders"),
+					"aria-label": K(L)("tooltip.pinnedFolders")
 				}, {
 					default: Q(() => [...t[11] ||= [U("i", {
 						class: "pi pi-folder",
 						"aria-hidden": "true"
 					}, null, -1)]]),
 					_: 1
-				}, 8, ["title", "aria-label"]), J(Sy, {
+				}, 8, ["title", "aria-label"]), J(ky, {
 					ref_key: "pinnedFoldersPopoverRef",
 					ref: O
 				}, null, 512)])]),
@@ -21314,26 +21552,26 @@ var Wv = { class: "mjr-menu mjr-collections-menu" }, Gv = { class: "mjr-menu-ite
 			}, 512)], 64);
 		};
 	}
-}, $y = (e) => {
+}, ob = (e) => {
 	try {
 		return String(e ?? "");
 	} catch {
 		return "";
 	}
-}, eb = (e) => {
+}, sb = (e) => {
 	let t = String(e || "");
-	return R(t === "name_asc" ? "sort.nameAZ" : t === "name_desc" ? "sort.nameZA" : t === "mtime_asc" ? "sort.oldest" : "sort.newest");
-}, tb = (e) => {
+	return L(t === "name_asc" ? "sort.nameAZ" : t === "name_desc" ? "sort.nameZA" : t === "mtime_asc" ? "sort.oldest" : "sort.newest");
+}, cb = (e) => {
 	let t = String(e || "").toLowerCase();
-	return t === "similar" ? R("scope.similar", "Similar") : t === "custom" ? R("scope.customBrowser") : t === "workflow" ? R("scope.workflow", "Workflow") : R(t === "all" ? "tab.all" : t === "input" || t === "inputs" ? "scope.input" : "scope.output");
+	return t === "similar" ? L("scope.similar", "Similar") : t === "custom" ? L("scope.customBrowser") : t === "workflow" ? L("scope.workflow", "Workflow") : L(t === "all" ? "tab.all" : t === "input" || t === "inputs" ? "scope.input" : "scope.output");
 };
-function nb({ label: e, value: t, onClear: n } = {}) {
+function lb({ label: e, value: t, onClear: n } = {}) {
 	let r = document.createElement("div");
 	r.className = "mjr-context-pill";
 	let i = document.createElement("span");
 	if (i.className = "mjr-context-pill-text", i.textContent = t != null && String(t).length ? `${e}: ${String(t)}` : String(e || ""), r.appendChild(i), typeof n == "function") {
 		let t = document.createElement("button");
-		t.type = "button", t.className = "mjr-context-pill-x", t.title = R("tooltip.clearFilter", { label: e || R("label.filters") }), t.setAttribute("aria-label", R("tooltip.clearFilter", { label: e || R("label.filters") })), t.textContent = "x", t.addEventListener("click", (e) => {
+		t.type = "button", t.className = "mjr-context-pill-x", t.title = L("tooltip.clearFilter", { label: e || L("label.filters") }), t.setAttribute("aria-label", L("tooltip.clearFilter", { label: e || L("label.filters") })), t.textContent = "x", t.addEventListener("click", (e) => {
 			try {
 				e.preventDefault(), e.stopPropagation();
 			} catch (e) {
@@ -21348,93 +21586,93 @@ function nb({ label: e, value: t, onClear: n } = {}) {
 	}
 	return r;
 }
-function rb() {
+function ub() {
 	let e = document.createElement("div");
 	return e.className = "mjr-am-context-pills", {
 		wrap: e,
 		update: ({ state: t, rawQuery: n = "", actions: r = null } = {}) => {
-			let i = r && typeof r == "object" ? r : {}, a = $y(n || "").trim(), o = a.length > 0 && a !== "*", s = !!($y(t?.kindFilter || "").trim() || t?.workflowOnly || (Number(t?.minRating || 0) || 0) > 0 || (Number(t?.minSizeMB || 0) || 0) > 0 || (Number(t?.maxSizeMB || 0) || 0) > 0 || (Number(t?.minWidth || 0) || 0) > 0 || (Number(t?.minHeight || 0) || 0) > 0 || (Number(t?.maxWidth || 0) || 0) > 0 || (Number(t?.maxHeight || 0) || 0) > 0 || $y(t?.workflowType || "").trim() || $y(t?.workflowId || "").trim() || $y(t?.workflowModelFilter || "").trim() || $y(t?.workflowRunsOnFilter || "").trim() || $y(t?.dateRangeFilter || "").trim() || $y(t?.dateExactFilter || "").trim()), c = $y(t?.sort || "mtime_desc").trim() !== "mtime_desc", l = $y(t?.collectionId || "").trim().length > 0, u = String(t?.viewScope || t?.scope || "output").toLowerCase(), d = u === "similar", f = u === "custom", p = u !== "output", m = $y(t?.similarSourceAssetId || "").trim();
+			let i = r && typeof r == "object" ? r : {}, a = ob(n || "").trim(), o = a.length > 0 && a !== "*", s = !!(ob(t?.kindFilter || "").trim() || t?.workflowOnly || (Number(t?.minRating || 0) || 0) > 0 || (Number(t?.minSizeMB || 0) || 0) > 0 || (Number(t?.maxSizeMB || 0) || 0) > 0 || (Number(t?.minWidth || 0) || 0) > 0 || (Number(t?.minHeight || 0) || 0) > 0 || (Number(t?.maxWidth || 0) || 0) > 0 || (Number(t?.maxHeight || 0) || 0) > 0 || ob(t?.workflowType || "").trim() || ob(t?.workflowId || "").trim() || ob(t?.workflowModelFilter || "").trim() || ob(t?.workflowRunsOnFilter || "").trim() || ob(t?.dateRangeFilter || "").trim() || ob(t?.dateExactFilter || "").trim()), c = ob(t?.sort || "mtime_desc").trim() !== "mtime_desc", l = ob(t?.collectionId || "").trim().length > 0, u = String(t?.viewScope || t?.scope || "output").toLowerCase(), d = u === "similar", f = u === "custom", p = u !== "output", m = ob(t?.similarSourceAssetId || "").trim();
 			if (!(!(o || s || c || l || p || d) && !e.childElementCount)) {
 				try {
 					e.replaceChildren();
 				} catch (e) {
 					console.debug?.(e);
 				}
-				if (!f && l && e.appendChild(nb({
-					label: R("label.collections"),
-					value: $y(t?.collectionName || t?.collectionId || "").trim(),
+				if (!f && l && e.appendChild(lb({
+					label: L("label.collections"),
+					value: ob(t?.collectionName || t?.collectionId || "").trim(),
 					onClear: () => i?.clearCollection?.()
-				})), d && e.appendChild(nb({
-					label: R("search.findSimilar", "Find Similar"),
-					value: m ? R("search.similarReference", "Reference #{id}", { id: m }) : R("scope.similar", "Similar"),
+				})), d && e.appendChild(lb({
+					label: L("search.findSimilar", "Find Similar"),
+					value: m ? L("search.similarReference", "Reference #{id}", { id: m }) : L("scope.similar", "Similar"),
 					onClear: () => i?.clearSimilarScope?.()
-				})), p && e.appendChild(nb({
-					label: R("label.scope"),
-					value: tb(u || "output"),
+				})), p && e.appendChild(lb({
+					label: L("label.scope"),
+					value: cb(u || "output"),
 					onClear: () => d ? i?.clearSimilarScope?.() : i?.clearScope?.()
-				})), o && e.appendChild(nb({
-					label: R("label.query"),
+				})), o && e.appendChild(lb({
+					label: L("label.query"),
 					value: a,
 					onClear: () => i?.clearQuery?.()
-				})), $y(t?.kindFilter || "").trim() && e.appendChild(nb({
-					label: R("label.type"),
-					value: $y(t?.kindFilter || "").trim(),
+				})), ob(t?.kindFilter || "").trim() && e.appendChild(lb({
+					label: L("label.type"),
+					value: ob(t?.kindFilter || "").trim(),
 					onClear: () => i?.clearKind?.()
-				})), Number(t?.minRating || 0) > 0 && e.appendChild(nb({
-					label: R("label.rating"),
+				})), Number(t?.minRating || 0) > 0 && e.appendChild(lb({
+					label: L("label.rating"),
 					value: `>= ${Number(t?.minRating || 0)}`,
 					onClear: () => i?.clearMinRating?.()
-				})), t?.workflowOnly && e.appendChild(nb({
-					label: R("label.workflow"),
-					value: R("label.only"),
+				})), t?.workflowOnly && e.appendChild(lb({
+					label: L("label.workflow"),
+					value: L("label.only"),
 					onClear: () => i?.clearWorkflowOnly?.()
-				})), $y(t?.workflowType || "").trim() && e.appendChild(nb({
-					label: R("label.workflowType"),
-					value: $y(t?.workflowType || "").trim(),
+				})), ob(t?.workflowType || "").trim() && e.appendChild(lb({
+					label: L("label.workflowType"),
+					value: ob(t?.workflowType || "").trim(),
 					onClear: () => i?.clearWorkflowType?.()
-				})), $y(t?.workflowId || "").trim()) {
-					let n = $y(t?.workflowId || "").trim();
-					e.appendChild(nb({
-						label: R("label.sameWorkflow", "Generated with Same Workflow"),
+				})), ob(t?.workflowId || "").trim()) {
+					let n = ob(t?.workflowId || "").trim();
+					e.appendChild(lb({
+						label: L("label.sameWorkflow", "Generated with Same Workflow"),
 						value: n.length > 18 ? `${n.slice(0, 8)}...${n.slice(-6)}` : n,
 						onClear: () => i?.clearWorkflowId?.()
 					}));
 				}
-				if ($y(t?.workflowModelFilter || "").trim() && e.appendChild(nb({
-					label: R("label.workflowModelFamily", "Model family"),
-					value: $y(t?.workflowModelFilter || "").trim(),
+				if (ob(t?.workflowModelFilter || "").trim() && e.appendChild(lb({
+					label: L("label.workflowModelFamily", "Model family"),
+					value: ob(t?.workflowModelFilter || "").trim(),
 					onClear: () => i?.clearWorkflowModel?.()
-				})), $y(t?.workflowRunsOnFilter || "").trim() && e.appendChild(nb({
-					label: R("label.workflowRunsOn", "Runs on"),
-					value: $y(t?.workflowRunsOnFilter || "").trim(),
+				})), ob(t?.workflowRunsOnFilter || "").trim() && e.appendChild(lb({
+					label: L("label.workflowRunsOn", "Runs on"),
+					value: ob(t?.workflowRunsOnFilter || "").trim(),
 					onClear: () => i?.clearWorkflowRunsOn?.()
 				})), (Number(t?.minSizeMB || 0) || 0) > 0 || (Number(t?.maxSizeMB || 0) || 0) > 0) {
 					let n = Number(t?.minSizeMB || 0) || 0, r = Number(t?.maxSizeMB || 0) || 0, a = n > 0 && r > 0 ? `${n}-${r} MB` : n > 0 ? `>= ${n} MB` : `<= ${r} MB`;
-					e.appendChild(nb({
-						label: R("sidebar.size"),
+					e.appendChild(lb({
+						label: L("sidebar.size"),
 						value: a,
 						onClear: () => i?.clearSize?.()
 					}));
 				}
 				if ((Number(t?.minWidth || 0) || 0) > 0 || (Number(t?.minHeight || 0) || 0) > 0 || (Number(t?.maxWidth || 0) || 0) > 0 || (Number(t?.maxHeight || 0) || 0) > 0) {
 					let n = String(t?.resolutionCompare || "gte") === "lte", r = Number(n ? t?.maxWidth : t?.minWidth || 0) || 0, a = Number(n ? t?.maxHeight : t?.minHeight || 0) || 0;
-					e.appendChild(nb({
-						label: R("label.resolution"),
+					e.appendChild(lb({
+						label: L("label.resolution"),
 						value: `${n ? "<=" : ">="} ${r || 0}x${a || 0} px`,
 						onClear: () => i?.clearResolution?.()
 					}));
 				}
-				$y(t?.dateRangeFilter || "").trim() && e.appendChild(nb({
-					label: R("sidebar.date"),
-					value: $y(t?.dateRangeFilter || "").trim(),
+				ob(t?.dateRangeFilter || "").trim() && e.appendChild(lb({
+					label: L("sidebar.date"),
+					value: ob(t?.dateRangeFilter || "").trim(),
 					onClear: () => i?.clearDateRange?.()
-				})), $y(t?.dateExactFilter || "").trim() && e.appendChild(nb({
-					label: R("label.day"),
-					value: $y(t?.dateExactFilter || "").trim(),
+				})), ob(t?.dateExactFilter || "").trim() && e.appendChild(lb({
+					label: L("label.day"),
+					value: ob(t?.dateExactFilter || "").trim(),
 					onClear: () => i?.clearDateExact?.()
-				})), c && e.appendChild(nb({
-					label: R("label.sort"),
-					value: eb(t?.sort),
+				})), c && e.appendChild(lb({
+					label: L("label.sort"),
+					value: sb(t?.sort),
 					onClear: () => i?.clearSort?.()
 				}));
 			}
@@ -21443,17 +21681,17 @@ function rb() {
 }
 //#endregion
 //#region ui/vue/components/panel/summaryBarState.ts
-var ib = (e, t = "") => R(e, t, void 0), ab = (e) => {
+var db = (e, t = "") => L(e, t, void 0), fb = (e) => {
 	try {
 		return String(e ?? "");
 	} catch {
 		return "";
 	}
-}, ob = (e) => {
+}, pb = (e) => {
 	let t = String(e || "").toLowerCase();
-	return t === "similar" ? ib("scope.similar", "Similar") : t === "workflow" ? ib("scope.workflow", "Workflow") : ib(t === "input" || t === "inputs" ? "scope.input" : t === "custom" ? "scope.customBrowser" : t === "all" ? "tab.all" : "scope.output");
+	return t === "similar" ? db("scope.similar", "Similar") : t === "workflow" ? db("scope.workflow", "Workflow") : db(t === "input" || t === "inputs" ? "scope.input" : t === "custom" ? "scope.customBrowser" : t === "all" ? "tab.all" : "scope.output");
 };
-function sb(e) {
+function mb(e) {
 	try {
 		let t = e?._mjrGetRenderedCards;
 		if (typeof t == "function") {
@@ -21465,7 +21703,7 @@ function sb(e) {
 	}
 	return [];
 }
-function cb(e) {
+function hb(e) {
 	try {
 		let t = String(e?.dataset?.mjrSelectedAssetIds || "").trim();
 		if (t) {
@@ -21482,8 +21720,8 @@ function cb(e) {
 	}
 	return 0;
 }
-function lb({ state: e, gridContainer: t, context: n = null } = {}) {
-	let r = sb(t), i = (() => {
+function gb({ state: e, gridContainer: t, context: n = null } = {}) {
+	let r = mb(t), i = (() => {
 		try {
 			let e = 0;
 			for (let t of r) String(t?._mjrAsset?.kind || "").toLowerCase() === "folder" && (e += 1);
@@ -21504,12 +21742,12 @@ function lb({ state: e, gridContainer: t, context: n = null } = {}) {
 		} catch (e) {
 			console.debug?.(e);
 		}
-		return cb(t);
-	})(), s = Number(t?.dataset?.mjrTotal || 0) || Math.max(0, Number(e?.lastGridTotal ?? 0) || 0), c = Number(t?.dataset?.mjrShown || 0) || Math.max(0, Number(e?.lastGridCount ?? 0) || 0) || a, l = String(e?.viewScope || e?.scope || t?.dataset?.mjrScope || "output").toLowerCase(), u = s && s >= c ? `${c}/${s}` : `${c}`, d = [`${c > 0 && i.total > 0 && i.folders === i.total ? ib("summary.folders") : ib("summary.assets")}: ${u}`];
-	o > 0 && d.push(`${ib("summary.selected")}: ${o}`), d.push(ob(l));
+		return hb(t);
+	})(), s = Number(t?.dataset?.mjrTotal || 0) || Math.max(0, Number(e?.lastGridTotal ?? 0) || 0), c = Number(t?.dataset?.mjrShown || 0) || Math.max(0, Number(e?.lastGridCount ?? 0) || 0) || a, l = String(e?.viewScope || e?.scope || t?.dataset?.mjrScope || "output").toLowerCase(), u = s && s >= c ? `${c}/${s}` : `${c}`, d = [`${c > 0 && i.total > 0 && i.folders === i.total ? db("summary.folders") : db("summary.assets")}: ${u}`];
+	o > 0 && d.push(`${db("summary.selected")}: ${o}`), d.push(pb(l));
 	try {
 		let e = Number(t?.dataset?.mjrHiddenPngSiblings || 0) || 0;
-		String(t?.dataset?.mjrHidePngSiblingsEnabled || "") === "1" && e > 0 && d.push(`${ib("summary.hidden")}: ${e}`);
+		String(t?.dataset?.mjrHidePngSiblingsEnabled || "") === "1" && e > 0 && d.push(`${db("summary.hidden")}: ${e}`);
 	} catch (e) {
 		console.debug?.(e);
 	}
@@ -21519,39 +21757,39 @@ function lb({ state: e, gridContainer: t, context: n = null } = {}) {
 		total: s,
 		activeScope: l,
 		summaryText: d.filter(Boolean).join(" | "),
-		duplicateText: h ? `${ib("summary.duplicates")}: ${p} | ${ib("summary.similar")}: ${m}` : "",
+		duplicateText: h ? `${db("summary.duplicates")}: ${p} | ${db("summary.similar")}: ${m}` : "",
 		showDuplicates: h,
-		rawQuery: ab(n?.rawQuery || "").trim()
+		rawQuery: fb(n?.rawQuery || "").trim()
 	};
 }
 //#endregion
 //#region ui/vue/components/panel/SummaryBarSection.vue
-var ub = {
+var _b = {
 	key: 2,
 	class: "mjr-folder-breadcrumb-separator"
-}, db = {
+}, vb = {
 	key: 0,
 	class: "mjr-folder-breadcrumb-separator"
-}, fb = { class: "mjr-am-summary-left" }, pb = { class: "mjr-am-summary-text" }, mb = { class: "mjr-am-summary-right" }, hb = ["aria-label"], gb = {
+}, yb = { class: "mjr-am-summary-left" }, bb = { class: "mjr-am-summary-text" }, xb = { class: "mjr-am-summary-right" }, Sb = ["aria-label"], Cb = {
 	__name: "SummaryBarSection",
 	setup(e, { expose: t }) {
-		let n = uh(), r = Z(null), i = Z(null), a = Z(null), o = Z(""), s = Z(""), c = Z(!1), l = Z(!1), u = Z(null), d = Z(null), f = Z([]), p = rb(), m = G(() => String(n.kindFilter || "").trim().toLowerCase()), h = G(() => {
-			let e = R("label.type", "Type");
+		let n = _h(), r = Z(null), i = Z(null), a = Z(null), o = Z(""), s = Z(""), c = Z(!1), l = Z(!1), u = Z(null), d = Z(null), f = Z([]), p = ub(), m = G(() => String(n.kindFilter || "").trim().toLowerCase()), h = G(() => {
+			let e = L("label.type", "Type");
 			return [
 				{
 					kind: "image",
 					icon: "pi pi-image",
-					title: `${e}: ${R("filter.images", "Images")}`
+					title: `${e}: ${L("filter.images", "Images")}`
 				},
 				{
 					kind: "video",
 					icon: "pi pi-video",
-					title: `${e}: ${R("filter.videos", "Videos")}`
+					title: `${e}: ${L("filter.videos", "Videos")}`
 				},
 				{
 					kind: "audio",
 					icon: "pi pi-volume-up",
-					title: `${e}: ${R("filter.audio", "Audio")}`
+					title: `${e}: ${L("filter.audio", "Audio")}`
 				},
 				{
 					kind: "model3d",
@@ -21582,7 +21820,7 @@ var ub = {
 			t && (n.kindFilter = v(t) ? "" : t, y());
 		}
 		function x({ state: e, gridContainer: t, context: r = null, actions: i = null } = {}) {
-			let a = lb({
+			let a = gb({
 				state: e,
 				gridContainer: t,
 				context: r
@@ -21663,8 +21901,8 @@ var ub = {
 					default: Q(() => [tr(q(d.value.label), 1)]),
 					_: 1
 				}, 8, ["disabled"])) : W("", !0),
-				u.value || d.value ? (V(), Y("span", ub, " | ")) : W("", !0),
-				(V(!0), Y(H, null, ar(f.value, (e, t) => (V(), Y(H, { key: `${e.target}:${t}` }, [t > 0 ? (V(), Y("span", db, "/")) : W("", !0), J(n, {
+				u.value || d.value ? (V(), Y("span", _b, " | ")) : W("", !0),
+				(V(!0), Y(H, null, ar(f.value, (e, t) => (V(), Y(H, { key: `${e.target}:${t}` }, [t > 0 ? (V(), Y("span", vb, "/")) : W("", !0), J(n, {
 					type: "button",
 					class: X(["mjr-btn-link mjr-folder-breadcrumb-segment", { "is-current": e.current }]),
 					severity: "secondary",
@@ -21684,10 +21922,10 @@ var ub = {
 				ref: r,
 				class: "mjr-am-summary",
 				"aria-live": "polite"
-			}, [U("div", fb, [U("div", pb, q(o.value), 1)]), U("div", mb, [
+			}, [U("div", yb, [U("div", bb, q(o.value), 1)]), U("div", xb, [
 				U("div", {
 					class: "mjr-media-shortcuts",
-					"aria-label": K(R)("label.type", "Type"),
+					"aria-label": K(L)("label.type", "Type"),
 					role: "group"
 				}, [(V(!0), Y(H, null, ar(h.value, (e) => (V(), nr(n, {
 					key: e.kind,
@@ -21712,7 +21950,7 @@ var ub = {
 					"aria-pressed",
 					"class",
 					"onClick"
-				]))), 128))], 8, hb),
+				]))), 128))], 8, Sb),
 				c.value ? (V(), nr(n, {
 					key: 0,
 					type: "button",
@@ -21735,11 +21973,11 @@ var ub = {
 };
 //#endregion
 //#region ui/vue/composables/useGridContextMenu.ts
-function _b(e, t) {
+function wb(e, t) {
 	let n = null;
 	function r(e) {
 		if (!(!e || e._mjrGridContextMenuBound)) try {
-			n = Wa({
+			n = Ga({
 				gridContainer: e,
 				getState: t
 			});
@@ -21759,7 +21997,7 @@ function _b(e, t) {
 }
 //#endregion
 //#region ui/vue/composables/useGridKeyboard.ts
-function vb(e) {
+function Tb(e) {
 	if (!e) return () => {};
 	let t = e;
 	try {
@@ -21781,7 +22019,7 @@ function vb(e) {
 				} catch (e) {
 					console.debug?.("[useGridKeyboard] rect lookup failed", e);
 				}
-				Ua(Math.round((i?.left || 0) + Math.min((i?.width || 0) * .5, 160)), Math.round((i?.top || 0) + Math.min((i?.height || 0) * .5, 120)), n, () => {
+				Wa(Math.round((i?.left || 0) + Math.min((i?.width || 0) * .5, 160)), Math.round((i?.top || 0) + Math.min((i?.height || 0) * .5, 120)), n, () => {
 					t._mjrOnKeyboardAssetChanged?.(n);
 				});
 			}
@@ -21798,7 +22036,7 @@ function vb(e) {
 		return console.debug?.("[useGridKeyboard] bind failed", e), () => {};
 	}
 }
-function yb(e) {
+function Eb(e) {
 	let t = null, n = () => {
 		try {
 			t?.();
@@ -21808,13 +22046,13 @@ function yb(e) {
 		t = null;
 	};
 	ir(e, (e, r) => {
-		r && n(), e && (t = vb(e));
+		r && n(), e && (t = Tb(e));
 	}, { immediate: !0 }), Or(n);
 }
 //#endregion
 //#region ui/vue/components/grid/assetsGridHostState.ts
-function bb() {}
-function xb() {
+function Db() {}
+function Ob() {
 	return new Promise((e) => {
 		try {
 			if (typeof requestAnimationFrame == "function") {
@@ -21827,7 +22065,7 @@ function xb() {
 		e();
 	});
 }
-function Sb(e, ...t) {
+function kb(e, ...t) {
 	try {
 		return typeof e == "function" ? e(...t) : void 0;
 	} catch (e) {
@@ -21835,21 +22073,21 @@ function Sb(e, ...t) {
 		return;
 	}
 }
-function Cb(e = {}) {
+function Ab(e = {}) {
 	let t = Array.isArray(e.selectedIds) ? e.selectedIds.map(String).filter(Boolean) : [];
 	return {
 		ids: t,
 		activeId: String(e.activeId || t[0] || "").trim()
 	};
 }
-function wb(e, t = {}, n = null) {
+function jb(e, t = {}, n = null) {
 	return {
 		count: Number(t.count ?? t.shown ?? e?.dataset?.mjrShown ?? n?.lastGridCount ?? 0) || 0,
 		total: Number(t.total ?? e?.dataset?.mjrTotal ?? n?.lastGridTotal ?? 0) || 0
 	};
 }
-function Tb(e, t = dh()) {
-	if (!e || !t) return bb;
+function Mb(e, t = vh()) {
+	if (!e || !t) return Db;
 	let n = 0, r = () => {
 		if (!n) try {
 			n = requestAnimationFrame(() => {
@@ -21875,8 +22113,8 @@ function Tb(e, t = dh()) {
 		}
 	};
 }
-function Eb(e, { panelStore: t = dh(), onContextChanged: n = null, markUserInteraction: r = null } = {}) {
-	if (!e) return bb;
+function Nb(e, { panelStore: t = vh(), onContextChanged: n = null, markUserInteraction: r = null } = {}) {
+	if (!e) return Db;
 	let i = 0, a = () => {
 		if (i) try {
 			cancelAnimationFrame(i);
@@ -21885,24 +22123,24 @@ function Eb(e, { panelStore: t = dh(), onContextChanged: n = null, markUserInter
 		}
 		try {
 			i = requestAnimationFrame(() => {
-				i = 0, Sb(n);
+				i = 0, kb(n);
 			});
 		} catch (e) {
-			console.debug?.(e), i = 0, Sb(n);
+			console.debug?.(e), i = 0, kb(n);
 		}
 	}, o = (r) => {
 		let i = r?.detail || {};
 		if (t) {
-			let { count: n, total: r } = wb(e, i, t);
+			let { count: n, total: r } = jb(e, i, t);
 			t.lastGridCount = n, t.lastGridTotal = r;
 		}
-		Sb(n);
+		kb(n);
 	}, s = (e) => {
-		if (Sb(r), t) {
-			let { ids: n, activeId: r } = Cb(e?.detail || {});
+		if (kb(r), t) {
+			let { ids: n, activeId: r } = Ab(e?.detail || {});
 			t.selectedAssetIds = n, t.activeAssetId = r;
 		}
-		Sb(n);
+		kb(n);
 	};
 	e.addEventListener("mjr:grid-stats", o), e.addEventListener("mjr:selection-changed", s);
 	try {
@@ -21950,14 +22188,14 @@ function Eb(e, { panelStore: t = dh(), onContextChanged: n = null, markUserInter
 		}
 	};
 }
-async function Db({ initialLoadPromise: e, gridWrapper: t, gridContainer: n, panelStore: r = dh(), onRestoreSidebar: i = null } = {}) {
+async function Pb({ initialLoadPromise: e, gridWrapper: t, gridContainer: n, panelStore: r = vh(), onRestoreSidebar: i = null } = {}) {
 	if (!t || !n || !r) return;
 	try {
 		await e;
 	} catch (e) {
 		console.debug?.(e);
 	}
-	await xb();
+	await Ob();
 	let a = Number(r.scrollTop || 0) || 0;
 	if (a > 0) try {
 		t.scrollTop = a;
@@ -21974,7 +22212,7 @@ async function Db({ initialLoadPromise: e, gridWrapper: t, gridContainer: n, pan
 		if (s) {
 			let e = () => {
 				try {
-					typeof n?._mjrScrollToAssetId == "function" ? n._mjrScrollToAssetId(s) : Kl(n, s)?.scrollIntoView?.({
+					typeof n?._mjrScrollToAssetId == "function" ? n._mjrScrollToAssetId(s) : Jl(n, s)?.scrollIntoView?.({
 						block: "nearest",
 						behavior: "instant"
 					});
@@ -21985,14 +22223,14 @@ async function Db({ initialLoadPromise: e, gridWrapper: t, gridContainer: n, pan
 			e(), setTimeout(e, 160);
 		}
 	}
-	r.sidebarOpen && s && Sb(i);
+	r.sidebarOpen && s && kb(i);
 }
 //#endregion
 //#region ui/vue/components/grid/AssetsGrid.vue
-var Ob = {
+var Fb = {
 	__name: "AssetsGrid",
 	setup(e, { expose: t }) {
-		let n = Z(null), r = Z(null), i = Z(null), a = uh(), o = G(() => i.value?.gridContainer ?? null), s = null, c = null, l = null, u = null;
+		let n = Z(null), r = Z(null), i = Z(null), a = _h(), o = G(() => i.value?.gridContainer ?? null), s = null, c = null, l = null, u = null;
 		function d() {
 			try {
 				l?.setVisibility?.();
@@ -22086,7 +22324,7 @@ var Ob = {
 				}
 			};
 		}
-		hr("mjr-grid-container-ref", o), _b(o, () => a), yb(o);
+		hr("mjr-grid-container-ref", o), wb(o, () => a), Eb(o);
 		function m() {
 			return o.value || null;
 		}
@@ -22098,14 +22336,14 @@ var Ob = {
 				} catch (e) {
 					console.debug?.(e);
 				}
-				c = Eb(t, {
+				c = Nb(t, {
 					panelStore: a,
 					...e
 				});
 			}
 		}
 		return fr(() => {
-			s = Tb(r.value, a), r.value && Number(a.scrollTop || 0) > 0 && (r.value.scrollTop = Number(a.scrollTop || 0)), p();
+			s = Mb(r.value, a), r.value && Number(a.scrollTop || 0) > 0 && (r.value.scrollTop = Number(a.scrollTop || 0)), p();
 			try {
 				window.addEventListener("mjr:keepalive-attached", f), document.addEventListener("visibilitychange", d);
 			} catch (e) {
@@ -22182,7 +22420,7 @@ var Ob = {
 				};
 			},
 			restoreGridUiState(e, t = {}) {
-				return Db({
+				return Pb({
 					initialLoadPromise: e,
 					gridWrapper: r.value,
 					gridContainer: m(),
@@ -22198,7 +22436,7 @@ var Ob = {
 				} catch (e) {
 					console.debug?.(e);
 				}
-				return l = Gg({
+				return l = Qg({
 					gridContainer: t,
 					gridWrapper: r.value,
 					...e
@@ -22253,13 +22491,13 @@ var Ob = {
 				overflow: "auto",
 				position: "relative"
 			}
-		}, [J(Qu, {
+		}, [J(ad, {
 			ref_key: "gridHostRef",
 			ref: i,
 			"scroll-element": r.value
 		}, null, 8, ["scroll-element"])], 512)], 512));
 	}
-}, kb = {
+}, Ib = {
 	class: "mjr-sidebar-header",
 	style: {
 		display: "flex",
@@ -22270,7 +22508,7 @@ var Ob = {
 		"flex-shrink": "0",
 		background: "var(--mjr-surface-2,#2e2e2e)"
 	}
-}, Ab = ["title"], jb = {
+}, Lb = ["title"], Rb = {
 	__name: "SidebarHeaderSection",
 	props: { asset: {
 		type: Object,
@@ -22281,7 +22519,7 @@ var Ob = {
 		let n = t;
 		return (t, r) => {
 			let i = gr("MButton");
-			return V(), Y("div", kb, [U("div", {
+			return V(), Y("div", Ib, [U("div", {
 				class: "mjr-sidebar-filename",
 				title: e.asset.filename,
 				style: {
@@ -22294,7 +22532,7 @@ var Ob = {
 					"min-width": "0",
 					"padding-right": "8px"
 				}
-			}, q(e.asset.filename), 9, Ab), J(i, {
+			}, q(e.asset.filename), 9, Lb), J(i, {
 				type: "button",
 				class: "mjr-sidebar-close",
 				severity: "secondary",
@@ -22326,14 +22564,14 @@ var Ob = {
 };
 //#endregion
 //#region ui/components/sidebar/utils/format.ts
-function Mb(e) {
+function zb(e) {
 	if (!e) return "Unknown";
 	let t = e / 1024;
 	if (t < 1024) return `${t.toFixed(1)} KB`;
 	let n = t / 1024;
 	return n < 1024 ? `${n.toFixed(1)} MB` : `${(n / 1024).toFixed(2)} GB`;
 }
-function Nb(e) {
+function Bb(e) {
 	if (!e) return "";
 	let t = /* @__PURE__ */ new Date(Number(e) * 1e3);
 	if (Number.isNaN(t.getTime())) return "";
@@ -22342,13 +22580,13 @@ function Nb(e) {
 }
 //#endregion
 //#region ui/vue/components/panel/sidebar/SidebarPreviewSection.vue
-var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["src"], Rb = {
+var Vb = { class: "mjr-sidebar-preview" }, Hb = ["src"], Ub = ["src"], Wb = ["src"], Gb = {
 	key: 3,
 	style: {
 		color: "rgba(255, 255, 255, 0.4)",
 		"font-size": "14px"
 	}
-}, zb = {
+}, Kb = {
 	class: "mjr-sidebar-preview-meta",
 	style: {
 		"margin-top": "10px",
@@ -22362,7 +22600,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		"padding-bottom": "12px",
 		"border-bottom": "1px solid var(--mjr-border, rgba(255, 255, 255, 0.12))"
 	}
-}, Bb = {
+}, qb = {
 	__name: "SidebarPreviewSection",
 	props: {
 		asset: {
@@ -22375,15 +22613,15 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		}
 	},
 	setup(e) {
-		let t = e, n = Z(null), r = null, i = G(() => ot(t.asset) || ""), a = G(() => {
+		let t = e, n = Z(null), r = null, i = G(() => st(t.asset) || ""), a = G(() => {
 			let e = String(t.asset?.filename || ""), n = e.lastIndexOf(".");
 			return n === -1 ? "" : e.slice(n + 1).toUpperCase();
 		}), o = G(() => {
 			let e = [];
 			a.value && e.push(a.value), t.asset?.kind && e.push(String(t.asset.kind).toLowerCase());
-			let n = Mb(t.asset?.size);
+			let n = zb(t.asset?.size);
 			n && e.push(n);
-			let r = Nb(t.asset?.mtime);
+			let r = Bb(t.asset?.mtime);
 			return r && e.push(r), e.join(" | ");
 		});
 		function s() {
@@ -22427,7 +22665,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			l();
 		}), lr(() => {
 			s();
-		}), (t, r) => (V(), Y("div", Pb, [e.showPreviewThumb ? (V(), Y("div", {
+		}), (t, r) => (V(), Y("div", Vb, [e.showPreviewThumb ? (V(), Y("div", {
 			key: 0,
 			ref_key: "previewContainerRef",
 			ref: n,
@@ -22450,7 +22688,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				"max-height": "100%",
 				"object-fit": "contain"
 			}
-		}, null, 8, Fb)) : e.asset.kind === "video" ? (V(), Y("video", {
+		}, null, 8, Hb)) : e.asset.kind === "video" ? (V(), Y("video", {
 			key: 1,
 			src: i.value,
 			muted: !0,
@@ -22463,7 +22701,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				"max-height": "100%",
 				"object-fit": "contain"
 			}
-		}, null, 8, Ib)) : e.asset.kind === "audio" ? (V(), Y("audio", {
+		}, null, 8, Ub)) : e.asset.kind === "audio" ? (V(), Y("audio", {
 			key: 2,
 			src: i.value,
 			controls: "",
@@ -22472,9 +22710,9 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				width: "92%",
 				"max-width": "560px"
 			}
-		}, null, 8, Lb)) : (V(), Y("div", Rb, q(String(e.asset.kind || "PREVIEW").toUpperCase()), 1))], 512)) : W("", !0), U("div", zb, q(o.value), 1)]));
+		}, null, 8, Wb)) : (V(), Y("div", Gb, q(String(e.asset.kind || "PREVIEW").toUpperCase()), 1))], 512)) : W("", !0), U("div", Kb, q(o.value), 1)]));
 	}
-}, Vb = {
+}, Jb = {
 	class: "mjr-sidebar-section",
 	style: {
 		background: "rgba(255, 255, 255, 0.03)",
@@ -22482,22 +22720,22 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		"border-radius": "8px",
 		padding: "10px"
 	}
-}, Hb = { style: {
+}, Yb = { style: {
 	"font-size": "12px",
 	"font-weight": "700",
 	color: "#26a69a",
 	"margin-bottom": "8px",
 	"text-transform": "uppercase",
 	"letter-spacing": "0.4px"
-} }, Ub = { style: {
+} }, Xb = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "6px"
-} }, Wb = { style: {
+} }, Zb = { style: {
 	"font-size": "12px",
 	opacity: "0.68",
 	"min-width": "92px"
-} }, Gb = ["title"], Kb = {
+} }, Qb = ["title"], $b = {
 	__name: "SidebarFolderSection",
 	props: { asset: {
 		type: Object,
@@ -22521,39 +22759,39 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		let r = G(() => {
 			let e = t.asset || {}, r = e.folder_info || e.folderInfo || {}, i = String(r.path || e.filepath || e.subfolder || ""), a = String(r.name || e.filename || "").trim(), o = Number(r.files ?? 0), s = Number(r.folders ?? 0), c = Number(r.size ?? 0), l = Number(r.mtime ?? e.mtime ?? 0), u = Number(r.ctime ?? 0), d = !!r.truncated, f = [
 				{
-					label: R("sidebar.folder.name", "Name"),
+					label: L("sidebar.folder.name", "Name"),
 					value: a || "-"
 				},
 				{
-					label: R("sidebar.folder.path", "Path"),
+					label: L("sidebar.folder.path", "Path"),
 					value: i || "-"
 				},
 				{
-					label: R("sidebar.folder.folders", "Folders"),
+					label: L("sidebar.folder.folders", "Folders"),
 					value: Number.isFinite(s) ? String(s) : "-"
 				},
 				{
-					label: R("sidebar.folder.files", "Files"),
+					label: L("sidebar.folder.files", "Files"),
 					value: Number.isFinite(o) ? String(o) : "-"
 				},
 				{
-					label: R("sidebar.size", "Size"),
+					label: L("sidebar.size", "Size"),
 					value: n(c)
 				}
 			];
 			return u > 0 && f.push({
-				label: R("sidebar.folder.created", "Created"),
+				label: L("sidebar.folder.created", "Created"),
 				value: `${zn(u) || "-"} ${Nn(u) || ""}`.trim()
 			}), l > 0 && f.push({
-				label: R("sidebar.folder.modified", "Modified"),
+				label: L("sidebar.folder.modified", "Modified"),
 				value: `${zn(l) || "-"} ${Nn(l) || ""}`.trim()
 			}), d && f.push({
-				label: R("sidebar.folder.note", "Note"),
-				value: R("sidebar.folder.scanTruncated", "Scan was truncated for performance"),
+				label: L("sidebar.folder.note", "Note"),
+				value: L("sidebar.folder.scanTruncated", "Scan was truncated for performance"),
 				valueStyle: "color:#FFB74D;font-weight:600;"
 			}), f;
 		});
-		return (e, t) => (V(), Y("div", Vb, [U("div", Hb, q(K(R)("sidebar.folder.details", "Folder Details")), 1), U("div", Ub, [(V(!0), Y(H, null, ar(r.value, (e) => (V(), Y("div", {
+		return (e, t) => (V(), Y("div", Jb, [U("div", Yb, q(K(L)("sidebar.folder.details", "Folder Details")), 1), U("div", Xb, [(V(!0), Y(H, null, ar(r.value, (e) => (V(), Y("div", {
 			key: e.label,
 			style: {
 				display: "flex",
@@ -22561,18 +22799,18 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				"align-items": "flex-start",
 				"justify-content": "space-between"
 			}
-		}, [U("div", Wb, q(e.label), 1), U("div", {
+		}, [U("div", Zb, q(e.label), 1), U("div", {
 			style: Cr(e.valueStyle || "font-size: 12px; text-align: right; word-break: break-word"),
 			title: String(e.value || "")
-		}, q(e.value), 13, Gb)]))), 128))])]));
+		}, q(e.value), 13, Qb)]))), 128))])]));
 	}
-}, qb = [
+}, ex = [
 	"aria-busy",
 	"aria-disabled",
 	"aria-label",
 	"aria-valuenow",
 	"tabindex"
-], Jb = {
+], tx = {
 	__name: "RatingEditor",
 	props: {
 		asset: {
@@ -22607,7 +22845,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			l = t, u = t, t !== o.value && (o.value = t);
 		}
 		function y(e = null) {
-			o.value = l, u = l, i("update:modelValue", l), e && A(e, "error");
+			o.value = l, u = l, i("update:modelValue", l), e && k(e, "error");
 		}
 		async function x() {
 			if (c.value) return;
@@ -22617,7 +22855,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				let t = 0;
 				for (; t < 10;) {
 					if (Date.now() - e > 3e4) {
-						y(R("toast.ratingUpdateFailed", "Rating update failed"));
+						y(L("toast.ratingUpdateFailed", "Rating update failed"));
 						break;
 					}
 					t > 0 && await _(g(t)), t += 1;
@@ -22631,12 +22869,12 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					}
 					if (!c?.ok) {
 						if (c?.code === "ABORTED" && u !== a) continue;
-						y(c?.error || R("toast.ratingUpdateFailed", "Rating update failed"));
+						y(c?.error || L("toast.ratingUpdateFailed", "Rating update failed"));
 						break;
 					}
 					try {
 						let e = c?.data?.asset_id ?? null;
-						e != null && !Be(r.asset.id) && (r.asset.id = e);
+						e != null && !Ve(r.asset.id) && (r.asset.id = e);
 					} catch (e) {
 						console.debug?.(e);
 					}
@@ -22649,15 +22887,15 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					if (i("update:modelValue", a), i("rating-change", {
 						assetId: r.asset?.id,
 						rating: a
-					}), Rt(ct, {
+					}), Rt(lt, {
 						assetId: r.asset?.id == null ? "" : String(r.asset.id),
 						rating: a
 					}), u === a) {
-						A(R("toast.ratingSetN", { n: a }), "success", 1e3);
+						k(L("toast.ratingSetN", { n: a }), "success", 1e3);
 						break;
 					}
 				}
-				t >= 10 && y(R("toast.ratingUpdateFailed", "Rating update failed"));
+				t >= 10 && y(L("toast.ratingUpdateFailed", "Rating update failed"));
 			} finally {
 				d = null, c.value = !1;
 			}
@@ -22727,7 +22965,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				"aria-busy": c.value,
 				"aria-disabled": e.disabled,
 				role: "slider",
-				"aria-label": K(R)("rating.label", "Rating"),
+				"aria-label": K(L)("rating.label", "Rating"),
 				"aria-valuemin": 0,
 				"aria-valuemax": 5,
 				"aria-valuenow": o.value,
@@ -22750,7 +22988,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					padding: "0",
 					transition: "all 0.15s ease"
 				}),
-				"aria-label": K(R)("rating.setN", { n: t }),
+				"aria-label": K(L)("rating.setN", { n: t }),
 				"aria-pressed": t <= o.value,
 				disabled: e.disabled,
 				onClick: (e) => C(t),
@@ -22766,22 +23004,22 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				"disabled",
 				"onClick",
 				"onMouseenter"
-			])), 64))], 44, qb);
+			])), 64))], 44, ex);
 		};
 	}
-}, Yb = ["aria-label"], Xb = { class: "mjr-context-menu-title" }, Zb = { class: "mjr-context-menu-item-left" }, Qb = {
+}, nx = ["aria-label"], rx = { class: "mjr-context-menu-title" }, ix = { class: "mjr-context-menu-item-left" }, ax = {
 	key: 0,
 	class: "mjr-context-menu-note"
-}, $b = {
+}, ox = {
 	key: 1,
 	class: "mjr-context-menu-note is-error"
-}, ex = {
+}, sx = {
 	key: 2,
 	class: "mjr-context-menu-note"
-}, tx = { class: "mjr-context-menu-item-left" }, nx = {
+}, cx = { class: "mjr-context-menu-item-left" }, lx = {
 	key: 0,
 	class: "mjr-context-menu-hint"
-}, rx = {
+}, ux = {
 	__name: "AddToCollectionMenu",
 	setup(e) {
 		let t = Z(null), n = Z(!1), r = Z([]), i = Z(""), a = 0, o = null, s = G(() => ({
@@ -22790,13 +23028,13 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			top: `${Math.round(Number(qt.y) || 0)}px`,
 			display: "block",
 			zIndex: "10004"
-		})), c = G(() => qt.assets.length || 0), l = G(() => R("ctx.addToCollection", "Add to collection") + (c.value > 1 ? ` (${c.value})` : ""));
+		})), c = G(() => qt.assets.length || 0), l = G(() => L("ctx.addToCollection", "Add to collection") + (c.value > 1 ? ` (${c.value})` : ""));
 		function u({ collectionName: e, selectedCount: t, addRes: n }) {
-			let r = Number(n?.data?.added ?? 0) || 0, i = Number(n?.data?.skipped_existing ?? 0) || 0, a = Number(n?.data?.skipped_duplicate ?? 0) || 0, o = String(e || "").trim() || R("label.collection", "collection"), s = R("msg.collectionAdd.added", "Added {added} item(s) to \"{name}\".", {
+			let r = Number(n?.data?.added ?? 0) || 0, i = Number(n?.data?.skipped_existing ?? 0) || 0, a = Number(n?.data?.skipped_duplicate ?? 0) || 0, o = String(e || "").trim() || L("label.collection", "collection"), s = L("msg.collectionAdd.added", "Added {added} item(s) to \"{name}\".", {
 				added: r,
 				name: o
 			});
-			return i > 0 && (s += `\n\n${R("msg.collectionAdd.skippedExisting", "Skipped {count} item(s): already present in the collection.", { count: i })}`), a > 0 && (s += `\n\n${R("msg.collectionAdd.skippedDuplicate", "Ignored {count} duplicate(s) in selection.", { count: a })}`), r === 0 && i > 0 && t > 0 && (s = R("msg.collectionAdd.noneAddedExisting", "No new items added to \"{name}\" (all exist).", { name: o })), s;
+			return i > 0 && (s += `\n\n${L("msg.collectionAdd.skippedExisting", "Skipped {count} item(s): already present in the collection.", { count: i })}`), a > 0 && (s += `\n\n${L("msg.collectionAdd.skippedDuplicate", "Ignored {count} duplicate(s) in selection.", { count: a })}`), r === 0 && i > 0 && t > 0 && (s = L("msg.collectionAdd.noneAddedExisting", "No new items added to \"{name}\" (all exist).", { name: o })), s;
 		}
 		function d() {
 			let e = t.value;
@@ -22808,12 +23046,12 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			let e = ++a;
 			n.value = !0, i.value = "";
 			try {
-				let t = await ae();
+				let t = await re();
 				if (e !== a) return;
 				r.value = Array.isArray(t?.data) ? t.data : [];
 			} catch (t) {
 				if (console.error("[AddToCollectionMenu.vue] listCollections failed:", t), e !== a) return;
-				r.value = [], i.value = R("toast.failedLoadCollections", "Failed to load collections.");
+				r.value = [], i.value = L("toast.failedLoadCollections", "Failed to load collections.");
 			} finally {
 				if (e === a) {
 					n.value = !1, await or(), d();
@@ -22828,33 +23066,33 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		async function p(e, t) {
 			let n = Array.isArray(qt.assets) ? qt.assets : [];
 			Nt();
-			let r = await m(e, n);
+			let r = await h(e, n);
 			if (!r?.ok) {
-				A(r?.error || R("toast.failedAddAssetsToCollection", "Failed to add assets to collection."), "error");
+				k(r?.error || L("toast.failedAddAssetsToCollection", "Failed to add assets to collection."), "error");
 				return;
 			}
-			A(u({
+			k(u({
 				collectionName: t,
 				selectedCount: n.length,
 				addRes: r
 			}), "success", 4e3);
 		}
-		async function h() {
+		async function m() {
 			let e = Array.isArray(qt.assets) ? qt.assets : [];
 			Nt();
-			let t = await Et(R("dialog.createCollection", "Create collection"), R("dialog.collectionPlaceholder", "My collection"));
+			let t = await Et(L("dialog.createCollection", "Create collection"), L("dialog.collectionPlaceholder", "My collection"));
 			if (!t) return;
 			let n = await E(t);
 			if (!n?.ok) {
-				A(n?.error || R("toast.failedCreateCollectionDot", "Failed to create collection."), "error");
+				k(n?.error || L("toast.failedCreateCollectionDot", "Failed to create collection."), "error");
 				return;
 			}
-			let r = n.data?.id, i = await m(r, e);
+			let r = n.data?.id, i = await h(r, e);
 			if (!i?.ok) {
-				A(i?.error || R("toast.failedAddAssetsToCollection", "Failed to add assets to collection."), "error");
+				k(i?.error || L("toast.failedAddAssetsToCollection", "Failed to add assets to collection."), "error");
 				return;
 			}
-			A(u({
+			k(u({
 				collectionName: n.data?.name || t,
 				selectedCount: e.length,
 				addRes: i
@@ -22903,20 +23141,20 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				role: "menu",
 				"aria-label": l.value
 			}, [
-				U("div", Xb, q(l.value), 1),
+				U("div", rx, q(l.value), 1),
 				J(o, {
 					type: "button",
 					class: "mjr-context-menu-item",
 					severity: "secondary",
 					text: "",
 					role: "menuitem",
-					onClick: h
+					onClick: m
 				}, {
-					default: Q(() => [U("span", Zb, [a[0] ||= U("i", { class: "pi pi-plus" }, null, -1), U("span", null, q(K(R)("dialog.createCollection", "Create collection")) + "...", 1)])]),
+					default: Q(() => [U("span", ix, [a[0] ||= U("i", { class: "pi pi-plus" }, null, -1), U("span", null, q(K(L)("dialog.createCollection", "Create collection")) + "...", 1)])]),
 					_: 1
 				}),
 				a[2] ||= U("div", { class: "mjr-context-menu-separator" }, null, -1),
-				n.value ? (V(), Y("div", Qb, q(K(R)("msg.loadingCollections", "Loading collections...")), 1)) : i.value ? (V(), Y("div", $b, q(i.value), 1)) : r.value.length ? W("", !0) : (V(), Y("div", ex, q(K(R)("msg.noCollections", "No collections yet.")), 1)),
+				n.value ? (V(), Y("div", ax, q(K(L)("msg.loadingCollections", "Loading collections...")), 1)) : i.value ? (V(), Y("div", ox, q(i.value), 1)) : r.value.length ? W("", !0) : (V(), Y("div", sx, q(K(L)("msg.noCollections", "No collections yet.")), 1)),
 				(V(!0), Y(H, null, ar(r.value, (e) => (V(), nr(o, {
 					key: String(e?.id || ""),
 					type: "button",
@@ -22926,28 +23164,28 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					role: "menuitem",
 					onClick: (t) => p(String(e?.id || ""), String(e?.name || e?.id || ""))
 				}, {
-					default: Q(() => [U("span", tx, [a[1] ||= U("i", { class: "pi pi-bookmark" }, null, -1), U("span", null, q(String(e?.name || e?.id || "")), 1)]), Number(e?.count || 0) > 0 ? (V(), Y("span", nx, q(Number(e?.count || 0)), 1)) : W("", !0)]),
+					default: Q(() => [U("span", cx, [a[1] ||= U("i", { class: "pi pi-bookmark" }, null, -1), U("span", null, q(String(e?.name || e?.id || "")), 1)]), Number(e?.count || 0) > 0 ? (V(), Y("span", lx, q(Number(e?.count || 0)), 1)) : W("", !0)]),
 					_: 2
 				}, 1032, ["onClick"]))), 128))
-			], 12, Yb)) : W("", !0)]);
+			], 12, nx)) : W("", !0)]);
 		};
 	}
-}, ix = {
+}, dx = {
 	key: 0,
 	class: "mjr-context-menu-separator"
-}, ax = { class: "mjr-context-menu-item-left" }, ox = { class: "mjr-context-menu-item-right" }, sx = {
+}, fx = { class: "mjr-context-menu-item-left" }, px = { class: "mjr-context-menu-item-right" }, mx = {
 	key: 0,
 	class: "mjr-context-menu-hint"
-}, cx = {
+}, hx = {
 	key: 1,
 	class: "mjr-context-menu-submenu-arrow"
-}, lx = {
+}, gx = {
 	key: 0,
 	class: "mjr-context-menu-separator"
-}, ux = { class: "mjr-context-menu-item-left" }, dx = {
+}, _x = { class: "mjr-context-menu-item-left" }, vx = {
 	key: 0,
 	class: "mjr-context-menu-hint"
-}, fx = {
+}, yx = {
 	__name: "GridContextMenu",
 	setup(e) {
 		let t = Z(null), n = Z(null), r = Z(null), i = null, a = null, o = G(() => l(an.main, 10031)), s = G(() => l(an.submenu, 10032)), c = G(() => l(an.tags, 10033));
@@ -23092,7 +23330,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					style: Cr(o.value),
 					role: "menu",
 					"aria-label": "Grid context menu"
-				}, [(V(!0), Y(H, null, ar(K(an).main.items, (e) => (V(), Y(H, { key: e.id }, [e.type === "separator" ? (V(), Y("div", ix)) : (V(), nr(a, {
+				}, [(V(!0), Y(H, null, ar(K(an).main.items, (e) => (V(), Y(H, { key: e.id }, [e.type === "separator" ? (V(), Y("div", dx)) : (V(), nr(a, {
 					key: 1,
 					type: "button",
 					class: X(["mjr-context-menu-item", {
@@ -23112,10 +23350,10 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					onMouseenter: (t) => _(e, t),
 					onMouseleave: (t) => v(e)
 				}, {
-					default: Q(() => [U("span", ax, [e.iconClass ? (V(), Y("i", {
+					default: Q(() => [U("span", fx, [e.iconClass ? (V(), Y("i", {
 						key: 0,
 						class: X(e.iconClass)
-					}, null, 2)) : W("", !0), U("span", null, q(e.label), 1)]), U("span", ox, [e.rightHint ? (V(), Y("span", sx, q(e.rightHint), 1)) : W("", !0), Array.isArray(e.submenu) && e.submenu.length ? (V(), Y("span", cx, " > ")) : W("", !0)])]),
+					}, null, 2)) : W("", !0), U("span", null, q(e.label), 1)]), U("span", px, [e.rightHint ? (V(), Y("span", mx, q(e.rightHint), 1)) : W("", !0), Array.isArray(e.submenu) && e.submenu.length ? (V(), Y("span", hx, " > ")) : W("", !0)])]),
 					_: 2
 				}, 1032, [
 					"class",
@@ -23135,7 +23373,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					"aria-label": "Grid context submenu",
 					onMouseenter: y,
 					onMouseleave: b
-				}, [(V(!0), Y(H, null, ar(K(an).submenu.items, (e) => (V(), Y(H, { key: e.id }, [e.type === "separator" ? (V(), Y("div", lx)) : (V(), nr(a, {
+				}, [(V(!0), Y(H, null, ar(K(an).submenu.items, (e) => (V(), Y(H, { key: e.id }, [e.type === "separator" ? (V(), Y("div", gx)) : (V(), nr(a, {
 					key: 1,
 					type: "button",
 					class: X(["mjr-context-menu-item", {
@@ -23152,10 +23390,10 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					tabindex: e.disabled ? -1 : 0,
 					onClick: (t) => g(e, t, "submenu")
 				}, {
-					default: Q(() => [U("span", ux, [e.iconClass ? (V(), Y("i", {
+					default: Q(() => [U("span", _x, [e.iconClass ? (V(), Y("i", {
 						key: 0,
 						class: X(e.iconClass)
-					}, null, 2)) : W("", !0), U("span", null, q(e.label), 1)]), e.rightHint ? (V(), Y("span", dx, q(e.rightHint), 1)) : W("", !0)]),
+					}, null, 2)) : W("", !0), U("span", null, q(e.label), 1)]), e.rightHint ? (V(), Y("span", vx, q(e.rightHint), 1)) : W("", !0)]),
 					_: 2
 				}, 1032, [
 					"class",
@@ -23178,7 +23416,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			]);
 		};
 	}
-}, px = { class: "mjr-workflow-picker-dialog mjr-workflow-info-dialog" }, mx = { class: "mjr-workflow-picker-header" }, hx = { class: "mjr-workflow-picker-title" }, gx = { class: "mjr-workflow-picker-subtitle" }, _x = { class: "mjr-workflow-info-form" }, vx = { class: "is-wide" }, yx = { class: "mjr-workflow-picker-footer" }, bx = {
+}, bx = { class: "mjr-workflow-picker-dialog mjr-workflow-info-dialog" }, xx = { class: "mjr-workflow-picker-header" }, Sx = { class: "mjr-workflow-picker-title" }, Cx = { class: "mjr-workflow-picker-subtitle" }, wx = { class: "mjr-workflow-info-form" }, Tx = { class: "is-wide" }, Ex = { class: "mjr-workflow-picker-footer" }, Dx = {
 	__name: "WorkflowInfoDialog",
 	setup(e) {
 		let t = Sr({
@@ -23199,30 +23437,30 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		async function a() {
 			let e = String(n.value?.filepath || "").trim();
 			if (!e) {
-				A(R("toast.workflowMissingPath", "Workflow file path is missing."), "error");
+				k(L("toast.workflowMissingPath", "Workflow file path is missing."), "error");
 				return;
 			}
-			let r = await g({
+			let r = await _({
 				filepath: e,
 				...t
 			}, { timeoutMs: 2e4 });
 			if (!r?.ok) {
-				A(r?.error || R("toast.workflowSaveFailed", "Failed to save workflow."), "error");
+				k(r?.error || L("toast.workflowSaveFailed", "Failed to save workflow."), "error");
 				return;
 			}
-			A(R("toast.workflowUpdated", "Workflow updated"), "success", 1800), window?.dispatchEvent?.(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-info" } })), i();
+			k(L("toast.workflowUpdated", "Workflow updated"), "success", 1800), window?.dispatchEvent?.(new CustomEvent("mjr:reload-grid", { detail: { reason: "workflow-info" } })), i();
 		}
 		return (e, n) => (V(), nr(Tr, { to: "body" }, [K(qi).open ? (V(), Y("div", {
 			key: 0,
 			class: "mjr-workflow-picker-backdrop",
 			onClick: pr(i, ["self"])
-		}, [U("section", px, [
-			U("header", mx, [U("div", null, [U("div", hx, q(K(R)("ctx.editWorkflowInfo", "Edit infos")), 1), U("div", gx, q(r.value), 1)]), U("button", {
+		}, [U("section", bx, [
+			U("header", xx, [U("div", null, [U("div", Sx, q(K(L)("ctx.editWorkflowInfo", "Edit infos")), 1), U("div", Cx, q(r.value), 1)]), U("button", {
 				type: "button",
 				class: "mjr-workflow-picker-close",
 				onClick: i
 			}, [...n[5] ||= [U("i", { class: "pi pi-times" }, null, -1)]])]),
-			U("div", _x, [
+			U("div", wx, [
 				U("label", null, [n[6] ||= U("span", null, "Task", -1), sr(U("input", {
 					"onUpdate:modelValue": n[0] ||= (e) => t.task = e,
 					type: "text",
@@ -23244,45 +23482,45 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					U("option", { value: "api" }, "api", -1),
 					U("option", { value: "cloud" }, "cloud", -1)
 				]], 512), [[wr, t.runs_on]])]),
-				U("label", vx, [n[11] ||= U("span", null, "Notes", -1), sr(U("textarea", {
+				U("label", Tx, [n[11] ||= U("span", null, "Notes", -1), sr(U("textarea", {
 					"onUpdate:modelValue": n[4] ||= (e) => t.notes = e,
 					rows: "5",
 					placeholder: "Notes displayed on workflow hover"
 				}, null, 512), [[Dr, t.notes]])])
 			]),
-			U("footer", yx, [U("button", {
+			U("footer", Ex, [U("button", {
 				type: "button",
 				class: "mjr-workflow-picker-secondary",
 				onClick: i
-			}, q(K(R)("btn.cancel", "Cancel")), 1), U("button", {
+			}, q(K(L)("btn.cancel", "Cancel")), 1), U("button", {
 				type: "button",
 				class: "mjr-workflow-picker-primary",
 				onClick: a
-			}, q(K(R)("btn.apply", "Apply")), 1)])
+			}, q(K(L)("btn.apply", "Apply")), 1)])
 		])])) : W("", !0)]));
 	}
-}, xx = { class: "mjr-workflow-picker-header" }, Sx = { class: "mjr-workflow-picker-title" }, Cx = {
+}, Ox = { class: "mjr-workflow-picker-header" }, kx = { class: "mjr-workflow-picker-title" }, Ax = {
 	key: 0,
 	class: "mjr-workflow-picker-source"
-}, wx = { class: "mjr-workflow-picker-toolbar" }, Tx = { class: "mjr-workflow-picker-search" }, Ex = ["placeholder"], Dx = { value: "" }, Ox = ["value"], kx = { value: "" }, Ax = ["value"], jx = { value: "" }, Mx = ["value"], Nx = { class: "mjr-workflow-picker-body" }, Px = {
+}, jx = { class: "mjr-workflow-picker-toolbar" }, Mx = { class: "mjr-workflow-picker-search" }, Nx = ["placeholder"], Px = { value: "" }, Fx = ["value"], Ix = { value: "" }, Lx = ["value"], Rx = { value: "" }, zx = ["value"], Bx = { class: "mjr-workflow-picker-body" }, Vx = {
 	key: 0,
 	class: "mjr-workflow-picker-empty"
-}, Fx = {
+}, Hx = {
 	key: 1,
 	class: "mjr-workflow-picker-empty is-error"
-}, Ix = {
+}, Ux = {
 	key: 2,
 	class: "mjr-workflow-picker-empty"
-}, Lx = ["onClick"], Rx = { class: "mjr-workflow-picker-thumb" }, zx = ["src", "alt"], Bx = {
+}, Wx = ["onClick"], Gx = { class: "mjr-workflow-picker-thumb" }, Kx = ["src", "alt"], qx = {
 	key: 1,
 	class: "pi pi-sitemap"
-}, Vx = { class: "mjr-workflow-picker-card-info" }, Hx = ["disabled"], Ux = { class: "mjr-workflow-picker-card-info" }, Wx = { class: "mjr-workflow-picker-footer" }, Gx = ["disabled"], Kx = 120, qx = {
+}, Jx = { class: "mjr-workflow-picker-card-info" }, Yx = ["disabled"], Xx = { class: "mjr-workflow-picker-card-info" }, Zx = { class: "mjr-workflow-picker-footer" }, Qx = ["disabled"], $x = 120, eS = {
 	__name: "WorkflowPickerDialog",
 	setup(e) {
-		let t = Z(""), n = Z(!1), r = Z(!1), i = Z(""), a = Z([]), s = Z(""), c = Z(0), l = Z(!1), u = 0, d = G(() => On.sourceAsset || null), f = G(() => On.workflow || null), p = G(() => String(On.mode || "") === "asset"), m = G(() => String(d.value?.filename || d.value?.display_name || f.value?.display_name || f.value?.filename || d.value?.filepath || f.value?.filepath || "")), h = G(() => x("task")), g = G(() => x("model_family")), _ = G(() => x("runs_on")), v = Z(""), y = Z(""), b = Z("");
+		let t = Z(""), n = Z(!1), r = Z(!1), i = Z(""), o = Z([]), s = Z(""), c = Z(0), l = Z(!1), u = 0, d = G(() => On.sourceAsset || null), f = G(() => On.workflow || null), p = G(() => String(On.mode || "") === "asset"), m = G(() => String(d.value?.filename || d.value?.display_name || f.value?.display_name || f.value?.filename || d.value?.filepath || f.value?.filepath || "")), h = G(() => x("task")), g = G(() => x("model_family")), _ = G(() => x("runs_on")), v = Z(""), y = Z(""), b = Z("");
 		function x(e) {
 			let t = /* @__PURE__ */ new Set();
-			for (let n of a.value || []) {
+			for (let n of o.value || []) {
 				let r = String(n?.[e] || "").trim();
 				r && t.add(r);
 			}
@@ -23290,7 +23528,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		}
 		let S = G(() => {
 			let e = t.value.trim().toLowerCase();
-			return (a.value || []).filter((t) => !p.value && (v.value && String(t?.task || "") !== v.value || y.value && String(t?.model_family || "") !== y.value || b.value && String(t?.runs_on || "") !== b.value) ? !1 : e ? [
+			return (o.value || []).filter((t) => !p.value && (v.value && String(t?.task || "") !== v.value || y.value && String(t?.model_family || "") !== y.value || b.value && String(t?.runs_on || "") !== b.value) ? !1 : e ? [
 				t?.display_name,
 				t?.filename,
 				t?.description,
@@ -23301,7 +23539,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				t?.kind,
 				t?.filepath
 			].join(" ").toLowerCase().includes(e) : !0);
-		}), C = G(() => (a.value || []).find((e) => String(e?.filepath || "") === s.value) || null);
+		}), C = G(() => (o.value || []).find((e) => String(e?.filepath || "") === s.value) || null);
 		function w(e) {
 			return String(e?.display_name || e?.name || e?.filename || "Workflow");
 		}
@@ -23323,24 +23561,24 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			e ? n.value = !0 : r.value = !0, i.value = "";
 			try {
 				if (p.value) {
-					a.value = Array.isArray(On.items) ? On.items.filter((e) => String(e?.filepath || "").trim()) : [], !s.value && a.value[0]?.filepath && (s.value = String(a.value[0].filepath));
+					o.value = Array.isArray(On.items) ? On.items.filter((e) => String(e?.filepath || "").trim()) : [], !s.value && o.value[0]?.filepath && (s.value = String(o.value[0].filepath));
 					return;
 				}
-				let n = await o({
+				let n = await a({
 					q: "*",
-					limit: Kx,
+					limit: $x,
 					offset: d,
 					sort: "mtime"
 				}, { timeoutMs: 2e4 });
 				if (t !== u) return;
 				if (!n?.ok) {
-					i.value = String(n?.error || "Failed to load workflows"), e && (a.value = []);
+					i.value = String(n?.error || "Failed to load workflows"), e && (o.value = []);
 					return;
 				}
 				let r = (Array.isArray(n?.data?.assets) ? n.data.assets : Array.isArray(n?.data) ? n.data : []).filter((e) => String(e?.filepath || "").trim());
-				a.value = e ? r : [...a.value, ...r], c.value = d + r.length, l.value = r.length >= Kx, !s.value && a.value[0]?.filepath && (s.value = String(a.value[0].filepath));
+				o.value = e ? r : [...o.value, ...r], c.value = d + r.length, l.value = r.length >= $x, !s.value && o.value[0]?.filepath && (s.value = String(o.value[0].filepath));
 			} catch (e) {
-				t === u && (i.value = String(e?.message || e || "Failed to load workflows"), a.value = []);
+				t === u && (i.value = String(e?.message || e || "Failed to load workflows"), o.value = []);
 			} finally {
 				t === u && (n.value = !1, r.value = !1);
 			}
@@ -23384,79 +23622,79 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			role: "dialog",
 			"aria-modal": "true"
 		}, [
-			U("header", xx, [U("div", Sx, [a[4] ||= U("i", { class: "pi pi-sitemap" }, null, -1), U("span", null, q(K(On).title), 1)]), U("button", {
+			U("header", Ox, [U("div", kx, [a[4] ||= U("i", { class: "pi pi-sitemap" }, null, -1), U("span", null, q(K(On).title), 1)]), U("button", {
 				class: "mjr-workflow-picker-icon-btn",
 				type: "button",
 				onClick: j
 			}, [...a[5] ||= [U("i", { class: "pi pi-times" }, null, -1)]])]),
-			m.value ? (V(), Y("div", Cx, [U("span", null, q(p.value ? K(R)("tab.workflow", "Workflow") : K(R)("dialog.workflowThumbnailSource", "Source")), 1), U("strong", null, q(m.value), 1)])) : W("", !0),
-			U("div", wx, [
-				U("label", Tx, [a[6] ||= U("i", { class: "pi pi-search" }, null, -1), sr(U("input", {
+			m.value ? (V(), Y("div", Ax, [U("span", null, q(p.value ? K(L)("tab.workflow", "Workflow") : K(L)("dialog.workflowThumbnailSource", "Source")), 1), U("strong", null, q(m.value), 1)])) : W("", !0),
+			U("div", jx, [
+				U("label", Mx, [a[6] ||= U("i", { class: "pi pi-search" }, null, -1), sr(U("input", {
 					"onUpdate:modelValue": a[0] ||= (e) => t.value = e,
 					type: "search",
-					placeholder: K(R)("search.workflows", "Search workflows...")
-				}, null, 8, Ex), [[Dr, t.value]])]),
+					placeholder: K(L)("search.workflows", "Search workflows...")
+				}, null, 8, Nx), [[Dr, t.value]])]),
 				p.value ? W("", !0) : sr((V(), Y("select", {
 					key: 0,
 					"onUpdate:modelValue": a[1] ||= (e) => v.value = e
-				}, [U("option", Dx, q(K(R)("filter.task", "Task")), 1), (V(!0), Y(H, null, ar(h.value, (e) => (V(), Y("option", {
+				}, [U("option", Px, q(K(L)("filter.task", "Task")), 1), (V(!0), Y(H, null, ar(h.value, (e) => (V(), Y("option", {
 					key: e,
 					value: e
-				}, q(e), 9, Ox))), 128))], 512)), [[wr, v.value]]),
+				}, q(e), 9, Fx))), 128))], 512)), [[wr, v.value]]),
 				p.value ? W("", !0) : sr((V(), Y("select", {
 					key: 1,
 					"onUpdate:modelValue": a[2] ||= (e) => y.value = e
-				}, [U("option", kx, q(K(R)("filter.model", "Model")), 1), (V(!0), Y(H, null, ar(g.value, (e) => (V(), Y("option", {
+				}, [U("option", Ix, q(K(L)("filter.model", "Model")), 1), (V(!0), Y(H, null, ar(g.value, (e) => (V(), Y("option", {
 					key: e,
 					value: e
-				}, q(e), 9, Ax))), 128))], 512)), [[wr, y.value]]),
+				}, q(e), 9, Lx))), 128))], 512)), [[wr, y.value]]),
 				p.value ? W("", !0) : sr((V(), Y("select", {
 					key: 2,
 					"onUpdate:modelValue": a[3] ||= (e) => b.value = e
-				}, [U("option", jx, q(K(R)("filter.runsOn", "Runs on")), 1), (V(!0), Y(H, null, ar(_.value, (e) => (V(), Y("option", {
+				}, [U("option", Rx, q(K(L)("filter.runsOn", "Runs on")), 1), (V(!0), Y(H, null, ar(_.value, (e) => (V(), Y("option", {
 					key: e,
 					value: e
-				}, q(e), 9, Mx))), 128))], 512)), [[wr, b.value]])
+				}, q(e), 9, zx))), 128))], 512)), [[wr, b.value]])
 			]),
-			U("div", Nx, [n.value ? (V(), Y("div", Px, q(K(R)("status.loading", "Loading...")), 1)) : i.value ? (V(), Y("div", Fx, q(i.value), 1)) : S.value.length ? (V(), Y(H, { key: 3 }, [(V(!0), Y(H, null, ar(S.value, (e) => (V(), Y("button", {
+			U("div", Bx, [n.value ? (V(), Y("div", Vx, q(K(L)("status.loading", "Loading...")), 1)) : i.value ? (V(), Y("div", Hx, q(i.value), 1)) : S.value.length ? (V(), Y(H, { key: 3 }, [(V(!0), Y(H, null, ar(S.value, (e) => (V(), Y("button", {
 				key: e.filepath,
 				type: "button",
 				class: X(["mjr-workflow-picker-card", { "is-selected": s.value === String(e.filepath || "") }]),
 				onClick: (t) => s.value = String(e.filepath || ""),
 				onDblclick: A
-			}, [U("div", Rx, [E(e) ? (V(), Y("img", {
+			}, [U("div", Gx, [E(e) ? (V(), Y("img", {
 				key: 0,
 				src: E(e),
 				alt: w(e),
 				loading: "lazy"
-			}, null, 8, zx)) : (V(), Y("i", Bx))]), U("div", Vx, [
+			}, null, 8, Kx)) : (V(), Y("i", qx))]), U("div", Jx, [
 				U("strong", null, q(w(e)), 1),
 				U("span", null, q(T(e)), 1),
 				U("small", null, q(e.filename), 1)
-			])], 42, Lx))), 128)), !p.value && l.value ? (V(), Y("button", {
+			])], 42, Wx))), 128)), !p.value && l.value ? (V(), Y("button", {
 				key: 0,
 				type: "button",
 				class: "mjr-workflow-picker-card mjr-workflow-picker-load-more",
 				disabled: r.value,
 				onClick: k
-			}, [a[7] ||= U("div", { class: "mjr-workflow-picker-thumb" }, [U("i", { class: "pi pi-angle-down" })], -1), U("div", Ux, [
-				U("strong", null, q(r.value ? K(R)("status.loading", "Loading...") : K(R)("action.loadMore", "Load more")), 1),
-				U("span", null, q(K(R)("tab.workflow", "Workflow")), 1),
+			}, [a[7] ||= U("div", { class: "mjr-workflow-picker-thumb" }, [U("i", { class: "pi pi-angle-down" })], -1), U("div", Xx, [
+				U("strong", null, q(r.value ? K(L)("status.loading", "Loading...") : K(L)("action.loadMore", "Load more")), 1),
+				U("span", null, q(K(L)("tab.workflow", "Workflow")), 1),
 				U("small", null, q(c.value) + " loaded", 1)
-			])], 8, Hx)) : W("", !0)], 64)) : (V(), Y("div", Ix, q(K(R)("toast.noWorkflowsFound", "No workflows found.")), 1))]),
-			U("footer", Wx, [U("button", {
+			])], 8, Yx)) : W("", !0)], 64)) : (V(), Y("div", Ux, q(K(L)("toast.noWorkflowsFound", "No workflows found.")), 1))]),
+			U("footer", Zx, [U("button", {
 				type: "button",
 				class: "mjr-workflow-picker-btn",
 				onClick: j
-			}, q(K(R)("action.cancel", "Cancel")), 1), U("button", {
+			}, q(K(L)("action.cancel", "Cancel")), 1), U("button", {
 				type: "button",
 				class: "mjr-workflow-picker-btn is-primary",
 				disabled: !C.value,
 				onClick: A
-			}, q(K(R)("action.apply", "Apply")), 9, Gx)])
+			}, q(K(L)("action.apply", "Apply")), 9, Qx)])
 		], 2)], 32)) : W("", !0)]));
 	}
-}, Jx = { class: "mjr-workflow-picker-dialog mjr-workflow-info-dialog" }, Yx = { class: "mjr-workflow-picker-header" }, Xx = { class: "mjr-workflow-picker-title" }, Zx = { class: "mjr-workflow-picker-subtitle" }, Qx = { class: "mjr-workflow-info-form" }, $x = { class: "is-wide" }, eS = { class: "is-wide" }, tS = { class: "mjr-workflow-picker-footer" }, nS = {
+}, tS = { class: "mjr-workflow-picker-dialog mjr-workflow-info-dialog" }, nS = { class: "mjr-workflow-picker-header" }, rS = { class: "mjr-workflow-picker-title" }, iS = { class: "mjr-workflow-picker-subtitle" }, aS = { class: "mjr-workflow-info-form" }, oS = { class: "is-wide" }, sS = { class: "is-wide" }, cS = { class: "mjr-workflow-picker-footer" }, lS = {
 	__name: "WorkflowSaveInfoDialog",
 	setup(e) {
 		let t = Sr({
@@ -23466,18 +23704,18 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			provider: "",
 			runs_on: "",
 			notes: ""
-		}), n = G(() => b_.initial || {}), r = G(() => R("dialog.saveWorkflowWithInfo", "Save workflow")), i = G(() => R("dialog.workflowInfoAutoFallback", "Leave fields empty to use automatic workflow detection."));
-		ir(() => b_.open, (e) => {
+		}), n = G(() => D_.initial || {}), r = G(() => L("dialog.saveWorkflowWithInfo", "Save workflow")), i = G(() => L("dialog.workflowInfoAutoFallback", "Leave fields empty to use automatic workflow detection."));
+		ir(() => D_.open, (e) => {
 			if (!e) return;
 			let r = n.value || {};
 			t.name = String(r.name || r.workflow?.name || r.workflow?.title || "workflow").trim(), t.task = String(r.task || ""), t.model_family = String(r.model_family || ""), t.provider = String(r.provider || ""), t.runs_on = String(r.runs_on || ""), t.notes = String(r.notes || "");
 		});
 		function a() {
-			S_(null);
+			k_(null);
 		}
 		function o() {
 			let e = String(t.name || "").trim();
-			e && S_({
+			e && k_({
 				name: e,
 				task: String(t.task || "").trim(),
 				model_family: String(t.model_family || "").trim(),
@@ -23488,12 +23726,12 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		}
 		return (e, n) => {
 			let s = gr("MButton"), c = gr("MInputText"), l = gr("MSelect"), u = gr("MTextarea");
-			return V(), nr(Tr, { to: "body" }, [K(b_).open ? (V(), Y("div", {
+			return V(), nr(Tr, { to: "body" }, [K(D_).open ? (V(), Y("div", {
 				key: 0,
 				class: "mjr-workflow-picker-backdrop",
 				onClick: pr(a, ["self"])
-			}, [U("section", Jx, [
-				U("header", Yx, [U("div", null, [U("div", Xx, q(r.value), 1), U("div", Zx, q(i.value), 1)]), J(s, {
+			}, [U("section", tS, [
+				U("header", nS, [U("div", null, [U("div", rS, q(r.value), 1), U("div", iS, q(i.value), 1)]), J(s, {
 					type: "button",
 					class: "mjr-workflow-picker-close",
 					onClick: a
@@ -23501,8 +23739,8 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					default: Q(() => [...n[6] ||= [U("i", { class: "pi pi-times" }, null, -1)]]),
 					_: 1
 				})]),
-				U("div", Qx, [
-					U("label", $x, [U("span", null, q(K(R)("dialog.workflowSaveName", "Workflow name")), 1), J(c, {
+				U("div", aS, [
+					U("label", oS, [U("span", null, q(K(L)("dialog.workflowSaveName", "Workflow name")), 1), J(c, {
 						modelValue: t.name,
 						"onUpdate:modelValue": n[0] ||= (e) => t.name = e,
 						type: "text",
@@ -23552,19 +23790,19 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 						"option-value": "value",
 						placeholder: "Auto"
 					}, null, 8, ["modelValue"])]),
-					U("label", eS, [n[11] ||= U("span", null, "Notes", -1), J(u, {
+					U("label", sS, [n[11] ||= U("span", null, "Notes", -1), J(u, {
 						modelValue: t.notes,
 						"onUpdate:modelValue": n[5] ||= (e) => t.notes = e,
 						rows: "5",
 						placeholder: "Notes displayed on workflow hover"
 					}, null, 8, ["modelValue"])])
 				]),
-				U("footer", tS, [J(s, {
+				U("footer", cS, [J(s, {
 					type: "button",
 					class: "mjr-workflow-picker-secondary",
 					onClick: a
 				}, {
-					default: Q(() => [tr(q(K(R)("btn.cancel", "Cancel")), 1)]),
+					default: Q(() => [tr(q(K(L)("btn.cancel", "Cancel")), 1)]),
 					_: 1
 				}), J(s, {
 					type: "button",
@@ -23572,13 +23810,13 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 					disabled: !String(t.name || "").trim(),
 					onClick: o
 				}, {
-					default: Q(() => [tr(q(K(R)("btn.save", "Save")), 1)]),
+					default: Q(() => [tr(q(K(L)("btn.save", "Save")), 1)]),
 					_: 1
 				}, 8, ["disabled"])])
 			])])) : W("", !0)]);
 		};
 	}
-}, rS = {
+}, uS = {
 	__name: "ContextMenuPortal",
 	setup(e) {
 		let t = Z(""), n = G(() => vn(t.value));
@@ -23587,14 +23825,14 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		}), Or(() => {
 			Rn(t.value), t.value = "";
 		}), (e, t) => n.value ? (V(), Y(H, { key: 0 }, [
-			J(fx),
-			J(rx),
-			J(qx),
-			J(bx),
-			J(nS)
+			J(yx),
+			J(ux),
+			J(eS),
+			J(Dx),
+			J(lS)
 		], 64)) : W("", !0);
 	}
-}, iS = {
+}, dS = {
 	class: "mjr-sidebar-content",
 	style: {
 		flex: "1",
@@ -23604,29 +23842,29 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		"flex-direction": "column",
 		gap: "16px"
 	}
-}, aS = {
+}, fS = {
 	class: "mjr-sidebar-rating-tags",
 	style: {
 		display: "flex",
 		"flex-direction": "column",
 		gap: "10px"
 	}
-}, oS = { style: {
+}, pS = { style: {
 	display: "flex",
 	"align-items": "center",
 	gap: "8px"
-} }, sS = { style: {
+} }, mS = { style: {
 	"font-size": "0.8em",
 	opacity: "0.6",
 	"min-width": "44px"
-} }, cS = { style: {
+} }, hS = { style: {
 	display: "flex",
 	"flex-direction": "column",
 	gap: "4px"
-} }, lS = { style: {
+} }, gS = { style: {
 	"font-size": "0.8em",
 	opacity: "0.6"
-} }, uS = {
+} }, _S = {
 	__name: "AssetSidebarContent",
 	props: {
 		asset: {
@@ -23656,7 +23894,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		});
 		function u() {
 			if (r.sidebar) try {
-				$m(r.sidebar);
+				oh(r.sidebar);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -23667,19 +23905,19 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			if (!(d.value || !f.value)) {
 				d.value = !0;
 				try {
-					A(R("toast.collectingFiles", "Collecting files..."), "info", 2500);
+					k(L("toast.collectingFiles", "Collecting files..."), "info", 2500);
 					let e = await n(f.value);
 					if (!e?.ok) {
-						A(e?.error || R("toast.collectFilesFailed", "Collect files failed"), "error");
+						k(e?.error || L("toast.collectFilesFailed", "Collect files failed"), "error");
 						return;
 					}
-					let t = e?.data || {}, r = Array.isArray(t.missing) ? t.missing.length : 0, i = t.fallback_used ? R("toast.collectFallbackDir", "output folder (source folder not writable)") : R("toast.collectSameDir", "asset folder"), a = R("toast.collectedFiles", "Collected {name} in {where}", {
+					let t = e?.data || {}, r = Array.isArray(t.missing) ? t.missing.length : 0, i = t.fallback_used ? L("toast.collectFallbackDir", "output folder (source folder not writable)") : L("toast.collectSameDir", "asset folder"), a = L("toast.collectedFiles", "Collected {name} in {where}", {
 						name: String(t.zip_name || "zip"),
 						where: i
 					});
-					r > 0 && (a += ` \u2014 ${r} ${R("toast.collectMissingInputs", "input(s) missing")}`), A(a, r > 0 ? "warning" : "success", 6e3);
+					r > 0 && (a += ` \u2014 ${r} ${L("toast.collectMissingInputs", "input(s) missing")}`), k(a, r > 0 ? "warning" : "success", 6e3);
 				} catch (e) {
-					console.debug?.(e), A(R("toast.collectFilesFailed", "Collect files failed"), "error");
+					console.debug?.(e), k(L("toast.collectFilesFailed", "Collect files failed"), "error");
 				} finally {
 					d.value = !1;
 				}
@@ -23688,23 +23926,23 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		return (t, n) => {
 			let r = gr("MButton");
 			return V(), Y(H, null, [
-				J(jb, {
+				J(Rb, {
 					asset: e.asset,
 					onClose: u
 				}, null, 8, ["asset"]),
-				U("div", iS, [a.value ? (V(), nr(Kb, {
+				U("div", dS, [a.value ? (V(), nr($b, {
 					key: 0,
 					asset: e.asset
 				}, null, 8, ["asset"])) : (V(), Y(H, { key: 1 }, [o.value ? W("", !0) : (V(), Y(H, { key: 0 }, [
-					J(Bb, {
+					J(qb, {
 						asset: e.asset,
 						"show-preview-thumb": l.value
 					}, null, 8, ["asset", "show-preview-thumb"]),
-					U("div", aS, [U("div", oS, [U("span", sS, q(K(R)("sidebar.rating", "Rating")), 1), J(Jb, {
+					U("div", fS, [U("div", pS, [U("span", mS, q(K(L)("sidebar.rating", "Rating")), 1), J(tx, {
 						asset: e.asset,
 						"model-value": s.value,
 						size: 60
-					}, null, 8, ["asset", "model-value"])]), U("div", cS, [U("span", lS, q(K(R)("sidebar.tags", "Tags")), 1), J(jr, {
+					}, null, 8, ["asset", "model-value"])]), U("div", hS, [U("span", gS, q(K(L)("sidebar.tags", "Tags")), 1), J(jr, {
 						asset: e.asset,
 						"model-value": c.value
 					}, null, 8, ["asset", "model-value"])])]),
@@ -23715,7 +23953,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 						class: "mjr-btn mjr-sidebar-collect-btn",
 						severity: "secondary",
 						disabled: d.value,
-						title: K(R)("sidebar.collectFilesTooltip", "Create a ZIP next to this asset with the workflow JSON, its media inputs and a manifest"),
+						title: K(L)("sidebar.collectFilesTooltip", "Create a ZIP next to this asset with the workflow JSON, its media inputs and a manifest"),
 						style: {
 							display: "flex",
 							"align-items": "center",
@@ -23725,16 +23963,16 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 						},
 						onClick: p
 					}, {
-						default: Q(() => [U("i", { class: X(d.value ? "pi pi-spin pi-spinner" : "pi pi-box") }, null, 2), U("span", null, q(d.value ? K(R)("sidebar.collectingFiles", "Collecting...") : K(R)("sidebar.collectFiles", "Collect files")), 1)]),
+						default: Q(() => [U("i", { class: X(d.value ? "pi pi-spin pi-spinner" : "pi pi-box") }, null, 2), U("span", null, q(d.value ? K(L)("sidebar.collectingFiles", "Collecting...") : K(L)("sidebar.collectFiles", "Collect files")), 1)]),
 						_: 1
 					}, 8, ["disabled", "title"])) : W("", !0),
 					J(Fn, { asset: e.asset }, null, 8, ["asset"])
 				], 64)), J(Bn, { asset: e.asset }, null, 8, ["asset"])], 64))]),
-				J(rS)
+				J(uS)
 			], 64);
 		};
 	}
-}, dS = {
+}, vS = {
 	key: 1,
 	class: "mjr-sidebar-placeholder",
 	style: {
@@ -23747,10 +23985,10 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		"font-size": "0.85em",
 		"text-align": "center"
 	}
-}, fS = {
+}, yS = {
 	__name: "SidebarSection",
 	setup(e, { expose: t }) {
-		let n = Z(null), { activeAsset: r, onUpdateCallback: i } = Vm();
+		let n = Z(null), { activeAsset: r, onUpdateCallback: i } = Jm();
 		return fr(() => {
 			let e = n.value;
 			if (!e) return;
@@ -23761,7 +23999,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			}, a = (n) => {
 				let r = n?.detail || {}, a = r.assetId ?? r.id ?? null, o = Number(r.rating);
 				if (!(!t(a) || !Number.isFinite(o))) {
-					Wm({ rating: o }, i.value);
+					Zm({ rating: o }, i.value);
 					try {
 						e._currentAsset && (e._currentAsset.rating = o), e._currentFullAsset && (e._currentFullAsset.rating = o);
 					} catch (e) {
@@ -23771,7 +24009,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			}, o = (n) => {
 				let r = n?.detail || {}, a = r.assetId ?? r.id ?? null, o = Array.isArray(r.tags) ? r.tags : null;
 				if (!(!t(a) || !o)) {
-					Wm({ tags: o }, i.value);
+					Zm({ tags: o }, i.value);
 					try {
 						e._currentAsset && (e._currentAsset.tags = o), e._currentFullAsset && (e._currentFullAsset.tags = o);
 					} catch (e) {
@@ -23793,11 +24031,11 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			}, e._dispose = e.dispose;
 			let l = c ? { signal: c.signal } : void 0;
 			try {
-				window.addEventListener(ct, a, l), window.addEventListener(nt, o, l);
+				window.addEventListener(lt, a, l), window.addEventListener(rt, o, l);
 			} catch (e) {
 				console.debug?.(e);
 				try {
-					window.addEventListener(ct, a), window.addEventListener(nt, o), s.push(() => window.removeEventListener(ct, a)), s.push(() => window.removeEventListener(nt, o));
+					window.addEventListener(lt, a), window.addEventListener(rt, o), s.push(() => window.removeEventListener(lt, a)), s.push(() => window.removeEventListener(rt, o));
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -23823,7 +24061,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				transition: "width 140ms ease,max-width 140ms ease,flex-basis 140ms ease,border-color 140ms ease",
 				contain: "layout paint style"
 			}
-		}, [K(r) ? (V(), nr(uS, {
+		}, [K(r) ? (V(), nr(_S, {
 			key: 0,
 			asset: K(r),
 			"on-update": K(i),
@@ -23832,9 +24070,9 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			"asset",
 			"on-update",
 			"sidebar"
-		])) : (V(), Y("div", dS, q(K(R)("sidebar.placeholderSelectAsset", "Select an asset to view details")), 1))], 512));
+		])) : (V(), Y("div", vS, q(K(L)("sidebar.placeholderSelectAsset", "Select an asset to view details")), 1))], 512));
 	}
-}, pS = {
+}, bS = {
 	__name: "App",
 	setup(e) {
 		let t = Z(null), n = Z(null), r = Z(null), i = Z(null), a = Z(null), o = Z(null), s = null;
@@ -23843,7 +24081,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			let e = {};
 			n.value && (e.statusSection = n.value.statusSection, e.statusDot = n.value.statusDot, e.statusText = n.value.statusText, e.capabilitiesSection = n.value.capabilitiesSection), r.value && (e.headerSection = r.value), i.value && (e.summaryBar = i.value.summaryBar, e.updateSummaryBar = i.value.updateSummaryBar, e.folderBreadcrumb = i.value.folderBreadcrumb, e.folderBreadcrumbController = i.value), a.value && (e.browseSection = a.value.browseSection, e.gridWrapper = a.value.gridWrapper, e.gridContainer = a.value.gridContainer, e.onGridContainerReady = (...e) => a.value?.onGridContainerReady?.(...e), e.bindGridHostState = (...e) => a.value?.bindGridHostState?.(...e), e.restoreGridUiState = (...e) => a.value?.restoreGridUiState?.(...e), e.initAssetsQueryController = (...e) => a.value?.initAssetsQueryController?.(...e), e.loadAssets = (e, t = "*", n = {}) => a.value?.loadAssets?.(t, n), e.loadAssetsFromList = (e, t = [], n = {}) => a.value?.loadAssetsFromList?.(t, n), e.prepareGridForScopeSwitch = (e) => a.value?.prepareGridForScopeSwitch?.(), e.refreshGrid = (e) => a.value?.refreshGrid?.(), e.captureAnchor = (e) => a.value?.captureAnchor?.(), e.restoreAnchor = (e, t) => a.value?.restoreAnchor?.(t), e.hydrateGridFromSnapshot = (e, t = {}, n = {}) => a.value?.hydrateGridFromSnapshot?.(t, n), e.upsertAsset = (e, t) => a.value?.upsertAsset?.(t), e.removeAssets = (e, t = [], n = {}) => a.value?.removeAssets?.(t, n), e.disposeGrid = (e) => a.value?.disposeGrid?.()), o.value && (e.sidebar = o.value.sidebar);
 			try {
-				s = await __(t.value, {
+				s = await w_(t.value, {
 					useComfyThemeUI: !0,
 					external: e
 				});
@@ -23851,7 +24089,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 				console.warn("[Majoor] App.vue: mountAssetsManagerPanelRuntime failed", e);
 			}
 			try {
-				uh().validatePersistedCustomRoot?.();
+				_h().validatePersistedCustomRoot?.();
 			} catch {}
 		}), Or(() => {
 			try {
@@ -23859,27 +24097,27 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			} catch {}
 			s = null;
 		}), (e, s) => (V(), Y(H, null, [
-			J(y_, {
+			J(E_, {
 				ref_key: "statusSectionRef",
 				ref: n
 			}, null, 512),
-			J(Qy, {
+			J(ab, {
 				ref_key: "headerSectionRef",
 				ref: r
 			}, null, 512),
-			J(gb, {
+			J(Cb, {
 				ref_key: "summaryBarSectionRef",
 				ref: i
 			}, null, 512),
-			J(Ob, {
+			J(Fb, {
 				ref_key: "assetsGridRef",
 				ref: a
 			}, null, 512),
-			J(fS, {
+			J(yS, {
 				ref_key: "sidebarSectionRef",
 				ref: o
 			}, null, 512),
-			J(rS),
+			J(uS),
 			U("div", {
 				ref_key: "containerRef",
 				ref: t,
@@ -23893,7 +24131,7 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			}, null, 512)
 		], 64));
 	}
-}, mS = {
+}, xS = {
 	__name: "GeneratedFeedApp",
 	setup(e) {
 		let t = Z(null), n = null;
@@ -23915,16 +24153,16 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 		}
 		return fr(() => {
 			if (t.value) try {
-				r(t.value), n = Yd(t.value);
+				r(t.value), n = nf(t.value);
 			} catch (e) {
 				console.warn("[Majoor] GeneratedFeedApp.vue: createGeneratedFeedHost failed", e);
 			}
 		}), Or(() => {
 			try {
-				Xd(n);
+				rf(n);
 			} catch {}
 			n = null;
-		}), (e, n) => (V(), Y(H, null, [J(rS), U("div", {
+		}), (e, n) => (V(), Y(H, null, [J(uS), U("div", {
 			ref_key: "containerRef",
 			ref: t,
 			class: "mjr-vue-feed-root",
@@ -23939,32 +24177,32 @@ var Pb = { class: "mjr-sidebar-preview" }, Fb = ["src"], Ib = ["src"], Lb = ["sr
 			}
 		}, null, 512)], 64));
 	}
-}, hS = "data-mjr-topbar-mfv-host", gS = "data-mjr-topbar-mfv-button", _S = "data-mjr-topbar-mfv-slot", vS = "label.floatingViewer", yS = "Viewer", bS = "V", xS = null, SS = null, CS = null, wS = null, TS = null, ES = !1, DS = null, OS = !1, kS = !1;
-function AS(e) {
-	if (!(xS && SS === e)) {
+}, SS = "data-mjr-topbar-mfv-host", CS = "data-mjr-topbar-mfv-button", wS = "data-mjr-topbar-mfv-slot", TS = "label.floatingViewer", ES = "Viewer", DS = "V", OS = null, kS = null, AS = null, jS = null, MS = null, NS = !1, PS = null, FS = !1, IS = !1;
+function LS(e) {
+	if (!(OS && kS === e)) {
 		if (!e) {
-			!CS && typeof MutationObserver < "u" && (CS = new MutationObserver(() => {
-				jS() && (CS?.disconnect?.(), CS = null, US());
-			}), CS.observe(document.body, {
+			!AS && typeof MutationObserver < "u" && (AS = new MutationObserver(() => {
+				RS() && (AS?.disconnect?.(), AS = null, XS());
+			}), AS.observe(document.body, {
 				childList: !0,
 				subtree: !0
 			}));
 			return;
 		}
 		try {
-			xS?.disconnect?.();
+			OS?.disconnect?.();
 		} catch {}
-		xS = new MutationObserver(() => US()), xS.observe(e, { childList: !0 }), SS = e;
+		OS = new MutationObserver(() => XS()), OS.observe(e, { childList: !0 }), kS = e;
 		try {
-			CS?.disconnect?.();
+			AS?.disconnect?.();
 		} catch {}
-		CS = null;
+		AS = null;
 	}
 }
-function jS() {
+function RS() {
 	return typeof document > "u" ? null : document.querySelector(".actionbar-container");
 }
-function MS(e = jS()) {
+function zS(e = RS()) {
 	if (typeof document > "u") return;
 	let t = document.documentElement?.style;
 	if (!t) return;
@@ -23975,176 +24213,176 @@ function MS(e = jS()) {
 	let n = e.getBoundingClientRect(), r = Math.max(60, Math.ceil(n.bottom + 12));
 	t.setProperty("--mjr-mfv-top-offset", `${r}px`);
 }
-function NS(e) {
+function BS(e) {
 	return e && e.querySelector(".queue-button-group") || null;
 }
-function PS(e) {
+function VS(e) {
 	if (!e) return null;
-	let t = e.querySelector(`[${_S}]`);
-	t || (t = document.createElement("div"), t.setAttribute(_S, "1"), t.className = "flex h-full items-center pointer-events-auto", t.style.position = "relative", t.style.zIndex = "10030", t.style.padding = "0 4px");
-	let n = NS(e), r = n?.parentElement || e;
+	let t = e.querySelector(`[${wS}]`);
+	t || (t = document.createElement("div"), t.setAttribute(wS, "1"), t.className = "flex h-full items-center pointer-events-auto", t.style.position = "relative", t.style.zIndex = "10030", t.style.padding = "0 4px");
+	let n = BS(e), r = n?.parentElement || e;
 	return t.parentElement === r ? n && r && t.previousSibling !== n ? r.insertBefore(t, n.nextSibling) : !n && t !== r.lastElementChild && r.appendChild(t) : n && r ? r.insertBefore(t, n.nextSibling) : r.appendChild(t), t;
 }
-function FS(e = "pi pi-eye") {
+function HS(e = "pi pi-eye") {
 	let t = document.createElement("i");
 	return t.className = e, t.setAttribute("aria-hidden", "true"), t;
 }
-function IS(e = "Viewer") {
+function US(e = "Viewer") {
 	let t = document.createElement("span");
 	return t.className = "mjr-topbar-mfv-label", t.textContent = e, t;
 }
-function LS(e) {
+function WS(e) {
 	if (!e) return;
-	let t = OS ? R("tooltip.closeMFV", "Close Floating Viewer") : R("tooltip.openMFV", "Open Floating Viewer");
-	zt(e, t, bS, { ariaLabel: t }), e.setAttribute("aria-pressed", OS ? "true" : "false"), e.classList.toggle("primary", OS), e.classList.toggle("mjr-topbar-mfv-active", OS), e.replaceChildren(FS(OS ? "pi pi-eye-slash" : "pi pi-eye"), IS(R(vS, yS)));
-}
-function RS() {
-	try {
-		window.dispatchEvent(new Event(B.MFV_TOGGLE));
-	} catch (e) {
-		console.debug?.("[Majoor] top bar MFV launch failed", e);
-	}
-	US();
-}
-function zS() {
-	let e = document.createElement("button");
-	return e.type = "button", e.setAttribute(gS, "1"), e.className = "comfyui-button mjr-topbar-mfv-button", e.style.position = "relative", e.style.zIndex = "10030", e.style.width = "auto", e.style.height = "32px", e.style.minWidth = "32px", e.style.padding = "0 10px", e.style.gap = "6px", e.style.display = "inline-flex", e.style.alignItems = "center", e.style.justifyContent = "center", e.style.whiteSpace = "nowrap", e.addEventListener("click", RS), LS(e), e;
-}
-function BS() {
-	let e = document.createElement("div");
-	return e.setAttribute(hS, "1"), e.className = "mjr-topbar-mfv-button-host", e.style.position = "relative", e.appendChild(zS()), e;
-}
-function VS() {
-	if (typeof document > "u" || kS) return;
-	let e = !!document.querySelector(".mjr-mfv.is-visible");
-	OS !== e && (OS = e);
-}
-function HS() {
-	let e = jS();
-	if (!e) return MS(null), null;
-	AS(e), VS();
-	let t = PS(e);
-	if (!t) return MS(e), null;
-	let n = t.querySelector(`[${hS}]`);
-	return n ||= BS(), n.parentElement !== t && t.replaceChildren(n), MS(e), LS(n.querySelector(`[${gS}]`)), t;
-}
-function US() {
-	ES || (ES = !0, DS = window.setTimeout(() => {
-		ES = !1, DS = null, HS();
-	}, 32));
-}
-function WS() {
-	return typeof window > "u" || typeof document > "u" || !document.body ? !1 : (US(), wS || (wS = (e) => {
-		OS = !!e?.detail?.visible, kS = !0, US();
-	}, window.addEventListener(B.MFV_VISIBILITY_CHANGED, wS)), TS || (TS = () => US(), window.addEventListener("resize", TS)), AS(jS()), !0);
+	let t = FS ? L("tooltip.closeMFV", "Close Floating Viewer") : L("tooltip.openMFV", "Open Floating Viewer");
+	zt(e, t, DS, { ariaLabel: t }), e.setAttribute("aria-pressed", FS ? "true" : "false"), e.classList.toggle("primary", FS), e.classList.toggle("mjr-topbar-mfv-active", FS), e.replaceChildren(HS(FS ? "pi pi-eye-slash" : "pi pi-eye"), US(L(TS, ES)));
 }
 function GS() {
 	try {
-		xS?.disconnect?.();
+		window.dispatchEvent(new Event(z.MFV_TOGGLE));
+	} catch (e) {
+		console.debug?.("[Majoor] top bar MFV launch failed", e);
+	}
+	XS();
+}
+function KS() {
+	let e = document.createElement("button");
+	return e.type = "button", e.setAttribute(CS, "1"), e.className = "comfyui-button mjr-topbar-mfv-button", e.style.position = "relative", e.style.zIndex = "10030", e.style.width = "auto", e.style.height = "32px", e.style.minWidth = "32px", e.style.padding = "0 10px", e.style.gap = "6px", e.style.display = "inline-flex", e.style.alignItems = "center", e.style.justifyContent = "center", e.style.whiteSpace = "nowrap", e.addEventListener("click", GS), WS(e), e;
+}
+function qS() {
+	let e = document.createElement("div");
+	return e.setAttribute(SS, "1"), e.className = "mjr-topbar-mfv-button-host", e.style.position = "relative", e.appendChild(KS()), e;
+}
+function JS() {
+	if (typeof document > "u" || IS) return;
+	let e = !!document.querySelector(".mjr-mfv.is-visible");
+	FS !== e && (FS = e);
+}
+function YS() {
+	let e = RS();
+	if (!e) return zS(null), null;
+	LS(e), JS();
+	let t = VS(e);
+	if (!t) return zS(e), null;
+	let n = t.querySelector(`[${SS}]`);
+	return n ||= qS(), n.parentElement !== t && t.replaceChildren(n), zS(e), WS(n.querySelector(`[${CS}]`)), t;
+}
+function XS() {
+	NS || (NS = !0, PS = window.setTimeout(() => {
+		NS = !1, PS = null, YS();
+	}, 32));
+}
+function ZS() {
+	return typeof window > "u" || typeof document > "u" || !document.body ? !1 : (XS(), jS || (jS = (e) => {
+		FS = !!e?.detail?.visible, IS = !0, XS();
+	}, window.addEventListener(z.MFV_VISIBILITY_CHANGED, jS)), MS || (MS = () => XS(), window.addEventListener("resize", MS)), LS(RS()), !0);
+}
+function QS() {
+	try {
+		OS?.disconnect?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
-	xS = null, SS = null;
+	OS = null, kS = null;
 	try {
-		CS?.disconnect?.();
+		AS?.disconnect?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
-	CS = null;
+	AS = null;
 	try {
-		DS && window.clearTimeout(DS);
+		PS && window.clearTimeout(PS);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	DS = null, wS && typeof window < "u" && window.removeEventListener(B.MFV_VISIBILITY_CHANGED, wS), wS = null, TS && typeof window < "u" && window.removeEventListener("resize", TS), TS = null, ES = !1, OS = !1, kS = !1;
+	PS = null, jS && typeof window < "u" && window.removeEventListener(z.MFV_VISIBILITY_CHANGED, jS), jS = null, MS && typeof window < "u" && window.removeEventListener("resize", MS), MS = null, NS = !1, FS = !1, IS = !1;
 	try {
-		document.documentElement?.style?.setProperty("--mjr-mfv-top-offset", "60px"), document.querySelector(`[${hS}]`)?.remove?.(), document.querySelector(`[${_S}]`)?.remove?.();
+		document.documentElement?.style?.setProperty("--mjr-mfv-top-offset", "60px"), document.querySelector(`[${SS}]`)?.remove?.(), document.querySelector(`[${wS}]`)?.remove?.();
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
 //#endregion
 //#region ui/features/runtime/entryUiRegistration.ts
-var KS = "mjr-global-runtime-root", qS = "_mjrGlobalRuntimeVueApp", JS = "_mjrSidebarVueApp", YS = "_mjrFeedVueApp", XS = "majoor-generated-feed", ZS = null;
-function QS() {
+var $S = "mjr-global-runtime-root", eC = "_mjrGlobalRuntimeVueApp", tC = "_mjrSidebarVueApp", nC = "_mjrFeedVueApp", rC = "majoor-generated-feed", iC = null;
+function aC() {
 	if (typeof document > "u" || !document?.body) return null;
-	let e = document.getElementById(KS);
-	return e || (e = document.createElement("div"), e.id = KS, e.setAttribute("role", "presentation"), e.style.cssText = "position:fixed;inset:0;overflow:visible;pointer-events:none;z-index:10020;", document.body.appendChild(e), e);
+	let e = document.getElementById($S);
+	return e || (e = document.createElement("div"), e.id = $S, e.setAttribute("role", "presentation"), e.style.cssText = "position:fixed;inset:0;overflow:visible;pointer-events:none;z-index:10020;", document.body.appendChild(e), e);
 }
-function $S() {
+function oC() {
 	try {
-		let e = QS();
+		let e = aC();
 		if (!e) return !1;
-		let t = !!En(e, Ip, qS);
-		return WS(), t;
+		let t = !!En(e, Up, eC);
+		return ZS(), t;
 	} catch {
 		return !1;
 	}
 }
-function eC() {
+function sC() {
 	try {
-		GS();
-		let e = document.getElementById(KS);
+		QS();
+		let e = document.getElementById($S);
 		if (!e) return;
-		Dn(e, qS), e.remove?.();
+		Dn(e, eC), e.remove?.();
 	} catch {}
 }
-function tC(e, t) {
-	let n = Ge(e, t);
-	if (zf(), !n) try {
-		window.dispatchEvent(new Event(B.OPEN_ASSETS_MANAGER));
+function cC(e, t) {
+	let n = Ke(e, t);
+	if (Kf(), !n) try {
+		window.dispatchEvent(new Event(z.OPEN_ASSETS_MANAGER));
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return n;
 }
-function nC() {
+function lC() {
 	try {
-		window.dispatchEvent(new CustomEvent(B.RELOAD_GRID, { detail: { reason: "command" } }));
+		window.dispatchEvent(new CustomEvent(z.RELOAD_GRID, { detail: { reason: "command" } }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-function rC(e) {
-	let t = Qe(e, XS);
+function uC(e) {
+	let t = $e(e, rC);
 	if (!t) try {
-		Nd();
+		Bd();
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return t;
 }
-async function iC() {
+async function dC() {
 	try {
-		let e = await ue(lt.BROWSE_FOLDER, {});
+		let e = await ue(B.BROWSE_FOLDER, {});
 		if (e?.ok) return String(e?.data?.path || "").trim();
 		let t = String(e?.code || "").trim();
-		t && t !== "CANCELLED" && A(e?.error || R("toast.nativeFolderBrowserUnavailable", "Native folder browser unavailable. Please enter path manually."), "warning", 3500);
+		t && t !== "CANCELLED" && k(e?.error || L("toast.nativeFolderBrowserUnavailable", "Native folder browser unavailable. Please enter path manually."), "warning", 3500);
 	} catch (e) {
-		console.debug?.(e), A(R("toast.nativeFolderBrowserUnavailable", "Native folder browser unavailable. Please enter path manually."), "warning", 3500);
+		console.debug?.(e), k(L("toast.nativeFolderBrowserUnavailable", "Native folder browser unavailable. Please enter path manually."), "warning", 3500);
 	}
 	return "";
 }
-async function aC(e, { settingId: t, settingsPathKey: n, save: r, successMessage: i, restartRequired: a = !1 }) {
-	let o = await iC();
+async function fC(e, { settingId: t, settingsPathKey: n, save: r, successMessage: i, restartRequired: a = !1 }) {
+	let o = await dC();
 	if (!o) return !1;
 	let s = await r(o);
-	if (!s?.ok) return A(s?.error || R("toast.settingsPathSaveFailed", "Failed to save path"), "error"), !1;
+	if (!s?.ok) return k(s?.error || L("toast.settingsPathSaveFailed", "Failed to save path"), "error"), !1;
 	try {
 		let r = mn();
-		r.paths = r.paths || {}, r.paths[n] = o, Xt(r), Le(e, t, o), window.dispatchEvent(new CustomEvent(B.SETTINGS_CHANGED, { detail: {
+		r.paths = r.paths || {}, r.paths[n] = o, Xt(r), Re(e, t, o), window.dispatchEvent(new CustomEvent(z.SETTINGS_CHANGED, { detail: {
 			key: `paths.${n}`,
 			value: o
 		} }));
 	} catch (e) {
 		console.debug?.(e);
 	}
-	return A(a ? `${i} ${R("toast.restartComfyUiToApply", "Restart ComfyUI to apply.")}` : i, "success", 2800), !0;
+	return k(a ? `${i} ${L("toast.restartComfyUiToApply", "Restart ComfyUI to apply.")}` : i, "success", 2800), !0;
 }
-function oC(e) {
-	return kC(e).find(OC) || null;
+function pC(e) {
+	return IC(e).find(FC) || null;
 }
-function sC(e) {
+function mC(e) {
 	let t = String(e?.id ?? e?.nodeId ?? e?.node_id ?? "").trim();
 	if (!t) return null;
 	let n = String(e?.comfyClass || e?.type || e?.constructor?.type || "").trim();
@@ -24156,7 +24394,7 @@ function sC(e) {
 		title: String(e?.title || e?.properties?.title || e?.properties?.name || n || "").trim()
 	};
 }
-async function cC(e) {
+async function hC(e) {
 	if (!e) return [];
 	try {
 		let t = (await import("./chunks/NodeStreamController-f2tXbqnR.js")).extractNodeFileData?.(e), n = String(t?.filename || "").trim();
@@ -24170,26 +24408,26 @@ async function cC(e) {
 		return console.debug?.(e), [];
 	}
 }
-function lC(e) {
+function gC(e) {
 	try {
 		if (typeof window > "u") return;
-		window.MajoorAssetsManager = window.MajoorAssetsManager || {}, window.MajoorAssetsManager.pendingNodeContext = e, window.dispatchEvent(new CustomEvent(B.OPEN_NODE_CONTEXT, { detail: e }));
+		window.MajoorAssetsManager = window.MajoorAssetsManager || {}, window.MajoorAssetsManager.pendingNodeContext = e, window.dispatchEvent(new CustomEvent(z.OPEN_NODE_CONTEXT, { detail: e }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-async function uC(e, t, n) {
-	tC(e, t);
-	let r = sC(n) || {}, i = await cC(n);
+async function _C(e, t, n) {
+	cC(e, t);
+	let r = mC(n) || {}, i = await hC(n);
 	i.length && (r.files = i);
 	let a = String(n?.comfyClass || n?.type || "").toLowerCase();
-	return i.length && /load|upload/.test(a) && (delete r.source_node_id, delete r.sourceNodeId), !r.source_node_id && !i.length ? (A(R("toast.nodeContextMissing", "Select an output node first."), "info", 2200), !1) : (lC(r), !0);
+	return i.length && /load|upload/.test(a) && (delete r.source_node_id, delete r.sourceNodeId), !r.source_node_id && !i.length ? (k(L("toast.nodeContextMissing", "Select an output node first."), "info", 2200), !1) : (gC(r), !0);
 }
-async function dC(e) {
+async function vC(e) {
 	try {
-		let t = await cC(e);
+		let t = await hC(e);
 		if (t.length) {
-			let { floatingViewerManager: e } = await import("./chunks/floatingViewerManager-CGdpmtv-.js").then((e) => e.n);
+			let { floatingViewerManager: e } = await import("./chunks/floatingViewerManager-C0fDYFQu.js").then((e) => e.n);
 			if (await e.openAssets({
 				assets: t,
 				index: 0
@@ -24199,40 +24437,40 @@ async function dC(e) {
 		console.debug?.(e);
 	}
 	try {
-		window.dispatchEvent(new Event(B.MFV_OPEN));
+		window.dispatchEvent(new Event(z.MFV_OPEN));
 	} catch (e) {
 		console.debug?.(e);
 	}
 	return !1;
 }
-function fC(e, t) {
-	let n = ZS;
-	return n ? (uC(e, t, n), !0) : (A(R("toast.nodeContextMissing", "Select an output node first."), "info", 2200), !1);
+function yC(e, t) {
+	let n = iC;
+	return n ? (_C(e, t, n), !0) : (k(L("toast.nodeContextMissing", "Select an output node first."), "info", 2200), !1);
 }
-function pC(e, { sidebarTabId: t, triggerStartupScan: n }) {
+function bC(e, { sidebarTabId: t, triggerStartupScan: n }) {
 	return [
 		{
 			id: "mjr.openAssetsManager",
-			label: R("manager.title", "Assets Manager"),
-			tooltip: R("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
-			title: R("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
-			description: R("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
+			label: L("manager.title", "Assets Manager"),
+			tooltip: L("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
+			title: L("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
+			description: L("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
 			icon: "pi pi-folder-open",
-			function: () => tC(e, t)
+			function: () => cC(e, t)
 		},
 		{
 			id: "mjr.scanAssets",
-			label: R("command.scanAssets", "Scan assets"),
+			label: L("command.scanAssets", "Scan assets"),
 			icon: "pi pi-refresh",
 			function: () => n()
 		},
 		{
 			id: "mjr.toggleFloatingViewer",
-			label: R("command.toggleFloatingViewer", "Toggle floating viewer"),
+			label: L("command.toggleFloatingViewer", "Toggle floating viewer"),
 			icon: "pi pi-images",
 			function: () => {
 				try {
-					window.dispatchEvent(new Event(B.MFV_TOGGLE));
+					window.dispatchEvent(new Event(z.MFV_TOGGLE));
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -24240,20 +24478,20 @@ function pC(e, { sidebarTabId: t, triggerStartupScan: n }) {
 		},
 		{
 			id: "mjr.refreshAssetsGrid",
-			label: R("command.refreshAssetsGrid", "Refresh assets grid"),
+			label: L("command.refreshAssetsGrid", "Refresh assets grid"),
 			icon: "pi pi-sync",
-			function: () => nC()
+			function: () => lC()
 		},
 		{
 			id: "mjr.openFloatingViewer",
-			label: R("command.openFloatingViewer", "Open floating viewer"),
-			tooltip: R("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
-			title: R("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
-			description: R("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
+			label: L("command.openFloatingViewer", "Open floating viewer"),
+			tooltip: L("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
+			title: L("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
+			description: L("tooltip.openFloatingViewer", "Open Majoor floating viewer"),
 			icon: "pi pi-window-maximize",
 			function: () => {
 				try {
-					window.dispatchEvent(new Event(B.MFV_OPEN));
+					window.dispatchEvent(new Event(z.MFV_OPEN));
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -24261,71 +24499,71 @@ function pC(e, { sidebarTabId: t, triggerStartupScan: n }) {
 		},
 		{
 			id: "mjr.openGeneratedFeed",
-			label: R("command.openGeneratedFeed", "Open generated feed"),
-			tooltip: R("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
-			title: R("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
-			description: R("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
+			label: L("command.openGeneratedFeed", "Open generated feed"),
+			tooltip: L("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
+			title: L("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
+			description: L("tooltip.openGeneratedFeed", "Open the Majoor generated feed panel"),
 			icon: "pi pi-list",
-			function: () => rC(e)
+			function: () => uC(e)
 		},
 		{
 			id: "mjr.openSettings",
-			label: R("command.openSettings", "Open Majoor settings"),
+			label: L("command.openSettings", "Open Majoor settings"),
 			icon: "pi pi-cog",
 			function: () => Jn(e)
 		},
 		{
 			id: "mjr.pickOutputDirectory",
-			label: R("command.pickOutputDirectory", "Pick output directory"),
-			tooltip: R("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
-			title: R("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
-			description: R("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
+			label: L("command.pickOutputDirectory", "Pick output directory"),
+			tooltip: L("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
+			title: L("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
+			description: L("tooltip.pickOutputDirectory", "Use the native folder browser to set Majoor's generation output directory"),
 			icon: "pi pi-folder",
-			function: () => aC(e, {
+			function: () => fC(e, {
 				settingId: "Majoor.Paths.OutputDirectory",
 				settingsPathKey: "outputDirectory",
-				save: y,
-				successMessage: R("toast.outputDirectorySaved", "Output directory saved.")
+				save: de,
+				successMessage: L("toast.outputDirectorySaved", "Output directory saved.")
 			})
 		},
 		{
 			id: "mjr.pickIndexDirectory",
-			label: R("command.pickIndexDirectory", "Pick index directory"),
-			tooltip: R("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
-			title: R("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
-			description: R("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
+			label: L("command.pickIndexDirectory", "Pick index directory"),
+			tooltip: L("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
+			title: L("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
+			description: L("tooltip.pickIndexDirectory", "Use the native folder browser to set Majoor's index database directory"),
 			icon: "pi pi-database",
-			function: () => aC(e, {
+			function: () => fC(e, {
 				settingId: "Majoor.Paths.IndexDirectory",
 				settingsPathKey: "indexDirectory",
-				save: De,
-				successMessage: R("toast.indexDirectorySaved", "Index directory saved."),
+				save: w,
+				successMessage: L("toast.indexDirectorySaved", "Index directory saved."),
 				restartRequired: !0
 			})
 		},
 		{
 			id: "mjr.openNodeContext",
-			label: R("command.openNodeContext", "Show assets from selected node"),
-			tooltip: R("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
-			title: R("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
-			description: R("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
+			label: L("command.openNodeContext", "Show assets from selected node"),
+			tooltip: L("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
+			title: L("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
+			description: L("tooltip.openNodeContext", "Show the latest indexed assets produced by this node"),
 			icon: "pi pi-sitemap",
-			function: () => fC(e, t)
+			function: () => yC(e, t)
 		},
 		{
 			id: "mjr.openNodeInFloatingViewer",
-			label: R("command.openNodeInFloatingViewer", "Open node media in floating viewer"),
-			tooltip: R("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
-			title: R("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
-			description: R("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
+			label: L("command.openNodeInFloatingViewer", "Open node media in floating viewer"),
+			tooltip: L("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
+			title: L("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
+			description: L("tooltip.openNodeInFloatingViewer", "Open this node's media in the Majoor floating viewer"),
 			icon: "pi pi-window-maximize",
 			function: () => {
-				dC(ZS);
+				vC(iC);
 			}
 		}
 	];
 }
-function mC() {
+function xC() {
 	return [{
 		combo: {
 			alt: !0,
@@ -24342,7 +24580,7 @@ function mC() {
 		commandId: "mjr.toggleFloatingViewer"
 	}];
 }
-function hC() {
+function SC() {
 	return [{
 		path: ["Extensions", "Majoor Assets Manager"],
 		commands: [
@@ -24357,45 +24595,45 @@ function hC() {
 		]
 	}];
 }
-function gC(e, { sidebarTabId: t, triggerStartupScan: n }) {
+function CC(e, { sidebarTabId: t, triggerStartupScan: n }) {
 	return [null, {
 		content: "Majoor Assets Manager",
 		submenu: { options: [
 			{
-				content: R("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
-				callback: () => tC(e, t)
+				content: L("tooltip.openAssetsManager", "Open Majoor Assets Manager"),
+				callback: () => cC(e, t)
 			},
 			{
-				content: R("command.openFloatingViewer", "Open floating viewer"),
+				content: L("command.openFloatingViewer", "Open floating viewer"),
 				callback: () => {
 					try {
-						window.dispatchEvent(new Event(B.MFV_OPEN));
+						window.dispatchEvent(new Event(z.MFV_OPEN));
 					} catch (e) {
 						console.debug?.(e);
 					}
 				}
 			},
 			{
-				content: R("command.openGeneratedFeed", "Open generated feed"),
-				callback: () => rC(e)
+				content: L("command.openGeneratedFeed", "Open generated feed"),
+				callback: () => uC(e)
 			},
 			null,
 			{
-				content: R("command.refreshAssetsGrid", "Refresh assets grid"),
-				callback: () => nC()
+				content: L("command.refreshAssetsGrid", "Refresh assets grid"),
+				callback: () => lC()
 			},
 			{
-				content: R("command.scanAssets", "Scan assets"),
+				content: L("command.scanAssets", "Scan assets"),
 				callback: () => n()
 			},
 			{
-				content: R("command.openSettings", "Open Majoor settings"),
+				content: L("command.openSettings", "Open Majoor settings"),
 				callback: () => Jn(e)
 			}
 		] }
 	}];
 }
-function _C() {
+function wC() {
 	return [
 		{
 			label: "Majoor Assets Manager",
@@ -24412,25 +24650,25 @@ function _C() {
 		}
 	];
 }
-function vC(e, t) {
-	for (let n of pC(e, t)) Ie(e, n);
+function TC(e, t) {
+	for (let n of bC(e, t)) Le(e, n);
 }
-function yC(e) {
-	for (let t of mC()) Ve(e, t);
+function EC(e) {
+	for (let t of xC()) He(e, t);
 }
-function bC(e, { sidebarTabId: t }) {
-	return Lf({ sidebarTabId: t }), He(e, {
+function DC(e, { sidebarTabId: t }) {
+	return Wf({ sidebarTabId: t }), Ue(e, {
 		id: t,
 		icon: "pi pi-folder",
-		title: R("manager.title"),
-		label: R("manager.sidebarLabel"),
-		tooltip: R("tooltip.sidebarTab"),
+		title: L("manager.title"),
+		label: L("manager.sidebarLabel"),
+		tooltip: L("tooltip.sidebarTab"),
 		type: "custom",
 		render(e) {
-			zf(), Yr({ idleOnly: !0 }).catch(() => null), En(e, pS, JS), setTimeout(() => {
-				let e = Hf();
+			Kf(), Yr({ idleOnly: !0 }).catch(() => null), En(e, bS, tC), setTimeout(() => {
+				let e = Yf();
 				if (e) try {
-					window.dispatchEvent(new CustomEvent(B.RELOAD_GRID, { detail: {
+					window.dispatchEvent(new CustomEvent(z.RELOAD_GRID, { detail: {
 						reason: "pending-generated-assets",
 						pending: e
 					} }));
@@ -24442,73 +24680,73 @@ function bC(e, { sidebarTabId: t }) {
 		destroy(e) {}
 	});
 }
-function xC() {
+function OC() {
 	try {
-		Dn(null, JS);
+		Dn(null, tC);
 	} catch {}
 }
-var SC = !1, CC = "mjr-sidebar-prewarm-host";
-function wC() {
-	if (SC || typeof document > "u" || !document?.body) return !1;
-	SC = !0;
+var kC = !1, AC = "mjr-sidebar-prewarm-host";
+function jC() {
+	if (kC || typeof document > "u" || !document?.body) return !1;
+	kC = !0;
 	try {
-		let e = document.getElementById(CC);
-		return e || (e = document.createElement("div"), e.id = CC, e.style.cssText = "position:fixed;left:-99999px;top:0;width:360px;height:600px;overflow:hidden;visibility:hidden;pointer-events:none;contain:strict;", e.setAttribute("aria-hidden", "true"), document.body.appendChild(e)), En(e, pS, JS), !0;
+		let e = document.getElementById(AC);
+		return e || (e = document.createElement("div"), e.id = AC, e.style.cssText = "position:fixed;left:-99999px;top:0;width:360px;height:600px;overflow:hidden;visibility:hidden;pointer-events:none;contain:strict;", e.setAttribute("aria-hidden", "true"), document.body.appendChild(e)), En(e, bS, tC), !0;
 	} catch (e) {
-		return console.debug?.(e), SC = !1, !1;
+		return console.debug?.(e), kC = !1, !1;
 	}
 }
-function TC() {
+function MC() {
 	return {
-		id: XS,
-		title: R("bottomFeed.title", "Generated Feed"),
+		id: rC,
+		title: L("bottomFeed.title", "Generated Feed"),
 		icon: "pi pi-images",
 		type: "custom",
 		render(e) {
-			En(e, mS, YS);
+			En(e, xS, nC);
 		},
 		destroy(e) {}
 	};
 }
-function EC() {
-	return [TC()];
+function NC() {
+	return [MC()];
 }
-function DC() {
+function PC() {
 	try {
-		Dn(null, YS);
+		Dn(null, nC);
 	} catch {}
 }
-function OC(e) {
+function FC(e) {
 	let t = String(e?.comfyClass || e?.type || e?.constructor?.type || "").trim();
 	return t ? /save|load|preview/i.test(t) : !1;
 }
-function kC(e) {
+function IC(e) {
 	return e ? Array.isArray(e) ? e.filter(Boolean) : e instanceof Set ? Array.from(e).filter(Boolean) : e instanceof Map ? Array.from(e.values()).filter(Boolean) : Array.isArray(e?.items) ? e.items.filter(Boolean) : Array.isArray(e?.nodes) ? e.nodes.filter(Boolean) : [e] : [];
 }
-function AC(e) {
-	return ZS = oC(e), ZS ? [
+function LC(e) {
+	return iC = pC(e), iC ? [
 		"mjr.openNodeContext",
 		"mjr.openAssetsManager",
 		"mjr.openNodeInFloatingViewer"
 	] : [];
 }
-function jC(e, t) {
+function RC(e, t) {
 	return {
 		content: e,
 		callback: t
 	};
 }
-function MC(e, t, { sidebarTabId: n }) {
-	return OC(e) ? [
-		jC("View in Assets Manager", () => {
-			uC(t, n, e);
+function zC(e, t, { sidebarTabId: n }) {
+	return FC(e) ? [
+		RC("View in Assets Manager", () => {
+			_C(t, n, e);
 		}),
-		jC("Open in Floating Viewer", () => {
-			dC(e);
+		RC("Open in Floating Viewer", () => {
+			vC(e);
 		}),
-		jC("Index Output", () => {
+		RC("Index Output", () => {
 			try {
-				nC(), A(R("toast.rescanningFile", "Rescanning file..."), "info", 1800);
+				lC(), k(L("toast.rescanningFile", "Rescanning file..."), "info", 1800);
 			} catch (e) {
 				console.debug?.(e);
 			}
@@ -24517,23 +24755,23 @@ function MC(e, t, { sidebarTabId: n }) {
 }
 //#endregion
 //#region ui/features/runtime/entryRuntimeLifecycle.ts
-var NC = "__MJR_ENTRY_RUNTIME__";
-function PC(e, t) {
+var BC = "__MJR_ENTRY_RUNTIME__";
+function VC(e, t) {
 	if (e) try {
-		e._mjrAssetUpdateReloadTimer &&= (clearTimeout(e._mjrAssetUpdateReloadTimer), null), e._mjrExecutedHandler && e.removeEventListener("executed", e._mjrExecutedHandler), e._mjrAssetAddedHandler && e.removeEventListener("mjr-asset-added", e._mjrAssetAddedHandler), e._mjrAssetUpdatedHandler && e.removeEventListener("mjr-asset-updated", e._mjrAssetUpdatedHandler), e._mjrStructuredEventHandler && e.removeEventListener(B.STRUCTURED_EVENT, e._mjrStructuredEventHandler), e._mjrScanCompleteHandler && e.removeEventListener(B.SCAN_COMPLETE, e._mjrScanCompleteHandler), e._mjrScanProgressHandler && e.removeEventListener(B.SCAN_PROGRESS, e._mjrScanProgressHandler), e._mjrAssetIndexingHandler && e.removeEventListener(B.ASSET_INDEXING, e._mjrAssetIndexingHandler), e._mjrAssetIndexedHandler && e.removeEventListener(B.ASSET_INDEXED, e._mjrAssetIndexedHandler), e._mjrExecutionStartHandler && e.removeEventListener("execution_start", e._mjrExecutionStartHandler), e._mjrExecutionEndHandler && (e.removeEventListener("execution_success", e._mjrExecutionEndHandler), e.removeEventListener("execution_error", e._mjrExecutionEndHandler), e.removeEventListener("execution_interrupted", e._mjrExecutionEndHandler)), e._mjrStacksUpdatedHandler && e.removeEventListener("mjr.stacks.updated", e._mjrStacksUpdatedHandler), e._mjrEnrichmentStatusHandler && e.removeEventListener(B.ENRICHMENT_STATUS, e._mjrEnrichmentStatusHandler), e._mjrDbRestoreStatusHandler && e.removeEventListener(B.DB_RESTORE_STATUS, e._mjrDbRestoreStatusHandler), e._mjrRuntimeStatusHandler && (e.removeEventListener("progress", e._mjrRuntimeStatusHandler), e.removeEventListener("status", e._mjrRuntimeStatusHandler), e.removeEventListener(B.RUNTIME_STATUS, e._mjrRuntimeStatusHandler), e.removeEventListener("execution_cached", e._mjrExecutionCachedHandler));
+		e._mjrAssetUpdateReloadTimer &&= (clearTimeout(e._mjrAssetUpdateReloadTimer), null), e._mjrExecutedHandler && e.removeEventListener("executed", e._mjrExecutedHandler), e._mjrAssetAddedHandler && e.removeEventListener("mjr-asset-added", e._mjrAssetAddedHandler), e._mjrAssetUpdatedHandler && e.removeEventListener("mjr-asset-updated", e._mjrAssetUpdatedHandler), e._mjrStructuredEventHandler && e.removeEventListener(z.STRUCTURED_EVENT, e._mjrStructuredEventHandler), e._mjrScanCompleteHandler && e.removeEventListener(z.SCAN_COMPLETE, e._mjrScanCompleteHandler), e._mjrScanProgressHandler && e.removeEventListener(z.SCAN_PROGRESS, e._mjrScanProgressHandler), e._mjrAssetIndexingHandler && e.removeEventListener(z.ASSET_INDEXING, e._mjrAssetIndexingHandler), e._mjrAssetIndexedHandler && e.removeEventListener(z.ASSET_INDEXED, e._mjrAssetIndexedHandler), e._mjrExecutionStartHandler && e.removeEventListener("execution_start", e._mjrExecutionStartHandler), e._mjrExecutionEndHandler && (e.removeEventListener("execution_success", e._mjrExecutionEndHandler), e.removeEventListener("execution_error", e._mjrExecutionEndHandler), e.removeEventListener("execution_interrupted", e._mjrExecutionEndHandler)), e._mjrStacksUpdatedHandler && e.removeEventListener("mjr.stacks.updated", e._mjrStacksUpdatedHandler), e._mjrEnrichmentStatusHandler && e.removeEventListener(z.ENRICHMENT_STATUS, e._mjrEnrichmentStatusHandler), e._mjrDbRestoreStatusHandler && e.removeEventListener(z.DB_RESTORE_STATUS, e._mjrDbRestoreStatusHandler), e._mjrRuntimeStatusHandler && (e.removeEventListener("progress", e._mjrRuntimeStatusHandler), e.removeEventListener("status", e._mjrRuntimeStatusHandler), e.removeEventListener(z.RUNTIME_STATUS, e._mjrRuntimeStatusHandler), e.removeEventListener("execution_cached", e._mjrExecutionCachedHandler));
 	} catch (e) {
 		t?.(e, "entry.removeApiHandlers");
 	}
 }
-function FC(e, t) {
+function HC(e, t) {
 	try {
 		let t = e?.assetsDeletedHandler;
-		t && typeof window < "u" && window.removeEventListener(B.ASSETS_DELETED, t);
+		t && typeof window < "u" && window.removeEventListener(z.ASSETS_DELETED, t);
 	} catch (e) {
 		t?.(e, "entry.removeRuntimeWindowHandlers");
 	}
 }
-function IC(e, { reportError: t } = {}) {
+function UC(e, { reportError: t } = {}) {
 	if (!(!e || typeof e != "object")) {
 		try {
 			let t = Array.isArray(e._listenerCleanupFns) ? e._listenerCleanupFns : [];
@@ -24558,13 +24796,13 @@ function IC(e, { reportError: t } = {}) {
 			console.warn("[MJR teardown]", e);
 		}
 		try {
-			PC(e.api || null, t), FC(e, t);
+			VC(e.api || null, t), HC(e, t);
 		} catch (e) {
 			console.warn("[MJR teardown]", e);
 		}
 	}
 }
-function LC(e, t, n, r, i = void 0) {
+function WC(e, t, n, r, i = void 0) {
 	if (!e || !t?.addEventListener || typeof r != "function") return null;
 	let a = i && typeof i == "object" ? { ...i } : i;
 	if (typeof AbortController < "u") try {
@@ -24584,11 +24822,11 @@ function LC(e, t, n, r, i = void 0) {
 		}
 	}), null;
 }
-function RC({ cleanupEntryRuntimeFn: e = IC, teardownLiveStreamTracker: t, teardownNodeStream: n, teardownFloatingViewerManager: r, teardownGeneratedFeed: i, teardownAssetsSidebar: a, teardownGlobalRuntime: o, teardownTopBarMfvButton: s, reportError: c }) {
+function GC({ cleanupEntryRuntimeFn: e = UC, teardownLiveStreamTracker: t, teardownNodeStream: n, teardownFloatingViewerManager: r, teardownGeneratedFeed: i, teardownAssetsSidebar: a, teardownGlobalRuntime: o, teardownTopBarMfvButton: s, reportError: c }) {
 	try {
 		if (typeof window < "u") {
 			try {
-				let t = window[NC];
+				let t = window[BC];
 				e(t, { reportError: c });
 			} catch (e) {
 				console.warn("[MJR teardown]", e);
@@ -24628,7 +24866,7 @@ function RC({ cleanupEntryRuntimeFn: e = IC, teardownLiveStreamTracker: t, teard
 			} catch (e) {
 				console.warn("[MJR teardown]", e);
 			}
-			window[NC] = {
+			window[BC] = {
 				api: null,
 				assetsDeletedHandler: null,
 				_cleanupControllers: [],
@@ -24641,42 +24879,42 @@ function RC({ cleanupEntryRuntimeFn: e = IC, teardownLiveStreamTracker: t, teard
 }
 //#endregion
 //#region ui/entry.ts
-var zC = null, BC = null, VC = null;
-function HC() {
-	return VC ||= import("./chunks/floatingViewerManager-CGdpmtv-.js").then((e) => e.n), VC;
+var KC = null, qC = null, JC = null;
+function YC() {
+	return JC ||= import("./chunks/floatingViewerManager-C0fDYFQu.js").then((e) => e.n), JC;
 }
-function UC() {
-	VC && VC.then((e) => e?.teardownFloatingViewerManager?.()).catch((e) => console.debug?.("[Majoor] MFV teardown skipped", e));
+function XC() {
+	JC && JC.then((e) => e?.teardownFloatingViewerManager?.()).catch((e) => console.debug?.("[Majoor] MFV teardown skipped", e));
 }
-var WC = "majoor-assets", GC = "__MJR_EXECUTION_RUNTIME__", KC = "Majoor.AssetsManager", qC = {
+var ZC = "majoor-assets", QC = "__MJR_EXECUTION_RUNTIME__", $C = "Majoor.AssetsManager", ew = {
 	active: null,
 	promptId: ""
-}, JC = null, YC = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, XC = /^[0-9a-f]{20,}$/i;
-function ZC(...e) {
+}, tw = null, nw = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, rw = /^[0-9a-f]{20,}$/i;
+function iw(...e) {
 	for (let t of e) {
 		let e = String(t || "").trim();
 		if (e) return e;
 	}
 	return "";
 }
-function QC(e) {
+function aw(e) {
 	let t = String(e || "").trim();
-	return YC.test(t) || XC.test(t);
+	return nw.test(t) || rw.test(t);
 }
-function $C(e) {
-	return ZC(e?.title, e?.properties?.title, e?.properties?.name, e?.properties?.label, e?.name);
+function ow(e) {
+	return iw(e?.title, e?.properties?.title, e?.properties?.name, e?.properties?.label, e?.name);
 }
-function ew(e) {
+function sw(e) {
 	if (!e || typeof e != "object") return [];
 	if (Array.isArray(e.nodes)) return e.nodes.filter(Boolean);
 	if (Array.isArray(e._nodes)) return e._nodes.filter(Boolean);
 	let t = e._nodes_by_id ?? e.nodes_by_id ?? null;
 	return t instanceof Map ? Array.from(t.values()).filter(Boolean) : t && typeof t == "object" ? Object.values(t).filter(Boolean) : [];
 }
-function tw(e) {
-	return ew(e).length > 0;
+function cw(e) {
+	return sw(e).length > 0;
 }
-function nw(e) {
+function lw(e) {
 	return !e || typeof e != "object" ? !1 : [
 		e.subgraph,
 		e._subgraph,
@@ -24687,13 +24925,13 @@ function nw(e) {
 		e.subgraph_instance?.graph,
 		e.inner_graph,
 		e.subgraph_graph
-	].some(tw) || Array.isArray(e.nodes) && e.nodes.length > 0 && e.nodes !== e.graph?.nodes ? !0 : QC(e.type) && !!$C(e);
+	].some(cw) || Array.isArray(e.nodes) && e.nodes.length > 0 && e.nodes !== e.graph?.nodes ? !0 : aw(e.type) && !!ow(e);
 }
-function rw(e, t) {
-	let n = String(e?.type || t || "").trim(), r = $C(e);
-	return QC(n) ? r || "Subgraph" : n || r || "Node";
+function uw(e, t) {
+	let n = String(e?.type || t || "").trim(), r = ow(e);
+	return aw(n) ? r || "Subgraph" : n || r || "Node";
 }
-function iw() {
+function dw() {
 	try {
 		return typeof window > "u" ? {
 			active_prompt_id: null,
@@ -24702,87 +24940,87 @@ function iw() {
 			progress_value: null,
 			progress_max: null,
 			cached_nodes: []
-		} : ((!window[GC] || typeof window[GC] != "object") && (window[GC] = {
+		} : ((!window[QC] || typeof window[QC] != "object") && (window[QC] = {
 			active_prompt_id: null,
 			queue_remaining: null,
 			progress_node: null,
 			progress_value: null,
 			progress_max: null,
 			cached_nodes: []
-		}), window[GC]);
+		}), window[QC]);
 	} catch (e) {
 		return console.debug?.(e), {};
 	}
 }
-function aw(e = {}) {
+function fw(e = {}) {
 	try {
-		let t = iw();
-		Object.assign(t, e || {}), window.dispatchEvent(new CustomEvent(B.RUNTIME_STATUS, { detail: { ...t } }));
+		let t = dw();
+		Object.assign(t, e || {}), window.dispatchEvent(new CustomEvent(z.RUNTIME_STATUS, { detail: { ...t } }));
 	} catch (e) {
 		console.debug?.(e);
 	}
 }
-async function ow({ active: e, promptId: t = "" } = {}) {
+async function pw({ active: e, promptId: t = "" } = {}) {
 	let n = !!e, r = String(t || "").trim();
-	if (!(qC.active === n && qC.promptId === r)) {
-		qC = {
+	if (!(ew.active === n && ew.promptId === r)) {
+		ew = {
 			active: n,
 			promptId: r
 		};
 		try {
-			await ue(lt.RUNTIME_EXECUTION, {
+			await ue(B.RUNTIME_EXECUTION, {
 				active: n,
 				prompt_id: r || void 0,
-				cooldown_ms: Number(z.EXECUTION_IDLE_GRACE_MS) || 6e3
+				cooldown_ms: Number(R.EXECUTION_IDLE_GRACE_MS) || 6e3
 			});
 		} catch (e) {
 			P(e, "entry.execution_state_sync");
 		}
 	}
 }
-function sw() {
+function mw() {
 	try {
-		return !!String(iw()?.active_prompt_id || "").trim();
+		return !!String(dw()?.active_prompt_id || "").trim();
 	} catch (e) {
 		return console.debug?.(e), !1;
 	}
 }
-function cw(e = 1200) {
+function hw(e = 1200) {
 	try {
-		JC && clearTimeout(JC);
+		tw && clearTimeout(tw);
 	} catch (e) {
 		console.debug?.(e);
 	}
-	JC = setTimeout(() => {
-		if (JC = null, sw()) {
-			cw(e);
+	tw = setTimeout(() => {
+		if (tw = null, mw()) {
+			hw(e);
 			return;
 		}
 		let t = Zn();
 		t && Ti(t);
 	}, Math.max(250, Number(e) || 0));
 }
-function lw(e) {
-	import("./chunks/LiveStreamTracker-BEJIPwIw.js").then((t) => {
-		zC = t;
+function gw(e) {
+	import("./chunks/LiveStreamTracker-ClU-8zBj.js").then((t) => {
+		KC = t;
 		try {
 			t.initLiveStreamTracker(e);
 		} catch (e) {
 			console.warn("[MJR setup] initLiveStreamTracker failed:", e);
 		}
 	}).catch((e) => console.warn("[MJR setup] LiveStreamTracker load failed:", e)), import("./chunks/NodeStreamController-f2tXbqnR.js").then((t) => {
-		BC = t;
+		qC = t;
 		try {
 			t.initNodeStream({
 				app: e,
 				onOutput: (e) => {
-					HC().then((t) => t?.floatingViewerManager?.feedNodeStream?.(e)).catch((e) => console.debug?.("[NodeStream] MFV output failed", e));
+					YC().then((t) => t?.floatingViewerManager?.feedNodeStream?.(e)).catch((e) => console.debug?.("[NodeStream] MFV output failed", e));
 				},
 				onStatus: (t, n) => {
 					try {
-						let r = (e?.graph ?? e?.canvas?.graph ?? null)?.getNodeById?.(Number(t)), i = nw(r), a = $C(r), o = i ? "Subgraph" : rw(r, n);
-						HC().then((e) => {
-							e?.floatingViewerManager?.setNodeStreamSelection?.(t, o, i ? a || rw(r, n) : a);
+						let r = (e?.graph ?? e?.canvas?.graph ?? null)?.getNodeById?.(Number(t)), i = lw(r), a = ow(r), o = i ? "Subgraph" : uw(r, n);
+						YC().then((e) => {
+							e?.floatingViewerManager?.setNodeStreamSelection?.(t, o, i ? a || uw(r, n) : a);
 						}).catch((e) => console.debug?.("[NodeStream] MFV status failed", e));
 					} catch (e) {
 						console.debug?.("[NodeStream] onStatus failed", e);
@@ -24794,12 +25032,12 @@ function lw(e) {
 		}
 	}).catch((e) => console.warn("[MJR setup] NodeStream load failed:", e));
 }
-async function uw(e, t) {
-	let n = await je({
+async function _w(e, t) {
+	let n = await Me({
 		app: e,
 		timeoutMs: 4e3
-	}) || Ue(e);
-	if (We(n || null), !n) {
+	}) || We(e);
+	if (Ge(n || null), !n) {
 		console.warn("Majoor API not available, real-time updates disabled");
 		return;
 	}
@@ -24813,87 +25051,87 @@ async function uw(e, t) {
 	} catch (e) {
 		console.debug?.(e);
 	}
-	PC(r?.api || null, P), n !== r?.api && PC(n, P), FC(r, P), await tp({
+	VC(r?.api || null, P), n !== r?.api && VC(n, P), HC(r, P), await cp({
 		api: n,
 		runtime: r,
 		executionRuntime: t,
 		appRef: Mr,
-		liveStreamModule: zC,
-		ensureExecutionRuntime: iw,
-		emitRuntimeStatus: aw,
+		liveStreamModule: KC,
+		ensureExecutionRuntime: dw,
+		emitRuntimeStatus: fw,
 		getActiveGridContainer: Zn,
-		pushGeneratedAsset: Jd,
+		pushGeneratedAsset: tf,
 		upsertAsset: Ni,
 		upsertAssetNow: Pi,
 		removeAssetsFromGrid: Mi,
 		getEnrichmentState: Lt,
 		setEnrichmentState: Ct,
-		comfyToast: A,
-		t: R,
+		comfyToast: k,
+		t: L,
 		reportError: P,
-		registerCleanableListener: LC,
-		syncExecutionBackendState: ow
+		registerCleanableListener: WC,
+		syncExecutionBackendState: pw
 	});
 }
-var dw = _f({
+var vw = wf({
 	post: ue,
-	ENDPOINTS: lt,
+	ENDPOINTS: B,
 	reportError: P,
-	extractOutputFiles: vf,
-	ensureExecutionRuntime: iw,
-	emitRuntimeStatus: aw,
-	refreshGeneratedFeedHosts: Nd,
+	extractOutputFiles: Tf,
+	ensureExecutionRuntime: dw,
+	emitRuntimeStatus: fw,
+	refreshGeneratedFeedHosts: Bd,
 	getActiveGridContainer: Zn
 });
 Mr.registerExtension({
-	name: KC,
+	name: $C,
 	settings: sn(Mr),
-	commands: pC(Mr, {
-		sidebarTabId: WC,
+	commands: bC(Mr, {
+		sidebarTabId: ZC,
 		triggerStartupScan: qr
 	}),
-	keybindings: mC(),
-	menuCommands: hC(),
-	aboutPageBadges: _C(),
-	bottomPanelTabs: EC(),
+	keybindings: xC(),
+	menuCommands: SC(),
+	aboutPageBadges: wC(),
+	bottomPanelTabs: NC(),
 	async setup() {
-		RC({
-			cleanupEntryRuntimeFn: IC,
-			teardownLiveStreamTracker: (e) => zC?.teardownLiveStreamTracker(e),
-			teardownNodeStream: (e) => BC?.teardownNodeStream(e),
-			teardownFloatingViewerManager: UC,
-			teardownGeneratedFeed: DC,
-			teardownAssetsSidebar: xC,
-			teardownGlobalRuntime: eC,
-			teardownTopBarMfvButton: GS,
+		GC({
+			cleanupEntryRuntimeFn: UC,
+			teardownLiveStreamTracker: (e) => KC?.teardownLiveStreamTracker(e),
+			teardownNodeStream: (e) => qC?.teardownNodeStream(e),
+			teardownFloatingViewerManager: XC,
+			teardownGeneratedFeed: PC,
+			teardownAssetsSidebar: OC,
+			teardownGlobalRuntime: sC,
+			teardownTopBarMfvButton: QS,
 			reportError: P
-		}), ap(), ze(Mr);
-		let e = await Xe({ timeoutMs: 12e3 }) || Mr;
-		ze(e), Pp(e);
+		}), fp(), Be(Mr);
+		let e = await Ze({ timeoutMs: 12e3 }) || Mr;
+		Be(e), Vp(e);
 		try {
 			typeof window < "u" && (window.__MJR_RUNTIME_APP__ = e);
 		} catch (e) {
 			console.debug?.(e);
 		}
-		Zr(), yi({ enabled: !0 }), $S(), lw(e), Sn(e, () => {
+		Zr(), yi({ enabled: !0 }), oC(), gw(e), Sn(e, () => {
 			let e = Zn();
 			if (e) {
-				if (z.DEFER_GRID_FETCH_DURING_EXECUTION && sw()) {
-					cw();
+				if (R.DEFER_GRID_FETCH_DURING_EXECUTION && mw()) {
+					hw();
 					return;
 				}
 				Ti(e);
 			}
-		}), vC(e, {
-			sidebarTabId: WC,
+		}), TC(e, {
+			sidebarTabId: ZC,
 			triggerStartupScan: qr
-		}), yC(e), setTimeout(() => {
+		}), EC(e), setTimeout(() => {
 			_i();
-		}, 5e3), uw(e, dw).catch((e) => P(e, "entry.api_setup")), bC(e, { sidebarTabId: WC }) ? we("[Majoor] Sidebar tab registered (Vue)") : console.warn("Majoor Assets Manager: extensionManager.registerSidebarTab is unavailable");
+		}, 5e3), _w(e, vw).catch((e) => P(e, "entry.api_setup")), DC(e, { sidebarTabId: ZC }) ? Te("[Majoor] Sidebar tab registered (Vue)") : console.warn("Majoor Assets Manager: extensionManager.registerSidebarTab is unavailable");
 		try {
 			let e = typeof window < "u" ? window.requestIdleCallback : null, t = () => {
 				try {
-					wC();
+					jC();
 				} catch (e) {
 					console.debug?.(e);
 				}
@@ -24902,26 +25140,26 @@ Mr.registerExtension({
 		} catch (e) {
 			console.debug?.(e);
 		}
-		np({ resolveNodeStreamModule: async () => (BC ||= await import("./chunks/NodeStreamController-f2tXbqnR.js"), BC) });
+		lp({ resolveNodeStreamModule: async () => (qC ||= await import("./chunks/NodeStreamController-f2tXbqnR.js"), qC) });
 	},
 	onNodeOutputsUpdated(e) {
 		try {
-			dw.handleNodeOutputsUpdated(e);
+			vw.handleNodeOutputsUpdated(e);
 		} catch (e) {
 			console.debug?.("[Majoor] onNodeOutputsUpdated error", e);
 		}
 	},
 	getNodeMenuItems(e) {
-		return MC(e, Mr, { sidebarTabId: WC });
+		return zC(e, Mr, { sidebarTabId: ZC });
 	},
 	getCanvasMenuItems(e) {
-		return gC(Mr, {
-			sidebarTabId: WC,
+		return CC(Mr, {
+			sidebarTabId: ZC,
 			triggerStartupScan: qr
 		});
 	},
 	getSelectionToolboxCommands(e) {
-		return AC(e);
+		return LC(e);
 	}
 });
 //#endregion

--- a/mjr_am_backend/routes/handlers/custom_roots.py
+++ b/mjr_am_backend/routes/handlers/custom_roots.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from aiohttp import web
 from mjr_am_backend.adapters.comfy_core import get_input_directory
-from mjr_am_backend.config import OUTPUT_ROOT
+from mjr_am_backend.config import OUTPUT_ROOT, get_runtime_output_root
 from mjr_am_backend.custom_roots import (
     add_custom_root,
     list_custom_roots,
@@ -765,9 +765,67 @@ def register_custom_roots_routes(routes: web.RouteTableDef) -> None:
             else:
                 logger.warning("browser/folder-op(%s): security prefs unavailable, skipping operation gate", op)
         source_raw = str(body.get("path") or body.get("filepath") or "").strip()
+        # Resolve scope markers into actual root paths
+        if source_raw.startswith("mjr://"):
+            parts = source_raw[len("mjr://"):].split("/", 1)
+            scope = parts[0]
+            rel = parts[1] if len(parts) > 1 else ""
+            if scope == "input":
+                root = get_input_directory()
+                if not root:
+                    return _json_response(Result.Err("DIR_NOT_FOUND", "Input directory not available"))
+                source_raw = str(Path(root) / rel) if rel else str(root)
+            elif scope == "output":
+                source_raw = str(Path(get_runtime_output_root()) / rel) if rel else str(get_runtime_output_root())
         source = _normalize_path(source_raw)
         if not source:
             return _json_response(Result.Err("INVALID_INPUT", "Invalid folder path"))
+
+        # move_file uses path for the SOURCE file (not a folder), so skip the
+        # common folder-directory validation and handle it separately.
+        if op == "move_file":
+            src_file = str(source)
+            dst_dir_raw = str(body.get("destination") or "").strip()
+            import sys; print(f"[MJR_MOVE] src='{src_file}' dst='{dst_dir_raw}'", file=sys.stderr, flush=True)
+            if not dst_dir_raw:
+                return _json_response(Result.Err("INVALID_INPUT", "Missing destination"))
+            dst_dir = _normalize_path(dst_dir_raw)
+            if not dst_dir:
+                return _json_response(Result.Err("INVALID_INPUT", "Invalid destination path"))
+            try:
+                dst_dir = dst_dir.resolve(strict=True)
+            except Exception:
+                return _json_response(Result.Err("DIR_NOT_FOUND", "Destination directory not found"))
+            if not dst_dir.is_dir():
+                return _json_response(Result.Err("INVALID_INPUT", "Destination is not a directory"))
+            if not (_is_path_allowed(dst_dir) or _is_path_allowed_custom(dst_dir)):
+                return _json_response(Result.Err("FORBIDDEN", "Destination is not within allowed roots"))
+            try:
+                src_path = Path(src_file).resolve(strict=True)
+            except Exception:
+                return _json_response(Result.Err("FILE_NOT_FOUND", "Source file not found"))
+            if not src_path.is_file():
+                return _json_response(Result.Err("INVALID_INPUT", "Source is not a file"))
+            if not (_is_path_allowed(src_path) or _is_path_allowed_custom(src_path)):
+                return _json_response(Result.Err("FORBIDDEN", "Source is not within allowed roots"))
+            try:
+                target = dst_dir / src_path.name
+                if target.exists():
+                    return _json_response(Result.Err("ALREADY_EXISTS", "File already exists at destination"))
+                await asyncio.to_thread(shutil.move, str(src_path), str(dst_dir))
+                await _invalidate_fs_list_cache()
+                try:
+                    src_scope, src_root_id = _infer_scan_scope(src_path.parent)
+                    await _kickoff_background_scan(
+                        str(src_path.parent), source=src_scope, root_id=src_root_id,
+                        recursive=False, incremental=True, respect_bg_scan_on_list=False,
+                    )
+                except Exception:
+                    pass
+                result = Result.Ok({"path": str(target.resolve(strict=False))})
+            except Exception as exc:
+                result = Result.Err("MOVE_FAILED", sanitize_error_message(exc, "Failed to move file"))
+            return _json_response(result)
 
         try:
             source = source.resolve(strict=True)
@@ -946,5 +1004,7 @@ def register_custom_roots_routes(routes: web.RouteTableDef) -> None:
                 recursive=recursive,
             )
             return _json_response(result)
+
+
 
         return _json_response(Result.Err("INVALID_INPUT", "Unsupported folder operation"))

--- a/mjr_am_backend/routes/handlers/filesystem.py
+++ b/mjr_am_backend/routes/handlers/filesystem.py
@@ -1473,3 +1473,106 @@ async def _dispatch_filesystem_listing_path(
         offset=offset,
         index_service=index_service,
     )
+
+
+# Directories under the *input* root that are hidden from the folder browser.
+# These are ComfyUI-internal folders that users should not navigate into.
+_INPUT_HIDDEN_DIRS: frozenset[str] = frozenset({
+    "pasted",      # ComfyUI paste buffer
+    "clipspace",   # ComfyUI clipboard between nodes
+    "3d",          # ComfyUI 3D model cache
+})
+
+
+async def _list_filesystem_folders(
+    root_dir: Path,
+    subfolder: str,
+    asset_type: str = "output",
+) -> Result[list[dict[str, Any]]]:
+    """
+    List visible subdirectories under ``root_dir/subfolder``.
+
+    Returns folder entries with ``kind: "folder"`` that can be merged into a
+    listing response alongside file assets.  Hidden directories (``.`` prefix,
+    ``_`` prefix, known system directories) are excluded.
+    """
+    target_result = _resolve_filesystem_listing_target(root_dir, subfolder)
+    if not target_result.ok:
+        return target_result
+    target_data = target_result.data if isinstance(target_result.data, dict) else {}
+    base = target_data.get("base")
+    target_dir_resolved = target_data.get("target_dir_resolved")
+    if not isinstance(base, Path) or not isinstance(target_dir_resolved, Path):
+        return Result.Err("LIST_FAILED", "Failed to resolve listing directory")
+
+    folders: list[dict[str, Any]] = []
+    try:
+        # ── ".." parent directory entry (except at root level) ──────────────
+        if subfolder:
+            try:
+                parent_resolved = target_dir_resolved.parent.resolve(strict=True)
+                if _is_within_root(parent_resolved, base):
+                    parent_rel = str(parent_resolved.relative_to(base)).replace("\\", "/")
+                    if parent_rel == ".":
+                        parent_rel = ""
+                    folders.append({
+                        "id": None,
+                        "filename": "..",
+                        "subfolder": parent_rel,
+                        "filepath": str(parent_resolved),
+                        "kind": "folder",
+                        "ext": "",
+                        "size": None,
+                        "mtime": 0,
+                        "width": None,
+                        "height": None,
+                        "duration": None,
+                        "rating": 0,
+                        "tags": [],
+                        "has_workflow": None,
+                        "has_generation_data": None,
+                        "type": asset_type,
+                        "root_id": "",
+                    })
+            except (ValueError, OSError):
+                pass
+
+        for entry in target_dir_resolved.iterdir():
+            if not entry.is_dir():
+                continue
+            name = entry.name
+            if name.startswith(".") or name.startswith("_"):
+                continue
+            if asset_type == "input" and name in _INPUT_HIDDEN_DIRS:
+                continue
+            try:
+                resolved = entry.resolve(strict=True)
+                if not _is_within_root(resolved, base):
+                    continue
+                rel = str(resolved.relative_to(base)).replace("\\", "/")
+            except (ValueError, OSError):
+                continue
+            folders.append({
+                "id": None,
+                "filename": name,
+                "subfolder": rel,
+                "filepath": str(resolved),
+                "kind": "folder",
+                "ext": "",
+                "size": None,
+                "mtime": int(entry.stat().st_mtime),
+                "width": None,
+                "height": None,
+                "duration": None,
+                "rating": 0,
+                "tags": [],
+                "has_workflow": None,
+                "has_generation_data": None,
+                "type": asset_type,
+                "root_id": "",
+            })
+    except OSError as exc:
+        return Result.Err("LIST_FAILED", f"Failed to list directory: {exc}")
+
+    folders.sort(key=lambda x: (x.get("filename") != "..", str(x.get("filename") or "").lower()))
+    return Result.Ok(folders)

--- a/mjr_am_backend/routes/handlers/filesystem.py
+++ b/mjr_am_backend/routes/handlers/filesystem.py
@@ -1498,7 +1498,7 @@ async def _list_filesystem_folders(
     """
     target_result = _resolve_filesystem_listing_target(root_dir, subfolder)
     if not target_result.ok:
-        return target_result
+        return Result.Err(target_result.code, target_result.error or "Unknown error")
     target_data = target_result.data if isinstance(target_result.data, dict) else {}
     base = target_data.get("base")
     target_dir_resolved = target_data.get("target_dir_resolved")

--- a/mjr_am_backend/routes/handlers/health.py
+++ b/mjr_am_backend/routes/handlers/health.py
@@ -1238,6 +1238,50 @@ def register_health_routes(routes: web.RouteTableDef) -> None:
         )
         return _json_response(response_result)
 
+    @routes.get("/mjr/am/settings/browser-show-folders")
+    async def get_browser_show_folders_settings(request):
+        svc, error_result = await _require_services()
+        if error_result:
+            return _json_response(error_result)
+
+        settings_service = svc.get("settings")
+        if not settings_service:
+            return _json_response(Result.Err("SERVICE_UNAVAILABLE", "Settings service unavailable"))
+
+        enabled = await settings_service.get_browser_show_folders()
+        return _json_response(Result.Ok({"enabled": bool(enabled)}))
+
+    @routes.post("/mjr/am/settings/browser-show-folders")
+    async def update_browser_show_folders_settings(request):
+        csrf = _csrf_error(request)
+        if csrf:
+            return _json_response(Result.Err(ErrorCode.CSRF, csrf))
+        auth = _require_write_access(request)
+        if not auth.ok:
+            return _json_response(auth)
+
+        svc, error_result = await _require_services()
+        if error_result:
+            return _json_response(error_result)
+
+        settings_service = svc.get("settings")
+        if not settings_service:
+            return _json_response(Result.Err(ErrorCode.SERVICE_UNAVAILABLE, "Settings service unavailable"))
+
+        body_res = await _read_json(request)
+        if not body_res.ok:
+            return _json_response(body_res)
+        body = body_res.data or {}
+
+        enabled = body.get("enabled")
+        if enabled is None:
+            return _json_response(Result.Err("INVALID_INPUT", "Missing enabled value"))
+
+        result = await settings_service.set_browser_show_folders(enabled)
+        if not result.ok:
+            return _json_response(result)
+        return _json_response(Result.Ok({"enabled": bool(result.data)}))
+
     @routes.get("/mjr/am/settings/huggingface")
     async def get_huggingface_settings(request):
         svc, error_result = await _require_services()

--- a/mjr_am_backend/routes/handlers/search_impl.py
+++ b/mjr_am_backend/routes/handlers/search_impl.py
@@ -29,6 +29,7 @@ from ..core.security import _check_rate_limit
 from .filesystem import (
     _kickoff_background_scan,
     _list_filesystem_assets,
+    _list_filesystem_folders,
     _paginate_filesystem_listing_entries,
     _parse_filesystem_listing_filters,
 )
@@ -188,6 +189,7 @@ async def list_assets(request: web.Request) -> web.Response:
         get_input_directory=get_input_directory,
         kickoff_background_scan=_kickoff_background_scan,
         list_filesystem_assets=_list_filesystem_assets,
+        list_filesystem_folders=_list_filesystem_folders,
         dedupe_result_assets_payload=_dedupe_result_assets_payload,
         resolve_custom_root_fn=resolve_custom_root,
         is_loopback_request=_is_loopback_request,

--- a/mjr_am_backend/routes/search/listing_endpoint.py
+++ b/mjr_am_backend/routes/search/listing_endpoint.py
@@ -27,6 +27,7 @@ async def list_assets(
     get_input_directory: Callable[[], str],
     kickoff_background_scan: Callable[..., Any],
     list_filesystem_assets: Callable[..., Any],
+    list_filesystem_folders: Callable[..., Any],
     dedupe_result_assets_payload: Callable[[dict[str, Any]], dict[str, Any]],
     resolve_custom_root_fn: Callable[[str], Any],
     is_loopback_request: Callable[[web.Request], bool],
@@ -102,6 +103,7 @@ async def list_assets(
             get_input_directory=get_input_directory,
             kickoff_background_scan=kickoff_background_scan,
             list_filesystem_assets=list_filesystem_assets,
+            list_filesystem_folders=list_filesystem_folders,
             dedupe_result_assets_payload=dedupe_result_assets_payload,
             json_response=json_response,
         )
@@ -201,6 +203,7 @@ async def list_assets(
         get_input_directory=get_input_directory,
         kickoff_background_scan=kickoff_background_scan,
         list_filesystem_assets=list_filesystem_assets,
+        list_filesystem_folders=list_filesystem_folders,
         dedupe_result_assets_payload=dedupe_result_assets_payload,
         exclude_assets_under_root=exclude_assets_under_root,
         json_response=json_response,

--- a/mjr_am_backend/routes/search/listing_input_scope.py
+++ b/mjr_am_backend/routes/search/listing_input_scope.py
@@ -7,6 +7,113 @@ from pathlib import Path
 from typing import Any
 
 from aiohttp import web
+from mjr_am_backend.shared import Result
+from .route_helpers import has_meaningful_filters
+
+
+async def _attach_filesystem_folders(
+    payload: dict[str, Any],
+    *,
+    root_dir: Path,
+    subfolder: str,
+    offset: int = 0,
+    list_filesystem_folders: Callable[..., Any],
+    show_folders: bool = True,
+) -> dict[str, Any]:
+    """List subdirectories under root_dir/subfolder and merge into assets.
+
+    Folders are only attached on the first page (offset == 0) — subsequent
+    pages skip them since the folders already appear at the top of the grid.
+    The *show_folders* parameter only controls root-level folder-only mode;
+    folders for navigation are always attached when inside a subfolder.
+    """
+    # Only show folders when the setting is enabled.  When disabled the
+    # behaviour is the original flat index listing — no folder entries at all.
+    # When enabled, folders are attached on every page (the frontend deduplicates
+    # them so they appear only once at the top of the grid).
+    if not show_folders:
+        return payload
+    try:
+        folder_result = await list_filesystem_folders(
+            root_dir, subfolder, asset_type="input"
+        )
+        if folder_result.ok and isinstance(folder_result.data, list):
+            folders = folder_result.data
+            assets = payload.get("assets") or []
+            if not folders:
+                return payload
+            payload["assets"] = folders + assets
+            existing_total = payload.get("total")
+            if existing_total is not None:
+                payload["total"] = int(existing_total) + len(folders)
+    except Exception:
+        pass
+    return payload
+
+
+async def _build_browse_response(
+    *,
+    root_dir: Path,
+    subfolder: str,
+    query: str,
+    limit: int,
+    offset: int,
+    sort_key: str,
+    filters: dict[str, Any] | None,
+    list_filesystem_assets: Callable[..., Any],
+    list_filesystem_folders: Callable[..., Any],
+    index_service: Any,
+    json_response: Callable[[Any], web.Response],
+) -> web.Response | None:
+    """Return current-level folders + files (non-recursive), paginated together."""
+    try:
+        # Get ALL folders at current level
+        folder_result = await list_filesystem_folders(
+            root_dir, subfolder, asset_type="input"
+        )
+        all_folders: list[dict] = folder_result.data if (folder_result.ok and isinstance(folder_result.data, list)) else []
+        folder_count = len(all_folders)
+
+        # Paginate: folders first, adjust file offset by folder count
+        file_offset = max(0, int(offset or 0) - folder_count)
+        file_limit = int(limit or 200)
+
+        page_folders = all_folders[offset:offset + file_limit] if offset < folder_count else []
+
+        files_used = len(page_folders)
+        remaining = file_limit - files_used
+
+        page_files: list[dict] = []
+        file_total = 0
+        if remaining > 0:
+            files_result = await list_filesystem_assets(
+                root_dir, subfolder, query, remaining, file_offset,
+                asset_type="input",
+                filters=filters or None,
+                index_service=index_service,
+                sort=sort_key,
+            )
+            if files_result.ok and isinstance(files_result.data, dict):
+                page_files = files_result.data.get("assets") or []
+                file_total = int(files_result.data.get("total") or 0)
+
+        # Don't return None even when the current page is empty — browse mode is
+        # valid once folders were found; empty pages just mean we've scrolled past
+        # the last item.
+        hybrid = page_folders + page_files
+        total = folder_count + file_total
+
+        payload = {
+            "assets": hybrid,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "query": query,
+            "scope": "input",
+        }
+        return json_response(Result.Ok(payload))
+    except Exception:
+        return None
 
 
 async def handle_input_scope(
@@ -23,12 +130,46 @@ async def handle_input_scope(
     get_input_directory: Callable[[], str],
     kickoff_background_scan: Callable[..., Any],
     list_filesystem_assets: Callable[..., Any],
+    list_filesystem_folders: Callable[..., Any],
     dedupe_result_assets_payload: Callable[[dict[str, Any]], dict[str, Any]],
     json_response: Callable[[Any], web.Response],
 ) -> web.Response:
     root_dir = Path(get_input_directory())
     svc, _ = await require_services()
     touch_enrichment_pause(svc, seconds=1.5)
+
+    _show_folders = True
+    try:
+        _settings_svc = svc.get("settings") if isinstance(svc, dict) else None
+        if _settings_svc is not None:
+            _show_folders = await _settings_svc.get_browser_show_folders()
+    except Exception:
+        pass
+
+    # ── Browse mode: show current-level folders + files (non-recursive) ────
+    # When the folder setting is on and the user is browsing normally, use
+    # the filesystem listing so each directory level shows only its own content.
+    is_browse_mode = (
+        _show_folders
+        and query == "*"
+        and not has_meaningful_filters(filters)
+    )
+    if is_browse_mode:
+        browse_resp = await _build_browse_response(
+            root_dir=root_dir,
+            subfolder=subfolder,
+            query=query,
+            limit=limit,
+            offset=offset,
+            sort_key=sort_key,
+            filters=filters,
+            list_filesystem_assets=list_filesystem_assets,
+            list_filesystem_folders=list_filesystem_folders,
+            index_service=svc.get("index") if isinstance(svc, dict) else None,
+            json_response=json_response,
+        )
+        if browse_resp is not None:
+            return browse_resp
 
     if svc and svc.get("index"):
         root_path = str(root_dir.resolve(strict=False))
@@ -52,6 +193,14 @@ async def handle_input_scope(
                 asset["type"] = "input"
             db_result.data["scope"] = "input"
             db_result.data = dedupe_result_assets_payload(db_result.data)
+            db_result.data = await _attach_filesystem_folders(
+                db_result.data,
+                root_dir=root_dir,
+                subfolder=subfolder,
+                offset=offset,
+                list_filesystem_folders=list_filesystem_folders,
+                show_folders=_show_folders,
+            )
             return json_response(db_result)
 
     if query == "*" and offset == 0 and not filters:
@@ -74,4 +223,12 @@ async def handle_input_scope(
     )
     if result.ok and isinstance(result.data, dict):
         result.data = dedupe_result_assets_payload(result.data)
+        result.data = await _attach_filesystem_folders(
+            result.data,
+            root_dir=root_dir,
+            subfolder=subfolder,
+            offset=offset,
+            list_filesystem_folders=list_filesystem_folders,
+            show_folders=_show_folders,
+        )
     return json_response(result)

--- a/mjr_am_backend/routes/search/listing_output_scope.py
+++ b/mjr_am_backend/routes/search/listing_output_scope.py
@@ -137,6 +137,23 @@ async def _build_browse_response(
             root_path, subfolder, asset_type="output"
         )
         all_folders: list[dict] = folder_result.data if (folder_result.ok and isinstance(folder_result.data, list)) else []
+
+        # Sort folders by mtime to match the requested sort order.
+        # ".." (parent navigation) always stays at the top.
+        parent_entry = None
+        regular_folders = []
+        for f in all_folders:
+            if f.get("filename") == "..":
+                parent_entry = f
+            else:
+                regular_folders.append(f)
+        reverse = sort_key != "mtime_asc"
+        regular_folders.sort(
+            key=lambda x: int(x.get("mtime") or 0) if x.get("mtime") is not None else 0,
+            reverse=reverse,
+        )
+        all_folders = ([parent_entry] if parent_entry else []) + regular_folders
+
         folder_count = len(all_folders)
 
         # Paginate: folders first, then files.  Adjust file offset by folder count

--- a/mjr_am_backend/routes/search/listing_output_scope.py
+++ b/mjr_am_backend/routes/search/listing_output_scope.py
@@ -12,6 +12,20 @@ from mjr_am_backend.shared import Result
 from .route_helpers import has_meaningful_filters
 
 
+def _merge_folders_into_assets(
+    assets: list[dict[str, Any]],
+    folders: list[dict[str, Any]],
+    total: int | None,
+) -> tuple[list[dict[str, Any]], int | None]:
+    """Prepend folder entries into the assets list and adjust total."""
+    if not folders:
+        return assets, total
+    merged = folders + assets
+    if total is not None:
+        total = total + len(folders)
+    return merged, total
+
+
 def _extract_total(raw_total):
     total_known = raw_total is not None
     try:
@@ -47,6 +61,128 @@ def _finalize_response(
 
 
 
+async def _attach_filesystem_folders(
+    payload: dict[str, Any],
+    *,
+    output_root: Any,
+    subfolder: str,
+    offset: int = 0,
+    list_filesystem_folders: Callable[..., Any],
+    show_folders: bool = True,
+) -> dict[str, Any]:
+    """List subdirectories under output_root/subfolder and merge into assets.
+
+    Folders are only attached on the first page (offset == 0) — subsequent
+    pages skip them since the folders already appear at the top of the grid.
+    The *show_folders* parameter only controls the root-level folder-only
+    mode; folders for navigation are always attached when the user is inside
+    a subfolder.
+    """
+    # Only show folders when the setting is enabled.  When disabled the
+    # behaviour is the original flat index listing — no folder entries at all.
+    # When enabled, folders are attached on every page (the frontend deduplicates
+    # them so they appear only once at the top of the grid).
+    if not show_folders:
+        return payload
+    try:
+        root_path = Path(output_root) if isinstance(output_root, (Path, str)) else None
+        if root_path is None:
+            return payload
+        folder_result = await list_filesystem_folders(
+            root_path, subfolder, asset_type="output"
+        )
+        if folder_result.ok and isinstance(folder_result.data, list):
+            folders = folder_result.data
+            assets = payload.get("assets") or []
+            merged, _ = _merge_folders_into_assets(assets, folders, None)
+            payload["assets"] = merged
+            existing_total = payload.get("total")
+            if existing_total is not None:
+                payload["total"] = int(existing_total) + len(folders)
+    except Exception:
+        pass
+    return payload
+
+
+async def _build_browse_response(
+    *,
+    output_root: Any,
+    subfolder: str,
+    query: str,
+    limit: int,
+    offset: int,
+    sort_key: str,
+    filters: dict[str, Any] | None,
+    list_filesystem_assets: Callable[..., Any],
+    list_filesystem_folders: Callable[..., Any],
+    index_service: Any,
+    json_response: Callable[[Any], web.Response],
+) -> web.Response | None:
+    """Return current-level folders + files (non-recursive).
+
+    Uses filesystem listing instead of the recursive index search so the
+    user sees only items at the current directory level — like a file browser.
+    Folders are only included on the first page (offset == 0); subsequent pages
+    skip them since they already appear at the top of the grid.
+    Returns None if the directory is empty, so the caller can fall through to
+    the normal recursive search.
+    """
+    try:
+        root_path = Path(output_root) if isinstance(output_root, (Path, str)) else None
+        if root_path is None:
+            return None
+
+        # Get ALL folders at current level (usually few)
+        folder_result = await list_filesystem_folders(
+            root_path, subfolder, asset_type="output"
+        )
+        all_folders: list[dict] = folder_result.data if (folder_result.ok and isinstance(folder_result.data, list)) else []
+        folder_count = len(all_folders)
+
+        # Paginate: folders first, then files.  Adjust file offset by folder count
+        # so the combined list scrolls naturally.
+        file_offset = max(0, int(offset or 0) - folder_count)
+        file_limit = int(limit or 200)
+
+        # Folders slice for this page
+        page_folders = all_folders[offset:offset + file_limit] if offset < folder_count else []
+
+        # Files fill the remaining space
+        files_used = len(page_folders)
+        remaining = file_limit - files_used
+
+        files: list[dict] = []
+        file_total = 0
+        if remaining > 0:
+            files_result = await list_filesystem_assets(
+                root_path, subfolder, query, remaining, file_offset,
+                asset_type="output",
+                filters=filters or None,
+                index_service=index_service,
+                sort=sort_key,
+            )
+            if files_result.ok and isinstance(files_result.data, dict):
+                files = files_result.data.get("assets") or []
+                file_total = int(files_result.data.get("total") or 0)
+
+        # Browse mode is valid once folders are found — even on subsequent pages
+        # (offset beyond folder count, no files at this level) return an empty
+        # page instead of falling through to the recursive index search.
+        hybrid = page_folders + files
+        total = folder_count + file_total
+        payload = {
+            "assets": hybrid,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "query": query,
+            "scope": "output",
+        }
+        return json_response(Result.Ok(payload))
+    except Exception:
+        return None
+
+
 async def handle_output_scope(
     *,
     query: str,
@@ -63,6 +199,7 @@ async def handle_output_scope(
     get_input_directory: Callable[[], str],
     kickoff_background_scan: Callable[..., Any],
     list_filesystem_assets: Callable[..., Any],
+    list_filesystem_folders: Callable[..., Any],
     dedupe_result_assets_payload: Callable[[dict[str, Any]], dict[str, Any]],
     exclude_assets_under_root: Callable[[list[dict[str, Any]], str], list[dict[str, Any]]],
     json_response: Callable[[Any], web.Response],
@@ -72,8 +209,44 @@ async def handle_output_scope(
         return json_response(error_result)
     touch_enrichment_pause(svc, seconds=1.5)
 
+    _show_folders = True
+    try:
+        _settings_svc = svc.get("settings") if isinstance(svc, dict) else None
+        if _settings_svc is not None:
+            _show_folders = await _settings_svc.get_browser_show_folders()
+    except Exception:
+        pass
+
     output_root = await runtime_output_root(svc)
     input_root = str(Path(get_input_directory()).resolve(strict=False))
+
+    # ── Browse mode: show current-level folders + files (non-recursive) ────
+    # When the folder setting is on and the user is browsing normally (no
+    # search query, no meaningful filters), use the filesystem listing so
+    # each directory level shows only its own content — like a file explorer.
+    # This applies to both root and subfolder levels.
+    is_browse_mode = (
+        _show_folders
+        and query == "*"
+        and not has_meaningful_filters(filters)
+    )
+    if is_browse_mode:
+        browse_resp = await _build_browse_response(
+            output_root=output_root,
+            subfolder=subfolder,
+            query=query,
+            limit=limit,
+            offset=offset,
+            sort_key=sort_key,
+            filters=filters,
+            list_filesystem_assets=list_filesystem_assets,
+            list_filesystem_folders=list_filesystem_folders,
+            index_service=svc.get("index"),
+            json_response=json_response,
+        )
+        if browse_resp is not None:
+            return browse_resp
+
     output_filters = {
         **(filters or {}),
         "source": "output",
@@ -123,6 +296,15 @@ async def handle_output_scope(
             fs_res = _prepare_filesystem_response(
                 fs_res, exclude_assets_under_root, dedupe_result_assets_payload, input_root
             )
+            if fs_res.ok and isinstance(fs_res.data, dict):
+                fs_res.data = await _attach_filesystem_folders(
+                    fs_res.data,
+                    output_root=output_root,
+                    subfolder=subfolder,
+                    offset=offset,
+                    list_filesystem_folders=list_filesystem_folders,
+                    show_folders=_show_folders,
+                )
             return json_response(fs_res)
     except Exception:
         pass
@@ -131,5 +313,13 @@ async def handle_output_scope(
         return json_response(out_res)
     payload = _finalize_response(
         out_res, exclude_assets_under_root, dedupe_result_assets_payload, input_root, sort_key
+    )
+    payload = await _attach_filesystem_folders(
+        payload,
+        output_root=output_root,
+        subfolder=subfolder,
+        offset=offset,
+        list_filesystem_folders=list_filesystem_folders,
+        show_folders=_show_folders,
     )
     return json_response(Result.Ok(payload))

--- a/mjr_am_backend/routes/search/listing_output_scope.py
+++ b/mjr_am_backend/routes/search/listing_output_scope.py
@@ -177,6 +177,7 @@ async def _build_browse_response(
             "offset": offset,
             "query": query,
             "scope": "output",
+            "mode": "filesystem",
         }
         return json_response(Result.Ok(payload))
     except Exception:

--- a/mjr_am_backend/settings.py
+++ b/mjr_am_backend/settings.py
@@ -55,6 +55,7 @@ _ROUTE_VERBOSE_LOGS_KEY = "route_verbose_logs"
 _STARTUP_VERBOSE_LOGS_KEY = "startup_verbose_logs"
 _LTXAV_RGB_FALLBACK_ENABLED_KEY = "ltxav_rgb_fallback_enabled"
 _JXL_ENABLED_KEY = "jxl_enabled"
+_BROWSER_SHOW_FOLDERS_KEY = "browser_show_folders"
 _SETTINGS_VERSION_KEY = "__settings_version"
 _SECURITY_API_TOKEN_KEY = "security_api_token"
 _SECURITY_API_TOKEN_HASH_KEY = "security_api_token_hash"
@@ -1363,6 +1364,30 @@ class AppSettings:
             bump = await self._bump_settings_version_locked()
             current_version = int(bump.data or await self._get_settings_version() or 0)
             self._cache.put(_JXL_ENABLED_KEY, "1" if normalized else "0", version=current_version)
+            return Result.Ok(normalized)
+
+    async def get_browser_show_folders(self) -> bool:
+        """Return whether Input/Output scope browser shows subfolders (default: True)."""
+        async with self._lock:
+            current_version = await self._get_settings_version()
+            cached = self._cache.get(_BROWSER_SHOW_FOLDERS_KEY, version=current_version)
+            if cached is not None:
+                return parse_bool(cached, True)
+            raw = await self._read_setting(_BROWSER_SHOW_FOLDERS_KEY)
+            enabled = parse_bool(raw, True) if raw is not None else True
+            self._cache.put(_BROWSER_SHOW_FOLDERS_KEY, "1" if enabled else "0", version=current_version)
+            return enabled
+
+    async def set_browser_show_folders(self, enabled: Any) -> Result[bool]:
+        """Persist Input/Output folder display preference and bump settings version."""
+        normalized = parse_bool(enabled, True)
+        async with self._lock:
+            res = await self._write_setting(_BROWSER_SHOW_FOLDERS_KEY, "1" if normalized else "0")
+            if not res.ok:
+                return Result.Err("DB_ERROR", res.error or "Failed to persist browser_show_folders")
+            bump = await self._bump_settings_version_locked()
+            current_version = int(bump.data or await self._get_settings_version() or 0)
+            self._cache.put(_BROWSER_SHOW_FOLDERS_KEY, "1" if normalized else "0", version=current_version)
             return Result.Ok(normalized)
 
     def _set_vector_search_env_vars(self, enabled: bool) -> None:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2542,23 +2542,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/editorconfig/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
     "node_modules/editorconfig/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -2983,23 +2966,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -3688,9 +3654,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -4062,9 +4028,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4081,7 +4047,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "format": "prettier --write \"ui/**/*.{ts,js,mjs,vue}\"",
     "format:check": "prettier --check \"ui/**/*.{ts,js,mjs,vue}\""
   },
+  "overrides": {
+    "brace-expansion": "5.0.8"
+  },
   "devDependencies": {
     "@comfyorg/litegraph": "^0.17.2",
     "@eslint/js": "^10.0.1",

--- a/tests/features/test_search_impl_routes.py
+++ b/tests/features/test_search_impl_routes.py
@@ -550,8 +550,12 @@ async def test_list_output_passes_cursor_to_index(monkeypatch, tmp_path) -> None
             seen.update(kwargs)
             return Result.Ok({"assets": [], "total": None, "next_cursor": "", "has_more": False})
 
+    class _Settings:
+        async def get_browser_show_folders(self):
+            return False
+
     async def _svc():
-        return {"index": _Index()}, None
+        return {"index": _Index(), "settings": _Settings()}, None
 
     monkeypatch.setattr(search_impl, "_require_services", _svc)
     monkeypatch.setattr(search_impl, "_check_rate_limit", lambda *args, **kwargs: (True, None))
@@ -757,8 +761,12 @@ async def test_list_output_db_scope_applies_subfolder_filter(monkeypatch, tmp_pa
                 }
             )
 
+    class _Settings:
+        async def get_browser_show_folders(self):
+            return False
+
     async def _svc():
-        return {"index": _Index()}, None
+        return {"index": _Index(), "settings": _Settings()}, None
 
     async def _out_root(_svc):
         return str(tmp_path)
@@ -793,8 +801,12 @@ async def test_list_output_db_scope_does_not_force_empty_subfolder_filter(monkey
                 }
             )
 
+    class _Settings:
+        async def get_browser_show_folders(self):
+            return False
+
     async def _svc():
-        return {"index": _Index()}, None
+        return {"index": _Index(), "settings": _Settings()}, None
 
     async def _out_root(_svc):
         return str(tmp_path)

--- a/ui/api/clientOps.ts
+++ b/ui/api/clientOps.ts
@@ -64,6 +64,14 @@ export async function setExecutionGroupingSettings(enabled = true) {
     return post(ENDPOINTS.SETTINGS_EXECUTION_GROUPING, { enabled: !!enabled });
 }
 
+export async function getBrowserShowFolders() {
+    return get(ENDPOINTS.SETTINGS_BROWSER_SHOW_FOLDERS);
+}
+
+export async function setBrowserShowFolders(enabled = true) {
+    return post(ENDPOINTS.SETTINGS_BROWSER_SHOW_FOLDERS, { enabled: !!enabled });
+}
+
 export async function getHuggingFaceSettings() {
     return get(ENDPOINTS.SETTINGS_HUGGINGFACE);
 }

--- a/ui/api/endpoints.ts
+++ b/ui/api/endpoints.ts
@@ -89,6 +89,7 @@ export const ENDPOINTS = {
     SETTINGS_STARTUP_LOGGING: "/mjr/am/settings/startup-logging",
     SETTINGS_LTXAV_RGB_FALLBACK: "/mjr/am/settings/ltxav-rgb-fallback",
     SETTINGS_JXL: "/mjr/am/settings/jxl",
+    SETTINGS_BROWSER_SHOW_FOLDERS: "/mjr/am/settings/browser-show-folders",
 
     // View (ComfyUI native)
     VIEW: "/view",

--- a/ui/app/settings/settingsCore.ts
+++ b/ui/app/settings/settingsCore.ts
@@ -102,6 +102,9 @@ export const DEFAULT_SETTINGS = {
         mfvPreviewMethod: APP_DEFAULTS.MFV_PREVIEW_METHOD,
         ltxavRgbFallback: false,
     },
+    browser: {
+        showFolders: true,
+    },
     rtHydrate: {
         concurrency: APP_DEFAULTS.RT_HYDRATE_CONCURRENCY,
         queueMax: APP_DEFAULTS.RT_HYDRATE_QUEUE_MAX,

--- a/ui/app/settings/settingsViewer.ts
+++ b/ui/app/settings/settingsViewer.ts
@@ -5,7 +5,12 @@
 import { t } from "../i18n.js";
 import { APP_DEFAULTS } from "../config.js";
 import { loadMajoorSettings, saveMajoorSettings, applySettingsToConfig } from "./settingsCore.js";
-import { getLtxavRgbFallbackSettings, setLtxavRgbFallbackSettings } from "../../api/client.js";
+import {
+    getBrowserShowFolders,
+    setBrowserShowFolders,
+    getLtxavRgbFallbackSettings,
+    setLtxavRgbFallbackSettings,
+} from "../../api/client.js";
 import { comfyToast } from "../toast.js";
 
 const SETTINGS_PREFIX = "Majoor";
@@ -91,6 +96,44 @@ export function registerViewerSettings(safeAddSetting: (def: any) => void, setti
             saveMajoorSettings(settings);
             applySettingsToConfig(settings);
             notifyApplied("viewer.floatingPauseDuringExecution");
+        },
+    });
+
+    // ----------------------------------------------
+    // Section: Browser panel
+    // ----------------------------------------------
+
+    safeAddSetting({
+        id: `${SETTINGS_PREFIX}.Browser.ShowFolders`,
+        category: viewerCat("Browser"),
+        name: "Show folders in Input / Output panels",
+        tooltip:
+            "When enabled, subdirectories under the Input and Output roots are shown as folder cards in the browser grid. Disable to see only files.",
+        type: "boolean",
+        defaultValue: !!(settings.browser?.showFolders ?? true),
+        onChange: async (value: any) => {
+            const next = !!value;
+            const prev = !!(settings.browser?.showFolders ?? true);
+            settings.browser = settings.browser || {};
+            settings.browser.showFolders = next;
+            saveMajoorSettings(settings);
+            applySettingsToConfig(settings);
+            notifyApplied("browser.showFolders");
+            try {
+                const res = await setBrowserShowFolders(next);
+                if (!res?.ok) {
+                    throw new Error(res?.error || "Failed to update show folders setting");
+                }
+            } catch (error: any) {
+                settings.browser.showFolders = prev;
+                saveMajoorSettings(settings);
+                applySettingsToConfig(settings);
+                notifyApplied("browser.showFolders");
+                comfyToast(
+                    error?.message || "Failed to update show folders setting",
+                    "error",
+                );
+            }
         },
     });
 

--- a/ui/features/contextmenu/GridContextMenu.ts
+++ b/ui/features/contextmenu/GridContextMenu.ts
@@ -534,7 +534,8 @@ function setRating(asset: any, rating: any, onChanged: any) {
 }
 
 function _isBrowserScope(panelState: any) {
-    return String(panelState?.scope || "").toLowerCase() === "custom";
+    const scope = String(panelState?.scope || "").toLowerCase();
+    return scope === "custom" || scope === "input" || scope === "output";
 }
 
 function _isWorkflowScope(panelState: any) {
@@ -990,6 +991,14 @@ function _buildRatingSubmenu(asset: any, canRate: any) {
     ];
 }
 
+function _resolveCreateFolderPath(currentPath: string, gridContainer: any): string {
+    const scope = String(gridContainer?.dataset?.mjrScope || "").toLowerCase();
+    if (scope !== "input" && scope !== "output") return currentPath;
+    const rel = String(currentPath || "").trim().replaceAll("\\", "/");
+    // Encode the scope + optional relative subfolder, e.g. "mjr://input/sub/dir"
+    return rel ? `mjr://${scope}/${rel}` : `mjr://${scope}`;
+}
+
 function _buildEmptyGridItems({ currentPath, gridContainer }: { currentPath?: any; gridContainer?: any } = {}) {
     return [
         createItem(
@@ -1006,7 +1015,7 @@ function _buildEmptyGridItems({ currentPath, gridContainer }: { currentPath?: an
                     if (!next) return;
                     const res = await browserFolderOp({
                         op: "create",
-                        path: currentPath,
+                        path: _resolveCreateFolderPath(currentPath, gridContainer),
                         name: next,
                     });
                     if (!res?.ok) {
@@ -1840,15 +1849,18 @@ export function bindGridContextMenu({ gridContainer, getState = () => ({}) }: { 
 
         if (!card) {
             if (!_isBrowserScope(panelState)) return;
-            const currentPath = String(gridContainer?.dataset?.mjrSubfolder || "").trim();
-            if (!currentPath) return;
+            const scope = String(gridContainer?.dataset?.mjrScope || "").toLowerCase();
+            const subfolderPath = String(gridContainer?.dataset?.mjrSubfolder || "").trim();
+            // For input/output scopes at root level the subfolder is empty —
+            // still show the menu so users can create folders at the root.
+            if (!subfolderPath && scope !== "input" && scope !== "output") return;
 
             event.preventDefault();
             event.stopPropagation();
             openGridContextMenu({
                 x: event.clientX,
                 y: event.clientY,
-                items: _buildEmptyGridItems({ currentPath, gridContainer }),
+                items: _buildEmptyGridItems({ currentPath: subfolderPath, gridContainer }),
             });
             return;
         }

--- a/ui/features/dnd/DragDrop.ts
+++ b/ui/features/dnd/DragDrop.ts
@@ -896,6 +896,11 @@ export function createDragDropRuntimeHandlers(): Record<string, any> {
         const app = _resolveApp();
         const types = Array.from(event?.dataTransfer?.types || []);
         if (!types.includes(DND_MIME)) return;
+        // If the drop landed on a folder card, skip the canvas handler —
+        // the folder card handles the drop itself (move file into folder).
+        try {
+            if ((event?.target as Element)?.closest?.(".mjr-folder-card")) return;
+        } catch {}
         const payload = getDraggedAsset(event, DND_MIME);
         if (!isManagedPayload(payload)) return;
         if (!isCanvasDropTarget(app, event)) return;

--- a/ui/features/dnd/out/DragOut.ts
+++ b/ui/features/dnd/out/DragOut.ts
@@ -167,7 +167,7 @@ export const applyDragOutToOS = ({  dt, asset, containerEl, card, viewUrl, strip
                 try {
                     dt.setData("text/uri-list", url);
                     dt.setData("DownloadURL", `application/zip:${zipName}:${url}`);
-                    dt.effectAllowed = "copy";
+                    dt.effectAllowed = "copyMove";
                 } catch (e: any) {
                     console.debug?.(e);
                 }
@@ -187,7 +187,7 @@ export const applyDragOutToOS = ({  dt, asset, containerEl, card, viewUrl, strip
     try {
         dt.setData("text/uri-list", url);
         dt.setData("DownloadURL", `${mime}:${filename}:${url}`);
-        dt.effectAllowed = "copy";
+        dt.effectAllowed = "copyMove";
     } catch (e: any) {
         console.debug?.(e);
     }

--- a/ui/features/panel/controllers/browserNavigationController.ts
+++ b/ui/features/panel/controllers/browserNavigationController.ts
@@ -56,6 +56,11 @@ export function createBrowserNavigationController({
     };
 
     const resolveFolderTargetPath = (asset: any) => {
+        // ".." parent folder: always navigate to parent of current path
+        if (normPath(asset?.filename || "") === "..") {
+            return parentFolderPath(currentFolderPath());
+        }
+
         const rawSubfolder = normPath(asset?.subfolder || "");
         if (rawSubfolder) return rawSubfolder;
 

--- a/ui/tests/drag_out.vitest.ts
+++ b/ui/tests/drag_out.vitest.ts
@@ -72,7 +72,7 @@ describe("drag-out to OS", () => {
         expect(dt.getData("text/uri-list")).toContain(
             "/mjr/am/batch-zip/mjr_1234567890123456789012345678",
         );
-        expect(dt.effectAllowed).toBe("copy");
+        expect(dt.effectAllowed).toBe("copyMove");
     });
 
     it("uses the canonical selected-assets API for multi-file drag-out", async () => {

--- a/ui/vue/components/grid/FolderCard.vue
+++ b/ui/vue/components/grid/FolderCard.vue
@@ -9,21 +9,62 @@
  *
  * Phase 4.2.
  */
+import { ref } from "vue";
+
 const props = defineProps({
     asset: { type: Object, required: true },
     selected: { type: Boolean, default: false },
 });
 
+const emit = defineEmits(["drop-asset"]);
+
 const filename = () => String(props.asset.filename || "");
+
+// ── Drop target for moving assets into this folder ──────────────────────
+const dropActive = ref(false);
+
+function onDragOver(event) {
+    // Allow drops — Vue's .prevent modifier already called preventDefault.
+    if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = "move";
+    }
+    dropActive.value = true;
+}
+
+function onDragLeave() {
+    dropActive.value = false;
+}
+
+function onDrop(event) {
+    dropActive.value = false;
+    if (!event.dataTransfer) return;
+    const types = Array.from(event.dataTransfer.types);
+    if (!types.includes("application/x-mjr-asset")) return;
+
+    let payload = null;
+    try {
+        const raw = event.dataTransfer.getData("application/x-mjr-asset");
+        if (raw) payload = JSON.parse(raw);
+    } catch {}
+    if (!payload) return;
+
+    const folderPath = String(props.asset.filepath || "").trim();
+    if (!folderPath) return;
+
+    emit("drop-asset", { asset: payload, folderPath });
+}
 </script>
 
 <template>
     <div
         class="mjr-asset-card mjr-card mjr-folder-card"
-        :class="{ 'is-selected': selected }"
+        :class="{ 'is-selected': selected, 'drop-active': dropActive }"
         role="button"
         :tabindex="0"
         draggable="true"
+        @dragover.prevent="onDragOver"
+        @dragleave="onDragLeave"
+        @drop.stop.prevent="onDrop"
         :data-mjr-asset-id="String(asset.id ?? '')"
         :data-mjr-filename-key="String(asset.filename || '').toLowerCase()"
         data-mjr-ext="FOLDER"
@@ -60,3 +101,11 @@ const filename = () => String(props.asset.filename || "");
         </div>
     </div>
 </template>
+
+<style scoped>
+.mjr-folder-card.drop-active {
+    outline: 2px solid #4a90e2;
+    outline-offset: -2px;
+    background: rgba(74, 144, 226, 0.08);
+}
+</style>

--- a/ui/vue/components/grid/VirtualAssetGridHost.vue
+++ b/ui/vue/components/grid/VirtualAssetGridHost.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, provide, ref, watch } f
 import { APP_CONFIG } from "../../../app/config.js";
 import { EVENTS } from "../../../app/events.js";
 import { get, getWorkflowContent, markWorkflowLoaded, setWorkflowFavorite } from "../../../api/client.js";
+import { browserFolderOp } from "../../../api/clientOps.js";
 import { buildStackMembersURL } from "../../../api/endpoints.js";
 import {
     getRawHostApp,
@@ -1505,6 +1506,26 @@ function handleCardDblclick(asset) {
     void openAssetViewer(asset);
 }
 
+async function handleDropAsset({ asset: draggedAsset, folderPath }) {
+    const filepath = String(draggedAsset?.filepath || "").trim();
+    if (!filepath || !folderPath) return;
+    try {
+        const res = await browserFolderOp({
+            op: "move_file",
+            path: filepath,
+            destination: folderPath,
+        });
+        if (res?.ok) {
+            comfyToast("Moved to folder", "success");
+            loader.reload();
+        } else {
+            comfyToast(res?.error || "Failed to move file", "error");
+        }
+    } catch (error) {
+        comfyToast(error?.message || "Failed to move file", "error");
+    }
+}
+
 let scrollCleanup = null;
 let fillViewportPromise = null;
 let lastFillViewportAt = 0;
@@ -1965,6 +1986,7 @@ defineExpose({
                         @mousedown.left="handleCardPrimaryMouseDown($event, asset)"
                         @click="handleCardClick($event, asset)"
                         @dblclick.stop="handleCardDblclick(asset)"
+                        @drop-asset="handleDropAsset"
                     />
 
                     <div
@@ -2042,6 +2064,7 @@ defineExpose({
                         @mousedown.left="handleCardPrimaryMouseDown($event, asset)"
                         @click="handleCardClick($event, asset)"
                         @dblclick.stop="handleCardDblclick(asset)"
+                        @drop-asset="handleDropAsset"
                     />
 
                     <div


### PR DESCRIPTION
## Summary

Add folder browsing support for Input and Output scopes: show subfolders as cards in the grid, drag-and-drop assets into folders to move them, navigate with `..` parent directory, and create subfolders from the context menu.

## Changes

### Backend (Python)

- **`filesystem.py`** — `_list_filesystem_folders()` scans visible subdirectories under `<root>/<subfolder>`. Adds a `..` parent folder entry when inside a subfolder.
- **`custom_roots.py`** — New `op: "move_file"` with `mjr://input|output` path marker resolution.
- **`settings.py`** / **`health.py`** — `browser_show_folders` setting + API.
- **`listing_input/output_scope.py`** — Hybrid folder+file pagination, browse mode.
- **`listing_endpoint.py`** / **`search_impl.py`** — Thread `list_filesystem_folders` callback.

### Frontend (TypeScript / Vue)

- **`FolderCard.vue`** — Drop target with highlight, `dropEffect: "move"`.
- **`VirtualAssetGridHost.vue`** — `handleDropAsset` → `browserFolderOp({ op: "move_file" })` + `loader.reload()`.
- **`DragDrop.ts`** / **`DragOut.ts`** — Skip canvas on folder card, `effectAllowed: "copyMove"`.
- **`settingsViewer.ts`** / **`settingsCore.ts`** — UI toggle.
- **`clientOps.ts`** / **`endpoints.ts`** — `browserFolderOp()` wrapper.
- **`GridContextMenu.ts`** — Subfolder creation.
- **`browserNavigationController.ts`** — Handle `..` navigation.